### PR TITLE
refactor(eza): Nutze EZA_ICONS_AUTO statt wiederholter --icons=auto

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -181,17 +181,17 @@ Verfügbare Aliase aus `~/.config/alias/`:
 
 | Alias | Befehl | Beschreibung |
 |-------|--------|--------------|
-| `ls` | `eza --icons=auto --group-directories-first` | ls-Ersatz mit Icons |
-| `ll` | `eza -l --icons=auto --group-directories-first --header` | Ausführliche Auflistung |
-| `la` | `eza -la --icons=auto --group-directories-first --header` | Alle Dateien inkl. versteckter |
-| `lsg` | `eza -l --icons=auto --git --header` | Long-Format mit Git-Status |
-| `lag` | `eza -la --icons=auto --git --header` | Alle Dateien mit Git-Status |
-| `lt` | `eza --tree --icons=auto --level=2` | Baumansicht (2 Ebenen) |
-| `lt3` | `eza --tree --icons=auto --level=3` | Baumansicht (3 Ebenen) |
-| `lss` | `eza -l --icons=auto --sort=size --reverse --header` | Sortiert nach Größe |
-| `lst` | `eza -l --icons=auto --sort=modified --reverse --header` | Sortiert nach Datum |
+| `ls` | `eza --group-directories-first` | ls-Ersatz mit Icons |
+| `ll` | `eza -l --group-directories-first --header` | Ausführliche Auflistung |
+| `la` | `eza -la --group-directories-first --header` | Alle Dateien inkl. versteckter |
+| `lsg` | `eza -l --git --header` | Long-Format mit Git-Status |
+| `lag` | `eza -la --git --header` | Alle Dateien mit Git-Status |
+| `lt` | `eza --tree --level=2` | Baumansicht (2 Ebenen) |
+| `lt3` | `eza --tree --level=3` | Baumansicht (3 Ebenen) |
+| `lss` | `eza -l --sort=size --reverse --header` | Sortiert nach Größe |
+| `lst` | `eza -l --sort=modified --reverse --header` | Sortiert nach Datum |
 
-> **Hinweis:** `--icons=auto` erkennt automatisch ob das Terminal Icons unterstützt. Ordner werden immer zuerst angezeigt (`--group-directories-first`).
+> **Hinweis:** Icons werden automatisch über `EZA_ICONS_AUTO=1` in `.zshrc` aktiviert. Ordner werden immer zuerst angezeigt (`--group-directories-first`).
 
 ### bat.alias
 

--- a/terminal/.config/alias/eza.alias
+++ b/terminal/.config/alias/eza.alias
@@ -4,6 +4,8 @@
 # Zweck   : Aliase für eza mit Icons und Git-Integration
 # Pfad    : ~/.config/alias/eza.alias
 # Docs    : https://eza.rocks
+# Hinweis : EZA_ICONS_AUTO=1 ist in .zshrc gesetzt, daher kein
+#           --icons=auto in den Aliasen nötig
 # ============================================================
 
 # Guard: Aliase nur aktivieren wenn eza installiert ist
@@ -14,32 +16,32 @@ fi
 # ------------------------------------------------------------
 # Basis-Auflistung
 # ------------------------------------------------------------
-# ls-Ersatz mit Icons (auto = erkennt Terminal-Support)
-alias ls='eza --icons=auto --group-directories-first'
+# ls-Ersatz (Icons durch EZA_ICONS_AUTO automatisch)
+alias ls='eza --group-directories-first'
 
 # Ausführliche Auflistung (long format)
-alias ll='eza -l --icons=auto --group-directories-first --header'
+alias ll='eza -l --group-directories-first --header'
 
 # Alle Dateien inkl. versteckter
-alias la='eza -la --icons=auto --group-directories-first --header'
+alias la='eza -la --group-directories-first --header'
 
 # ------------------------------------------------------------
 # Mit Git-Integration (nur in Git-Repos sinnvoll)
 # ------------------------------------------------------------
-alias lsg='eza -l --icons=auto --git --header'
-alias lag='eza -la --icons=auto --git --header'
+alias lsg='eza -l --git --header'
+alias lag='eza -la --git --header'
 
 # ------------------------------------------------------------
 # Baumansicht
 # ------------------------------------------------------------
-alias lt='eza --tree --icons=auto --level=2'
-alias lt3='eza --tree --icons=auto --level=3'
+alias lt='eza --tree --level=2'
+alias lt3='eza --tree --level=3'
 
 # ------------------------------------------------------------
 # Sortierung
 # ------------------------------------------------------------
 # Nach Größe (größte zuerst)
-alias lss='eza -l --icons=auto --sort=size --reverse --header'
+alias lss='eza -l --sort=size --reverse --header'
 
 # Nach Änderungsdatum (neueste zuerst)
-alias lst='eza -l --icons=auto --sort=modified --reverse --header'
+alias lst='eza -l --sort=modified --reverse --header'

--- a/terminal/.zshrc
+++ b/terminal/.zshrc
@@ -53,6 +53,9 @@ export FZF_DEFAULT_OPTS_FILE="$HOME/.config/fzf/config"
 export RIPGREP_CONFIG_PATH="$HOME/.config/ripgrep/config"
 # bat nutzt automatisch ~/.config/bat/config
 
+# eza: Icons automatisch aktivieren wenn Terminal unterstützt wird
+export EZA_ICONS_AUTO=1
+
 # ------------------------------------------------------------
 # Tools initialisieren
 # ------------------------------------------------------------


### PR DESCRIPTION
## Zusammenfassung

Optimiert die eza-Aliase nach dem DRY-Prinzip (Don't Repeat Yourself).

## Änderungen

### `.zshrc`
- `EZA_ICONS_AUTO=1` als zentrale Environment-Variable hinzugefügt

### `eza.alias`
- `--icons=auto` aus allen 9 Aliasen entfernt
- Header-Kommentar ergänzt, der auf die zentrale Konfiguration hinweist

### `docs/tools.md`
- Dokumentation aktualisiert: Hinweis auf `EZA_ICONS_AUTO=1`

## Motivation

Vorher wurde `--icons=auto` in jedem eza-Alias wiederholt:

```bash
# Vorher
alias ls='eza --icons=auto --group-directories-first'
alias ll='eza -l --icons=auto --group-directories-first --header'
# ... 7 weitere mit --icons=auto
```

Nachher ist die Option zentral konfiguriert:

```bash
# In .zshrc
export EZA_ICONS_AUTO=1

# In eza.alias
alias ls='eza --group-directories-first'
alias ll='eza -l --group-directories-first --header'
```

## Warum nicht alles in eine Config-Datei?

eza unterstützt **keine** Config-Datei für CLI-Optionen (nur für Themes/Farben). Die `EZA_ICONS_AUTO` Environment-Variable ist die einzige Möglichkeit, Icons global zu konfigurieren.

`--group-directories-first` hat keine entsprechende Environment-Variable und muss daher in den Aliasen bleiben.

## Validierung

```
✅ Dokumentation ist synchron
✅ Alle Aliase sind dokumentiert
```