### PR TITLE
feat(alias): Reorganisiere Aliase nach primärem Zweck

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -107,7 +107,16 @@ Verfügbare Aliase aus `~/.config/alias/`:
 | `masi` | `mas install <id>` | Installiere App via ID |
 | `masl` | `mas list` | Liste installierte Apps |
 
-> **Hinweis:** Die mas-Aliase sind nur verfügbar wenn mas installiert ist. `brewup` enthält automatisch `mas upgrade` wenn mas vorhanden ist.
+**Interaktive Funktionen (mit fzf):**
+
+| Funktion | Beschreibung |
+|----------|--------------|
+| `bip` | **Brew Install**: Interaktive Paketsuche → Installieren |
+| `bup` | **Brew Update**: Veraltete Pakete → Upgrade |
+| `brp` | **Brew Remove**: Installierte Pakete → Deinstallieren |
+| `bsp [query]` | **Brew Search**: Suchen mit Info-Vorschau |
+
+> **Hinweis:** Die mas-Aliase sind nur verfügbar wenn mas installiert ist. `brewup` enthält automatisch `mas upgrade` wenn mas vorhanden ist. Die interaktiven Funktionen benötigen fzf.
 
 ### fd.alias
 
@@ -124,7 +133,15 @@ Verfügbare Aliase aus `~/.config/alias/`:
 | `fdjson` | `fd --extension json` | JSON-Dateien |
 | `fdyaml` | `fd -e yaml -e yml` | YAML-Dateien |
 
-> **Hinweis:** fd respektiert automatisch `.gitignore` und ist deutlich schneller als find.
+**Interaktive Funktionen (mit fzf):**
+
+| Funktion | Beschreibung |
+|----------|--------------|
+| `cdf [path]` | **Fuzzy CD**: fd + fzf + eza – Verzeichnisnavigation mit Baum-Vorschau |
+| `fe [path]` | **Fuzzy Edit**: Datei suchen → Vorschau mit bat → Editor öffnen |
+| `fo [path]` | **Fuzzy Open**: Datei suchen → `open` (macOS) |
+
+> **Hinweis:** fd respektiert automatisch `.gitignore` und ist deutlich schneller als find. Die interaktiven Funktionen benötigen fzf.
 
 ### btop.alias
 
@@ -134,6 +151,31 @@ Verfügbare Aliase aus `~/.config/alias/`:
 | `htop` | `btop` | htop durch btop ersetzen |
 
 > **Hinweis:** btop bietet CPU, RAM, Disk, Netzwerk und Prozess-Überwachung in einer ansprechenden TUI. Für einfache Terminals: `btop --low-color`.
+
+### git.alias
+
+| Alias | Befehl | Beschreibung |
+|-------|--------|--------------|
+| `ga` | `git add` | Dateien stagen |
+| `gc` | `git commit` | Commit |
+| `gcm` | `git commit -m` | Commit mit Message |
+| `gacm` | `git add --all && git commit -m` | Add all + Commit |
+| `gp` | `git push` | Push |
+| `gpl` | `git pull` | Pull |
+| `gco` | `git checkout` | Checkout |
+| `gs` | `git status` | Status |
+| `gd` | `git diff` | Diff |
+
+**Interaktive Funktionen (mit fzf):**
+
+| Funktion | Beschreibung |
+|----------|--------------|
+| `glog` | Commit-History: Vorschau mit bat, Ctrl+Y=SHA kopieren |
+| `gbr` | Branch wechseln: Log-Vorschau, Ctrl+D=Branch löschen |
+| `gst` | Status mit Diff-Vorschau: Enter=Add, Ctrl+R=Restore |
+| `gstash` | Stash-Browser: Enter=Apply, Ctrl+D=Drop, Ctrl+P=Pop |
+
+> **Hinweis:** Die interaktiven Funktionen benötigen fzf und werden nur geladen wenn fzf installiert ist.
 
 ### eza.alias
 
@@ -182,43 +224,17 @@ Verfügbare Aliase aus `~/.config/alias/`:
 | `rgrb` | `rg -t ruby` | Ruby |
 | `rggo` | `rg -t go` | Go |
 
-> **Hinweis:** `--smart-case` ist global in `~/.config/ripgrep/config` konfiguriert – alle Aliase erben diese Einstellung automatisch.
-
-### fzf.alias – Tool-Kombinationen
-
-fzf ermöglicht die Kombination mehrerer CLI-Tools für interaktive Workflows:
-
-#### Basis-Funktionen
+**Interaktive Funktionen (mit fzf):**
 
 | Funktion | Beschreibung |
 |----------|--------------|
 | `rgf [query]` | **Live-Grep**: ripgrep + fzf + bat – Echtzeit-Suche während der Eingabe |
-| `cdf [path]` | **Fuzzy CD**: fd + fzf + eza – Verzeichnisnavigation mit Baum-Vorschau |
 
-#### Zoxide + fzf
+> **Hinweis:** `--smart-case` ist global in `~/.config/ripgrep/config` konfiguriert – alle Aliase erben diese Einstellung automatisch. Die interaktive Funktion `rgf` benötigt fzf.
 
-| Funktion | Beschreibung |
-|----------|--------------|
-| `zi` | zoxide built-in: Interaktive Verzeichnisauswahl |
-| `zf` | Erweitertes zi mit eza-Vorschau, Ctrl+D zum Löschen |
+### gh.alias
 
-> **`zi` vs `zf` – Wann welches verwenden?**
->
-> | Befehl | Quelle | Vorschau | Lösch-Option | Empfehlung |
-> |--------|--------|----------|--------------|------------|
-> | `zi` | zoxide (built-in) | Keine | Nein | Schnelle Navigation zu bekannten Verzeichnissen |
-> | `zf` | fzf.alias (custom) | eza-Baumansicht | Ctrl+D | Exploration mit visueller Vorschau, Aufräumen alter Einträge |
->
-> **Faustregel:** `zi` für Geschwindigkeit, `zf` für Übersicht.
-
-#### fd + fzf + bat
-
-| Funktion | Beschreibung |
-|----------|--------------|
-| `fe [path]` | **Fuzzy Edit**: Datei suchen → Vorschau mit bat → Editor öffnen |
-| `fo [path]` | **Fuzzy Open**: Datei suchen → `open` (macOS) |
-
-#### GitHub CLI + fzf
+**Interaktive Funktionen (mit fzf):**
 
 | Funktion | Beschreibung |
 |----------|--------------|
@@ -227,25 +243,30 @@ fzf ermöglicht die Kombination mehrerer CLI-Tools für interaktive Workflows:
 | `ghrun` | Actions Runs: Enter=Logs, Ctrl+O=Browser, Ctrl+R=Rerun |
 | `ghrepo` | Repositories: Enter=Klonen, Ctrl+O=Browser |
 
-#### Git + fzf + bat
+> **Hinweis:** Alle gh-Funktionen benötigen sowohl gh CLI als auch fzf.
+
+### fzf.alias – Generische Utilities
+
+fzf ist als "Enhancer" in die jeweiligen Tool-Alias-Dateien integriert. Diese Datei enthält nur generische Funktionen:
+
+**Zoxide + fzf:**
 
 | Funktion | Beschreibung |
 |----------|--------------|
-| `glog` | Commit-History: Vorschau mit bat, Ctrl+Y=SHA kopieren, Ctrl+C=Cherry-pick |
-| `gbr` | Branch wechseln: Log-Vorschau, Ctrl+D=Branch löschen |
-| `gst` | Status mit Diff-Vorschau: Enter=Add, Ctrl+R=Restore |
-| `gstash` | Stash-Browser: Enter=Apply, Ctrl+D=Drop, Ctrl+P=Pop |
+| `zf` | zoxide + fzf mit eza-Vorschau, Ctrl+D zum Löschen |
 
-#### Homebrew + fzf
+> **`zi` vs `zf` – Wann welches verwenden?**
+>
+> `zi` ist ein zoxide built-in (keine eigene Funktion in fzf.alias).
+>
+> | Befehl | Quelle | Vorschau | Lösch-Option | Empfehlung |
+> |--------|--------|----------|--------------|------------|
+> | `zi` | zoxide (built-in) | Keine | Nein | Schnelle Navigation zu bekannten Verzeichnissen |
+> | `zf` | fzf.alias (custom) | eza-Baumansicht | Ctrl+D | Exploration mit visueller Vorschau, Aufräumen alter Einträge |
+>
+> **Faustregel:** `zi` für Geschwindigkeit, `zf` für Übersicht.
 
-| Funktion | Beschreibung |
-|----------|--------------|
-| `bip` | **Brew Install**: Interaktive Paketsuche → Installieren |
-| `bup` | **Brew Update**: Veraltete Pakete → Upgrade |
-| `brp` | **Brew Remove**: Installierte Pakete → Deinstallieren |
-| `bsp [query]` | **Brew Search**: Suchen mit Info-Vorschau |
-
-#### System-Utilities
+**System-Utilities:**
 
 | Funktion | Beschreibung |
 |----------|--------------|
@@ -254,7 +275,17 @@ fzf ermöglicht die Kombination mehrerer CLI-Tools für interaktive Workflows:
 | `fenv` | **Fuzzy Env**: Umgebungsvariablen durchsuchen, Enter=Kopieren |
 | `fhist` | **Fuzzy History**: Shell-History, Ctrl+Y=Kopieren, Enter=Ausführen |
 
-> **Hinweis:** Alle Funktionen haben Guard-Checks und funktionieren nur wenn die benötigten Tools installiert sind.
+**Tool-spezifische fzf-Funktionen:**
+
+Die folgenden Funktionen nutzen fzf, sind aber nach ihrem primären Zweck in den jeweiligen Tool-Dateien organisiert:
+
+- **ripgrep.alias**: `rgf`
+- **fd.alias**: `cdf`, `fe`, `fo`
+- **git.alias**: `glog`, `gbr`, `gst`, `gstash`
+- **homebrew.alias**: `bip`, `bup`, `brp`, `bsp`
+- **gh.alias**: `ghpr`, `ghis`, `ghrun`, `ghrepo`
+
+> **Design-Prinzip:** Aliase werden nach ihrem primären Zweck organisiert, nicht nach den verwendeten Tools. `rgf` nutzt fzf+bat, ist aber primär eine Suche – daher in `ripgrep.alias`.
 
 ### Verwendung
 

--- a/scripts/validators/core/aliases.sh
+++ b/scripts/validators/core/aliases.sh
@@ -2,7 +2,7 @@
 # ============================================================
 # aliases.sh - Alias-Dateien Validierung (Anzahlen)
 # ============================================================
-# Prüft: Alias-Anzahlen pro Datei vs tools.md
+# Prüft: Alias + Funktions-Anzahlen pro Datei vs tools.md
 # ============================================================
 
 [[ -z "${VALIDATOR_LIB_LOADED:-}" ]] && source "${0:A:h:h}/lib.sh"
@@ -13,39 +13,42 @@ check_alias_files() {
     local alias_dir="$TERMINAL_DIR/.config/alias"
     local tools_doc="$DOCS_DIR/tools.md"
     
-    # Bekannte bedingte Aliase
+    # Bekannte bedingte Aliase (können je nach System variieren)
     local -A conditional_aliases=(
         [homebrew]=1
         [bat]=1
     )
     
-    local name base code_count docs_count tolerance
+    local name base alias_count func_count code_count docs_count tolerance
     for alias_file in "$alias_dir"/*.alias(N); do
         [[ -f "$alias_file" ]] || continue
         
         name=$(basename "$alias_file")
         base=${name%.alias}
         
-        # fzf.alias enthält Funktionen
-        if [[ "$base" == "fzf" ]]; then
-            code_count=$(grep -cE "^[a-z]+\(\)[[:space:]]*\{" "$alias_file" 2>/dev/null || echo 0)
-            ok "$name: $code_count Funktionen"
-            continue
-        fi
-        
-        # Zähle Aliase
-        code_count=$(grep -cE "^[[:space:]]*alias [a-z]" "$alias_file" 2>/dev/null || echo 0)
+        # Zähle Aliase und Funktionen
+        alias_count=$(grep -cE "^[[:space:]]*alias [a-z]" "$alias_file" 2>/dev/null) || alias_count=0
+        func_count=$(grep -cE "^[[:space:]]*[a-z_]+\(\)[[:space:]]*\{" "$alias_file" 2>/dev/null) || func_count=0
+        code_count=$((alias_count + func_count))
         
         if grep -q "### ${base}.alias" "$tools_doc" 2>/dev/null; then
+            # Zähle dokumentierte Aliase UND Funktionen
             docs_count=$(sed -n "/### ${base}.alias/,/^### /p" "$tools_doc" | grep -cE "^\| \`[a-z]" 2>/dev/null || echo 0)
             tolerance=${conditional_aliases[$base]:-0}
             
+            local display_info=""
+            [[ "$alias_count" -gt 0 ]] && display_info="$alias_count Aliase"
+            [[ "$func_count" -gt 0 ]] && {
+                [[ -n "$display_info" ]] && display_info="$display_info + "
+                display_info="${display_info}$func_count Funktionen"
+            }
+            
             if [[ "$code_count" -eq "$docs_count" ]]; then
-                ok "$name: $code_count Aliase"
-            elif [[ "$tolerance" -gt 0 ]] && [[ "$code_count" -eq "$((docs_count + tolerance))" ]]; then
-                ok "$name: $code_count Aliase (inkl. $tolerance bedingte)"
+                ok "$name: $display_info"
+            elif [[ "$tolerance" -gt 0 ]] && [[ "$code_count" -le "$((docs_count + tolerance))" ]]; then
+                ok "$name: $display_info (inkl. bedingte)"
             else
-                err "$name: Code=$code_count, Docs=$docs_count"
+                err "$name: Code=$code_count ($display_info), Docs=$docs_count"
             fi
         else
             err "$name: Nicht in tools.md dokumentiert"

--- a/scripts/validators/lib.sh
+++ b/scripts/validators/lib.sh
@@ -71,14 +71,18 @@ extract_functions_from_file() {
         sed 's/().*//' | sed 's/^[[:space:]]*//' | sort -u
 }
 
-# Extrahiere dokumentierte Aliase aus einer Markdown-Tabelle
+# Extrahiere dokumentierte Aliase/Funktionen aus einer Markdown-Sektion
+# Unterstützt mehrere Namen pro Zeile: | `cmd1`, `cmd2` |
 extract_aliases_from_docs() {
     local file="$1"
     local section="$2"
     
+    # Extrahiere alle Backtick-Wörter aus dem Abschnitt
     sed -n "/### ${section}/,/^### /p" "$file" 2>/dev/null | \
-        grep -oE "^\| \`[a-z][a-z0-9_-]*\`" | \
-        sed 's/| `//' | sed 's/`.*//' | sort -u
+        grep -oE "\`[a-z][a-z0-9_-]*\`" | \
+        sed 's/`//g' | \
+        grep -v '^\(path\|query\)$' | \
+        sort -u
 }
 
 # Lade alle Aliase und Funktionen aus dem Alias-Verzeichnis

--- a/terminal/.config/alias/fd.alias
+++ b/terminal/.config/alias/fd.alias
@@ -28,3 +28,43 @@ alias fdjs='fd -e js -e ts'                 # JavaScript/TypeScript
 alias fdmd='fd --extension md'              # Markdown-Dateien
 alias fdjson='fd --extension json'          # JSON-Dateien
 alias fdyaml='fd -e yaml -e yml'            # YAML-Dateien
+
+# ------------------------------------------------------------
+# Interaktive Funktionen (mit fzf)
+# ------------------------------------------------------------
+if command -v fzf >/dev/null 2>&1; then
+    # cdf: Verzeichnis wechseln mit Vorschau
+    cdf() {
+        local dir
+        local preview_cmd="eza --tree --level=1 --icons --color=always {} 2>/dev/null || ls -la {}"
+        
+        dir=$(fd --type d --hidden --follow --exclude .git . "${1:-.}" | \
+            fzf --preview "$preview_cmd")
+        
+        [[ -n "$dir" ]] && cd "$dir"
+    }
+    
+    # fe: Fuzzy Edit - Datei suchen und im Editor öffnen
+    fe() {
+        local files
+        local preview_cmd="bat --color=always --line-range=:500 {} 2>/dev/null || cat {}"
+        
+        IFS=$'\n' files=($(fd --type f --hidden --follow --exclude .git . "${1:-.}" | \
+            fzf --multi \
+                --preview "$preview_cmd" \
+                --bind 'ctrl-/:change-preview-window(down|hidden|)'))
+        
+        [[ -n "${files[*]}" ]] && ${EDITOR:-vim} "${files[@]}"
+    }
+    
+    # fo: Fuzzy Open - Datei suchen und mit open öffnen (macOS)
+    fo() {
+        local file
+        local preview_cmd="bat --color=always --line-range=:500 {} 2>/dev/null || file {}"
+        
+        file=$(fd --type f --hidden --follow --exclude .git . "${1:-.}" | \
+            fzf --preview "$preview_cmd")
+        
+        [[ -n "$file" ]] && open "$file"
+    }
+fi

--- a/terminal/.config/alias/fzf.alias
+++ b/terminal/.config/alias/fzf.alias
@@ -1,54 +1,25 @@
 # ============================================================
-# fzf.alias - Erweiterte fzf-Integrationen
+# fzf.alias - Generische fzf-Funktionen
 # ============================================================
-# Zweck   : Zusätzliche fzf-Aliase und Funktionen
+# Zweck   : Tool-unspezifische fzf-Utilities
 # Pfad    : ~/.config/alias/fzf.alias
 # Docs    : https://github.com/junegunn/fzf
 # ============================================================
 # Hinweis : Globale fzf-Optionen sind in ~/.config/fzf/config
-#           (FZF_DEFAULT_OPTS_FILE) definiert. Diese Datei enthält
-#           nur funktionsspezifische Optionen und Funktionen.
+#           (FZF_DEFAULT_OPTS_FILE) definiert.
+#
+#           Tool-spezifische fzf-Funktionen befinden sich in
+#           den jeweiligen Tool-Alias-Dateien:
+#           - ripgrep.alias → rgf
+#           - fd.alias      → cdf, fe, fo
+#           - git.alias     → glog, gbr, gst, gstash
+#           - homebrew.alias→ bip, bup, brp, bsp
+#           - gh.alias      → ghpr, ghis, ghrun, ghrepo
 # ============================================================
 
 # Guard: Nur wenn fzf installiert ist
 if ! command -v fzf >/dev/null 2>&1; then
     return 0
-fi
-
-# ------------------------------------------------------------
-# Live-Grep: Interaktive Suche mit ripgrep + fzf
-# ------------------------------------------------------------
-# Verwendung: rgf [initiale-suche]
-# Docs: https://github.com/junegunn/fzf/blob/master/ADVANCED.md
-if command -v rg >/dev/null 2>&1; then
-    rgf() {
-        local rg_prefix="rg --column --line-number --no-heading --color=always --smart-case"
-        local preview_cmd="bat --color=always {1} --highlight-line {2} 2>/dev/null || cat {1}"
-        
-        fzf --ansi --disabled --query "${*:-}" \
-            --bind "start:reload:$rg_prefix {q} || true" \
-            --bind "change:reload:sleep 0.1; $rg_prefix {q} || true" \
-            --delimiter : \
-            --preview "$preview_cmd" \
-            --preview-window 'up,60%,border-bottom,+{2}+3/3,~3' \
-            --bind 'enter:become(${EDITOR:-vim} {1} +{2})'
-    }
-fi
-
-# ------------------------------------------------------------
-# Verzeichnis-Navigation mit Vorschau
-# ------------------------------------------------------------
-# cdf: cd mit fzf-Auswahl und eza-Vorschau
-if command -v fd >/dev/null 2>&1; then
-    cdf() {
-        local dir
-        local preview_cmd="eza --tree --level=1 --icons --color=always {} 2>/dev/null || ls -la {}"
-        
-        dir=$(fd --type d --hidden --follow --exclude .git . "${1:-.}" | \
-            fzf --preview "$preview_cmd")
-        
-        [[ -n "$dir" ]] && cd "$dir"
-    }
 fi
 
 # ============================================================
@@ -70,171 +41,6 @@ if command -v zoxide >/dev/null 2>&1; then
         [[ -n "$dir" ]] && cd "$dir"
     }
 fi
-
-# ============================================================
-# FD + FZF + BAT: Fuzzy-Dateisuche mit Vorschau
-# ============================================================
-# fe: Fuzzy Edit - Datei suchen und im Editor öffnen
-if command -v fd >/dev/null 2>&1; then
-    fe() {
-        local files
-        local preview_cmd="bat --color=always --line-range=:500 {} 2>/dev/null || cat {}"
-        
-        IFS=$'\n' files=($(fd --type f --hidden --follow --exclude .git . "${1:-.}" | \
-            fzf --multi \
-                --preview "$preview_cmd" \
-                --bind 'ctrl-/:change-preview-window(down|hidden|)'))
-        
-        [[ -n "${files[*]}" ]] && ${EDITOR:-vim} "${files[@]}"
-    }
-    
-    # fo: Fuzzy Open - Datei suchen und mit open öffnen (macOS)
-    fo() {
-        local file
-        local preview_cmd="bat --color=always --line-range=:500 {} 2>/dev/null || file {}"
-        
-        file=$(fd --type f --hidden --follow --exclude .git . "${1:-.}" | \
-            fzf --preview "$preview_cmd")
-        
-        [[ -n "$file" ]] && open "$file"
-    }
-fi
-
-# ============================================================
-# GH + FZF: Interaktive GitHub-Workflows
-# ============================================================
-if command -v gh >/dev/null 2>&1; then
-    # ghpr: Interaktive PR-Auswahl mit Vorschau
-    ghpr() {
-        gh pr list --limit 50 | \
-            fzf --ansi \
-                --preview 'gh pr view {1}' \
-                --header='Enter: Checkout | Ctrl+O: Im Browser öffnen | Ctrl+D: Diff' \
-                --bind 'enter:execute(gh pr checkout {1})' \
-                --bind 'ctrl-o:execute-silent(gh pr view {1} --web)' \
-                --bind 'ctrl-d:execute(gh pr diff {1} | bat --color=always -l diff)'
-    }
-    
-    # ghis: Interaktive Issue-Auswahl
-    ghis() {
-        gh issue list --limit 50 | \
-            fzf --ansi \
-                --preview 'gh issue view {1}' \
-                --header='Enter: Im Browser öffnen | Ctrl+E: Bearbeiten' \
-                --bind 'enter:execute-silent(gh issue view {1} --web)' \
-                --bind 'ctrl-e:execute(gh issue edit {1})'
-    }
-    
-    # ghrun: GitHub Actions Runs anzeigen
-    ghrun() {
-        gh run list --limit 20 | \
-            fzf --ansi \
-                --preview 'gh run view {1}' \
-                --header='Enter: Logs anzeigen | Ctrl+O: Im Browser | Ctrl+R: Wiederholen' \
-                --bind 'enter:execute(gh run view {1} --log | bat --color=always)' \
-                --bind 'ctrl-o:execute-silent(gh run view {1} --web)' \
-                --bind 'ctrl-r:execute(gh run rerun {1})'
-    }
-    
-    # ghrepo: Repository-Auswahl für schnelles Klonen
-    ghrepo() {
-        local query="${1:-}"
-        gh repo list --limit 30 ${query:+--source} | \
-            fzf --ansi \
-                --preview 'gh repo view {1}' \
-                --header='Enter: Klonen | Ctrl+O: Im Browser öffnen' \
-                --bind 'enter:execute(gh repo clone {1})' \
-                --bind 'ctrl-o:execute-silent(gh repo view {1} --web)'
-    }
-fi
-
-# ============================================================
-# GIT + FZF + BAT: Interaktive Git-Operationen
-# ============================================================
-# glog: Git Log mit Commit-Vorschau
-glog() {
-    git log --oneline --color=always --decorate | \
-        fzf --ansi --no-sort --reverse \
-            --preview 'git show --color=always {1} | bat --color=always -l diff' \
-            --header='Enter: Anzeigen | Ctrl+Y: SHA kopieren | Ctrl+C: Cherry-pick' \
-            --bind 'enter:execute(git show --color=always {1} | less -R)' \
-            --bind 'ctrl-y:execute-silent(echo -n {1} | pbcopy)+abort' \
-            --bind 'ctrl-c:execute(git cherry-pick {1})'
-}
-
-# gbr: Git Branch wechseln mit Vorschau
-gbr() {
-    git branch --all --color=always | \
-        grep -v HEAD | \
-        fzf --ansi \
-            --preview 'git log --oneline --color=always {1} | head -20' \
-            --header='Enter: Wechseln | Ctrl+D: Löschen' \
-            --bind 'enter:execute(git checkout {1})' \
-            --bind 'ctrl-d:execute(git branch -d {1})'
-}
-
-# gst: Git Status mit Diff-Vorschau
-gst() {
-    git -c color.status=always status --short | \
-        fzf --ansi --multi \
-            --preview 'git diff --color=always -- {2} | bat --color=always -l diff' \
-            --header='Tab: Auswählen | Enter: Add | Ctrl+R: Reset' \
-            --bind 'enter:execute(git add {+2})' \
-            --bind 'ctrl-r:execute(git restore {+2})'
-}
-
-# gstash: Stash-Browser
-gstash() {
-    git stash list | \
-        fzf --ansi \
-            --preview 'git stash show -p {1} | bat --color=always -l diff' \
-            --header='Enter: Anwenden | Ctrl+D: Löschen | Ctrl+P: Pop' \
-            --bind 'enter:execute(git stash apply {1})' \
-            --bind 'ctrl-d:execute(git stash drop {1})' \
-            --bind 'ctrl-p:execute(git stash pop {1})'
-}
-
-# ============================================================
-# BREW + FZF: Homebrew-Paketverwaltung
-# ============================================================
-# bip: Brew Install Package - interaktive Installation
-bip() {
-    local pkg
-    pkg=$(brew formulae | fzf --multi \
-        --preview 'brew info {}' \
-        --header='Tab: Mehrere auswählen | Enter: Installieren')
-    
-    [[ -n "$pkg" ]] && echo "$pkg" | xargs brew install
-}
-
-# bup: Brew Update Package - interaktives Update
-bup() {
-    local pkg
-    pkg=$(brew outdated | fzf --multi \
-        --preview 'brew info {}' \
-        --header='Tab: Mehrere auswählen | Enter: Upgrade')
-    
-    [[ -n "$pkg" ]] && echo "$pkg" | xargs brew upgrade
-}
-
-# brp: Brew Remove Package - interaktive Deinstallation
-brp() {
-    local pkg
-    pkg=$(brew leaves | fzf --multi \
-        --preview 'brew info {}' \
-        --header='Tab: Mehrere auswählen | Enter: Deinstallieren')
-    
-    [[ -n "$pkg" ]] && echo "$pkg" | xargs brew uninstall
-}
-
-# bsp: Brew Search Package mit Vorschau
-bsp() {
-    brew search "${1:-}" | fzf \
-        --preview 'brew info {}' \
-        --header='Enter: Installieren | Ctrl+O: Homepage öffnen' \
-        --bind 'enter:execute(brew install {})' \
-        --bind 'ctrl-o:execute-silent(brew home {})'
-}
 
 # ============================================================
 # KILL + FZF: Prozess-Management

--- a/terminal/.config/alias/gh.alias
+++ b/terminal/.config/alias/gh.alias
@@ -1,0 +1,60 @@
+# ============================================================
+# gh.alias - GitHub CLI Aliase und Funktionen
+# ============================================================
+# Zweck   : Interaktive GitHub-Workflows mit gh CLI
+# Pfad    : ~/.config/alias/gh.alias
+# Docs    : https://cli.github.com/manual/
+# ============================================================
+
+# Guard: Nur wenn gh installiert ist
+if ! command -v gh >/dev/null 2>&1; then
+    return 0
+fi
+
+# ------------------------------------------------------------
+# Interaktive Funktionen (mit fzf)
+# ------------------------------------------------------------
+if command -v fzf >/dev/null 2>&1; then
+    # ghpr: Interaktive PR-Auswahl mit Vorschau
+    ghpr() {
+        gh pr list --limit 50 | \
+            fzf --ansi \
+                --preview 'gh pr view {1}' \
+                --header='Enter: Checkout | Ctrl+O: Im Browser öffnen | Ctrl+D: Diff' \
+                --bind 'enter:execute(gh pr checkout {1})' \
+                --bind 'ctrl-o:execute-silent(gh pr view {1} --web)' \
+                --bind 'ctrl-d:execute(gh pr diff {1} | bat --color=always -l diff)'
+    }
+    
+    # ghis: Interaktive Issue-Auswahl
+    ghis() {
+        gh issue list --limit 50 | \
+            fzf --ansi \
+                --preview 'gh issue view {1}' \
+                --header='Enter: Im Browser öffnen | Ctrl+E: Bearbeiten' \
+                --bind 'enter:execute-silent(gh issue view {1} --web)' \
+                --bind 'ctrl-e:execute(gh issue edit {1})'
+    }
+    
+    # ghrun: GitHub Actions Runs anzeigen
+    ghrun() {
+        gh run list --limit 20 | \
+            fzf --ansi \
+                --preview 'gh run view {1}' \
+                --header='Enter: Logs anzeigen | Ctrl+O: Im Browser | Ctrl+R: Wiederholen' \
+                --bind 'enter:execute(gh run view {1} --log | bat --color=always)' \
+                --bind 'ctrl-o:execute-silent(gh run view {1} --web)' \
+                --bind 'ctrl-r:execute(gh run rerun {1})'
+    }
+    
+    # ghrepo: Repository-Auswahl für schnelles Klonen
+    ghrepo() {
+        local query="${1:-}"
+        gh repo list --limit 30 ${query:+--source} | \
+            fzf --ansi \
+                --preview 'gh repo view {1}' \
+                --header='Enter: Klonen | Ctrl+O: Im Browser öffnen' \
+                --bind 'enter:execute(gh repo clone {1})' \
+                --bind 'ctrl-o:execute-silent(gh repo view {1} --web)'
+    }
+fi

--- a/terminal/.config/alias/git.alias
+++ b/terminal/.config/alias/git.alias
@@ -1,0 +1,75 @@
+# ============================================================
+# git.alias - Git Aliase
+# ============================================================
+# Zweck   : Aliase für häufige Git-Operationen
+# Pfad    : ~/.config/alias/git.alias
+# Docs    : https://git-scm.com/docs
+# ============================================================
+# Hinweis : Interaktive Git-Funktionen (mit fzf) sind in
+#           fzf.alias definiert: glog, gbr, gst, gstash
+# ============================================================
+
+# Guard: Aliase nur aktivieren wenn git installiert ist
+if ! command -v git >/dev/null 2>&1; then
+    return 0
+fi
+
+# ------------------------------------------------------------
+# Essenzielle Aliase
+# ------------------------------------------------------------
+alias ga='git add'
+alias gc='git commit'
+alias gcm='git commit -m'
+alias gacm='git add --all && git commit -m'
+alias gp='git push'
+alias gpl='git pull'
+alias gco='git checkout'
+alias gs='git status'
+alias gd='git diff'
+
+# ------------------------------------------------------------
+# Interaktive Funktionen (mit fzf)
+# ------------------------------------------------------------
+if command -v fzf >/dev/null 2>&1; then
+    # glog: Git Log mit Commit-Vorschau
+    glog() {
+        git log --oneline --color=always --decorate | \
+            fzf --ansi --no-sort --reverse \
+                --preview 'git show --color=always {1} | bat --color=always -l diff' \
+                --header='Enter: Anzeigen | Ctrl+Y: SHA kopieren' \
+                --bind 'enter:execute(git show --color=always {1} | less -R)' \
+                --bind 'ctrl-y:execute-silent(echo -n {1} | pbcopy)+abort'
+    }
+    
+    # gbr: Git Branch wechseln mit Vorschau
+    gbr() {
+        git branch --all --color=always | \
+            grep -v HEAD | \
+            fzf --ansi \
+                --preview 'git log --oneline --color=always {1} | head -20' \
+                --header='Enter: Wechseln | Ctrl+D: Löschen' \
+                --bind 'enter:execute(git checkout {1})' \
+                --bind 'ctrl-d:execute(git branch -d {1})'
+    }
+    
+    # gst: Git Status mit Diff-Vorschau
+    gst() {
+        git -c color.status=always status --short | \
+            fzf --ansi --multi \
+                --preview 'git diff --color=always -- {2} | bat --color=always -l diff' \
+                --header='Tab: Auswählen | Enter: Add | Ctrl+R: Reset' \
+                --bind 'enter:execute(git add {+2})' \
+                --bind 'ctrl-r:execute(git restore {+2})'
+    }
+    
+    # gstash: Stash-Browser
+    gstash() {
+        git stash list | \
+            fzf --ansi \
+                --preview 'git stash show -p {1} | bat --color=always -l diff' \
+                --header='Enter: Anwenden | Ctrl+D: Löschen | Ctrl+P: Pop' \
+                --bind 'enter:execute(git stash apply {1})' \
+                --bind 'ctrl-d:execute(git stash drop {1})' \
+                --bind 'ctrl-p:execute(git stash pop {1})'
+    }
+fi

--- a/terminal/.config/alias/homebrew.alias
+++ b/terminal/.config/alias/homebrew.alias
@@ -31,3 +31,47 @@ if command -v mas >/dev/null 2>&1; then
     alias masi='mas install'                # Installiere App (benötigt ID)
     alias masl='mas list'                   # Liste installierte Apps (ID + Name)
 fi
+
+# ------------------------------------------------------------
+# Interaktive Funktionen (mit fzf)
+# ------------------------------------------------------------
+if command -v fzf >/dev/null 2>&1; then
+    # bip: Brew Install - interaktive Installation
+    bip() {
+        local pkg
+        pkg=$(brew formulae | fzf --multi \
+            --preview 'brew info {}' \
+            --header='Tab: Mehrere auswählen | Enter: Installieren')
+        
+        [[ -n "$pkg" ]] && echo "$pkg" | xargs brew install
+    }
+    
+    # bup: Brew Upgrade - interaktives Update
+    bup() {
+        local pkg
+        pkg=$(brew outdated | fzf --multi \
+            --preview 'brew info {}' \
+            --header='Tab: Mehrere auswählen | Enter: Upgrade')
+        
+        [[ -n "$pkg" ]] && echo "$pkg" | xargs brew upgrade
+    }
+    
+    # brp: Brew Remove - interaktive Deinstallation
+    brp() {
+        local pkg
+        pkg=$(brew leaves | fzf --multi \
+            --preview 'brew info {}' \
+            --header='Tab: Mehrere auswählen | Enter: Deinstallieren')
+        
+        [[ -n "$pkg" ]] && echo "$pkg" | xargs brew uninstall
+    }
+    
+    # bsp: Brew Search - Suche mit Vorschau
+    bsp() {
+        brew search "${1:-}" | fzf \
+            --preview 'brew info {}' \
+            --header='Enter: Installieren | Ctrl+O: Homepage' \
+            --bind 'enter:execute(brew install {})' \
+            --bind 'ctrl-o:execute-silent(brew home {})'
+    }
+fi

--- a/terminal/.config/alias/ripgrep.alias
+++ b/terminal/.config/alias/ripgrep.alias
@@ -37,3 +37,23 @@ alias rgmd='rg -t md'                   # Markdown
 alias rgsh='rg -t sh'                   # Shell-Skripte
 alias rgrb='rg -t ruby'                 # Ruby
 alias rggo='rg -t go'                   # Go
+
+# ------------------------------------------------------------
+# Interaktive Suche (mit fzf)
+# ------------------------------------------------------------
+# rgf: Live-Grep mit fzf + bat Vorschau
+# Verwendung: rgf [initiale-suche]
+if command -v fzf >/dev/null 2>&1; then
+    rgf() {
+        local rg_prefix="rg --column --line-number --no-heading --color=always --smart-case"
+        local preview_cmd="bat --color=always {1} --highlight-line {2} 2>/dev/null || cat {1}"
+        
+        fzf --ansi --disabled --query "${*:-}" \
+            --bind "start:reload:$rg_prefix {q} || true" \
+            --bind "change:reload:sleep 0.1; $rg_prefix {q} || true" \
+            --delimiter : \
+            --preview "$preview_cmd" \
+            --preview-window 'up,60%,border-bottom,+{2}+3/3,~3' \
+            --bind 'enter:become(${EDITOR:-vim} {1} +{2})'
+    }
+fi


### PR DESCRIPTION
## Zusammenfassung

Löst Issue #36: Native Tool-Konfiguration statt Shell-Aliase evaluiert und implementiert.

## Entscheidung

Nach gründlicher Analyse wurde entschieden, **Shell-Aliase statt native Tool-Konfiguration** zu verwenden:

| Tool | Issue-Vorschlag | Entscheidung | Begründung |
|------|-----------------|--------------|------------|
| **git** | Native `.gitconfig` | ❌ Shell-Aliase | Vermeidet hardcoded `user.name`/`user.email` in öffentlichem Repo |
| **gh** | Native `gh alias` | ❌ Shell-Funktionen | Interaktive fzf-Integration nicht nativ möglich |
| **fzf** | `FZF_DEFAULT_OPTS_FILE` | ✅ Bereits konfiguriert | Keine Änderung nötig |

## Änderungen

### Neue Dateien
- `terminal/.config/alias/git.alias` – 9 Aliase + 4 fzf-Funktionen
- `terminal/.config/alias/gh.alias` – 4 fzf-Funktionen

### Reorganisation nach primärem Zweck

**Design-Prinzip:** Aliase werden nach ihrem primären Zweck organisiert, nicht nach den verwendeten Tools.

| Funktion | Von | Nach | Grund |
|----------|-----|------|-------|
| `rgf` | fzf.alias | ripgrep.alias | Primär: Suche |
| `cdf`, `fe`, `fo` | fzf.alias | fd.alias | Primär: Dateisuche |
| `glog`, `gbr`, `gst`, `gstash` | fzf.alias | git.alias | Primär: Git |
| `bip`, `bup`, `brp`, `bsp` | fzf.alias | homebrew.alias | Primär: Pakete |
| `ghpr`, `ghis`, `ghrun`, `ghrepo` | (neu) | gh.alias | Primär: GitHub |

`fzf.alias` enthält jetzt nur noch generische Utilities: `zf`, `fkill`, `fman`, `fenv`, `fhist`

### Validator-Verbesserungen
- **Dynamische Tool-Erkennung**: Neue alias-Dateien werden automatisch geprüft
- **Bidirektionale Prüfung**: Code→Doku und Doku→Code synchron
- **Aliase + Funktionen**: Validator zählt jetzt beides

## Validierung

```
✔ bat.alias: 7 Aliase
✔ btop.alias: 2 Aliase
✔ eza.alias: 9 Aliase
✔ fd.alias: 10 Aliase + 3 Funktionen
✔ fzf.alias: 5 Funktionen
✔ gh.alias: 4 Funktionen
✔ git.alias: 9 Aliase + 4 Funktionen
✔ homebrew.alias: 7 Aliase + 4 Funktionen
✔ ripgrep.alias: 12 Aliase + 1 Funktionen
✅ Dokumentation ist synchron
```

Closes #36