### PR TITLE
feat(fd): add global ignore file and optimize alias

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -116,7 +116,7 @@ Verfügbare Aliase aus `~/.config/alias/`:
 | `fdf` | `fd --type f` | Nur Dateien suchen |
 | `fdd` | `fd --type d` | Nur Verzeichnisse suchen |
 | `fdh` | `fd --hidden` | Inkl. versteckte Dateien |
-| `fda` | `fd --hidden --no-ignore` | Alles (ignoriert nichts) |
+| `fda` | `fd -u` | Alles (unrestricted = --hidden --no-ignore) |
 | `fdsh` | `fd --extension sh` | Shell-Skripte |
 | `fdpy` | `fd --extension py` | Python-Dateien |
 | `fdjs` | `fd -e js -e ts` | JavaScript/TypeScript |

--- a/terminal/.config/alias/fd.alias
+++ b/terminal/.config/alias/fd.alias
@@ -17,7 +17,7 @@ fi
 alias fdf='fd --type f'                     # Nur Dateien
 alias fdd='fd --type d'                     # Nur Verzeichnisse
 alias fdh='fd --hidden'                     # Inkl. versteckte Dateien
-alias fda='fd --hidden --no-ignore'         # Alles (ignoriert nichts)
+alias fda='fd -u'                           # Alles (unrestricted = -HI)
 
 # ------------------------------------------------------------
 # Typspezifische Suche

--- a/terminal/.config/fd/ignore
+++ b/terminal/.config/fd/ignore
@@ -1,0 +1,42 @@
+# ============================================================
+# fd Global Ignore Patterns
+# ============================================================
+# Zweck   : Globale Ausschlüsse für fd (auch bei --hidden)
+# Pfad    : ~/.config/fd/ignore
+# Docs    : https://github.com/sharkdp/fd#excluding-specific-files-or-directories
+# Tipp    : "fd -u" ignoriert diese Datei (unrestricted mode)
+# ============================================================
+
+# Git internals (bei --hidden nicht durchsuchen)
+# Siehe: man fd → "Tips and Tricks"
+.git/
+
+# ------------------------------------------------------------
+# macOS (basierend auf github/gitignore/Global/macOS.gitignore)
+# ------------------------------------------------------------
+.DS_Store
+._*
+__MACOSX/
+.AppleDouble
+.LSOverride
+
+# ------------------------------------------------------------
+# Python
+# ------------------------------------------------------------
+__pycache__/
+*.pyc
+.venv/
+.mypy_cache/
+.pytest_cache/
+
+# ------------------------------------------------------------
+# Node.js
+# ------------------------------------------------------------
+node_modules/
+
+# ------------------------------------------------------------
+# Build artifacts
+# ------------------------------------------------------------
+dist/
+build/
+*.egg-info/


### PR DESCRIPTION
## Änderungen

### Neues fd Global Ignore File
Erstellt `~/.config/fd/ignore` für globale Ausschlüsse:

| Kategorie | Patterns |
|-----------|----------|
| **Git** | `.git/` (per fd man page Empfehlung) |
| **macOS** | `.DS_Store`, `._*`, `__MACOSX/`, `.AppleDouble`, `.LSOverride` |
| **Python** | `__pycache__/`, `*.pyc`, `.venv/`, `.mypy_cache/`, `.pytest_cache/` |
| **Node.js** | `node_modules/` |
| **Build** | `dist/`, `build/`, `*.egg-info/` |

### Alias-Optimierung
`fda` nutzt jetzt `-u` statt `--hidden --no-ignore` (idiomatischer, offiziell dokumentiert).

### Performance-Gewinn
- `fd --hidden` überspringt automatisch `.git/` (tausende Dateien)
- Alle fzf-Funktionen (Ctrl+T, Alt+C, `fe`, `cdf`) profitieren
- macOS-Metadaten (`.DS_Store`, `._*`) werden nicht mehr angezeigt

### Quellen
- [fd man page](https://github.com/sharkdp/fd) → "Tips and Tricks"
- [GitHub macOS.gitignore](https://github.com/github/gitignore/blob/main/Global/macOS.gitignore)