### PR TITLE
fix: fzf integrations and cleanup redundant aliases

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -168,10 +168,10 @@ Verfügbare Aliase aus `~/.config/alias/`:
 | Funktion | Beschreibung |
 |----------|--------------|
 | `cdf [path]` | **Fuzzy CD**: fd + fzf + eza – Verzeichnisnavigation mit Baum-Vorschau |
-| `fe [path]` | **Fuzzy Edit**: Datei suchen → Vorschau mit bat → Editor öffnen |
-| `fo [path]` | **Fuzzy Open**: Datei suchen → `open` (macOS) |
 
-> **Hinweis:** fd respektiert automatisch `.gitignore` und ist deutlich schneller als find. Zusätzlich werden Patterns aus `~/.config/fd/ignore` global ausgeschlossen (z.B. `.git/`, `node_modules/`, `__pycache__/`). Mit `fd -u` (unrestricted) werden alle Ignore-Dateien umgangen. Die interaktiven Funktionen benötigen fzf.
+> **Hinweis:** fd respektiert automatisch `.gitignore` und ist deutlich schneller als find. Zusätzlich werden Patterns aus `~/.config/fd/ignore` global ausgeschlossen (z.B. `.git/`, `node_modules/`, `__pycache__/`). Mit `fd -u` (unrestricted) werden alle Ignore-Dateien umgangen.
+>
+> **Tipp:** Für Dateisuche mit Vorschau nutze `Ctrl+T` (fzf Shell-Integration) – fügt den Pfad direkt ein.
 
 ### btop.alias
 
@@ -228,7 +228,6 @@ Verfügbare Aliase aus `~/.config/alias/`:
 | Alias | Befehl | Beschreibung |
 |-------|--------|--------------|
 | `cat` | `bat -pp` | cat-Ersatz: Plain + kein Pager |
-| `catp` | `bat --paging=never` | Mit Highlighting, ohne Pager |
 | `catn` | `bat --style=numbers --paging=never` | Nur Zeilennummern |
 | `catd` | `bat --diff` | Mit Git-Diff-Markierungen |
 | `bat-themes` | `bat --list-themes` | Verfügbare Themes auflisten |
@@ -310,7 +309,7 @@ fzf ist als "Enhancer" in die jeweiligen Tool-Alias-Dateien integriert. Diese Da
 Die folgenden Funktionen nutzen fzf, sind aber nach ihrem primären Zweck in den jeweiligen Tool-Dateien organisiert:
 
 - **ripgrep.alias**: `rgf`
-- **fd.alias**: `cdf`, `fe`, `fo`
+- **fd.alias**: `cdf`
 - **git.alias**: `glog`, `gbr`, `gst`, `gstash`
 - **homebrew.alias**: `bip`, `bup`, `brp`, `bsp`
 - **gh.alias**: `ghpr`, `ghis`, `ghrun`, `ghrepo`
@@ -381,9 +380,6 @@ lst                # Nach Änderungsdatum (neueste zuerst)
 ```zsh
 # cat-Ersatz (Plain, kein Pager)
 cat README.md          # bat -pp
-
-# Mit Syntax-Highlighting (ohne Pager)
-catp README.md         # bat --paging=never
 
 # Mit Zeilennummern
 catn config.yaml       # bat --style=numbers --paging=never

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -326,7 +326,7 @@ rm -rf ~/dotfiles
 
 ### Symptom
 
-- Befehle wie `ghpr`, `glog`, `fe` werden nicht erkannt
+- Befehle wie `ghpr`, `glog`, `cdf` werden nicht erkannt
 - Fehlermeldung: `command not found`
 
 ### Ursache
@@ -364,7 +364,7 @@ exec zsh
 | Funktion | Benötigte Tools |
 |----------|-----------------|
 | `rgf` | fzf, ripgrep, bat |
-| `fe`, `fo`, `cdf` | fzf, fd, bat/eza |
+| `cdf` | fzf, fd, eza |
 | `zf` | fzf, zoxide, eza |
 | `ghpr`, `ghis`, `ghrun`, `ghrepo` | fzf, gh |
 | `glog`, `gbr`, `gst`, `gstash` | fzf, git, bat |

--- a/terminal/.config/alias/bat.alias
+++ b/terminal/.config/alias/bat.alias
@@ -20,9 +20,6 @@ fi
 # Ersetzt cat mit Syntax-Highlighting (plain style)
 alias cat='bat -pp'
 
-# Syntax-Highlighting ohne Pager
-alias catp='bat --paging=never'
-
 # Mit Zeilennummern, ohne weitere Dekoration
 alias catn='bat --style=numbers --paging=never'
 

--- a/terminal/.config/alias/fd.alias
+++ b/terminal/.config/alias/fd.alias
@@ -55,7 +55,7 @@ alias fdyaml='fd -e yaml -e yml'
 # Interaktive Funktionen (mit fzf)
 # ------------------------------------------------------------
 if command -v fzf >/dev/null 2>&1; then
-    # Verzeichnis wechseln mit Vorschau
+    # Verzeichnis wechseln mit eza-Vorschau (cdf [pfad])
     cdf() {
         local dir
         local preview_cmd="eza --tree --level=1 --icons --color=always {} 2>/dev/null || ls -la {}"
@@ -64,29 +64,5 @@ if command -v fzf >/dev/null 2>&1; then
             fzf --preview "$preview_cmd")
         
         [[ -n "$dir" ]] && cd "$dir"
-    }
-    
-    # Fuzzy Edit - Datei suchen und im Editor öffnen
-    fe() {
-        local files
-        local preview_cmd="bat --color=always --line-range=:500 {} 2>/dev/null || cat {}"
-        
-        IFS=$'\n' files=($(fd --type f --hidden --follow --exclude .git . "${1:-.}" | \
-            fzf --multi \
-                --preview "$preview_cmd" \
-                --bind 'ctrl-/:change-preview-window(down|hidden|)'))
-        
-        [[ -n "${files[*]}" ]] && ${EDITOR:-vim} "${files[@]}"
-    }
-    
-    # Fuzzy Open - Datei suchen und mit open öffnen (macOS)
-    fo() {
-        local file
-        local preview_cmd="bat --color=always --line-range=:500 {} 2>/dev/null || file {}"
-        
-        file=$(fd --type f --hidden --follow --exclude .git . "${1:-.}" | \
-            fzf --preview "$preview_cmd")
-        
-        [[ -n "$file" ]] && open "$file"
     }
 fi

--- a/terminal/.config/alias/fzf.alias
+++ b/terminal/.config/alias/fzf.alias
@@ -5,13 +5,14 @@
 # Pfad    : ~/.config/alias/fzf.alias
 # Docs    : https://github.com/junegunn/fzf
 # ============================================================
-# Hinweis : Globale fzf-Optionen sind in ~/.config/fzf/config
-#           (FZF_DEFAULT_OPTS_FILE) definiert.
+# Hinweis : Shell-Keybindings (in .zshrc): Ctrl+R=History,
+#           Ctrl+T=Dateisuche mit Vorschau, Alt+C=Verzeichnis
 #
-#           Tool-spezifische fzf-Funktionen befinden sich in
-#           den jeweiligen Tool-Alias-Dateien:
-#           - ripgrep.alias → rgf
-#           - fd.alias      → cdf, fe, fo
+#           Globale fzf-Optionen in ~/.config/fzf/config
+#
+#           Tool-spezifische fzf-Funktionen:
+#           - fd.alias      → cdf (Verzeichnis+Vorschau)
+#           - ripgrep.alias → rgf (Live-Grep)
 #           - git.alias     → glog, gbr, gst, gstash
 #           - homebrew.alias→ bip, bup, brp, bsp
 #           - gh.alias      → ghpr, ghis, ghrun, ghrepo
@@ -21,6 +22,13 @@
 if ! command -v fzf >/dev/null 2>&1; then
     return 0
 fi
+
+# ============================================================
+# Shell-Keybindings (in .zshrc konfiguriert)
+# ============================================================
+# Ctrl+T: Datei suchen mit bat-Vorschau, Pfad einfügen
+# Ctrl+R: History durchsuchen mit Vorschau
+# Alt+C:  Verzeichnis wechseln mit eza-Vorschau
 
 # ============================================================
 # ZOXIDE + FZF: Intelligente Directory-Jumps
@@ -63,11 +71,17 @@ fkill() {
 # ============================================================
 # Man-Pages interaktiv durchsuchen mit Syntax-Highlighting
 fman() {
-    man -k . 2>/dev/null | \
+    local selection page
+    selection=$(man -k . 2>/dev/null | \
         fzf --prompt='Man> ' \
-            --preview "echo {} | awk '{print \$1}' | xargs man 2>/dev/null | bat --color=always -l man -p" \
-            --header='Enter: Man-Page öffnen' \
-            --bind 'enter:execute(echo {} | awk "{print \$1}" | xargs man)'
+            --preview "echo {} | sed 's/(.*//' | xargs man 2>/dev/null | bat --color=always -l man -p" \
+            --header='Enter: Man-Page öffnen')
+    
+    if [[ -n "$selection" ]]; then
+        # Extrahiere Seitenname ohne (1), (3), etc.
+        page=$(echo "$selection" | sed 's/(.*//')
+        man "$page"
+    fi
 }
 
 # ============================================================
@@ -75,11 +89,18 @@ fman() {
 # ============================================================
 # Umgebungsvariablen durchsuchen und Wert in Zwischenablage kopieren
 fenv() {
-    printenv | sort | fzf \
+    local selection
+    selection=$(printenv | sort | fzf \
         --preview 'echo {} | cut -d= -f2-' \
         --preview-window='down:3' \
-        --header='Enter: Wert in Zwischenablage kopieren' \
-        --bind 'enter:execute-silent(echo {} | cut -d= -f2- | pbcopy)+abort'
+        --header='Enter: Wert kopieren | Ctrl+Y: Nur kopieren' \
+        --bind 'ctrl-y:execute-silent(echo {} | cut -d= -f2- | pbcopy)+abort')
+    
+    if [[ -n "$selection" ]]; then
+        local value="${selection#*=}"
+        echo "$value" | pbcopy
+        echo "Kopiert: ${selection%%=*}"
+    fi
 }
 
 # ============================================================
@@ -87,12 +108,15 @@ fenv() {
 # ============================================================
 # Befehlshistorie durchsuchen und direkt ausführen (anders als Ctrl+R)
 fhist() {
-    local cmd
-    cmd=$(fc -l 1 | fzf --tac --no-sort \
+    local selection cmd
+    selection=$(fc -l 1 | fzf --tac --no-sort \
         --header='Enter: Ausführen | Ctrl+Y: In Zwischenablage' \
-        --bind 'ctrl-y:execute-silent(echo {2..} | pbcopy)+abort' | \
-        awk '{$1=""; print substr($0,2)}')
+        --bind 'ctrl-y:execute-silent(echo {2..} | pbcopy)+abort')
     
-    [[ -n "$cmd" ]] && eval "$cmd"
+    if [[ -n "$selection" ]]; then
+        cmd=$(echo "$selection" | awk '{$1=""; print substr($0,2)}')
+        print -s "$cmd"  # Zur History hinzufügen
+        eval "$cmd"
+    fi
 }
 

--- a/terminal/.config/alias/gh.alias
+++ b/terminal/.config/alias/gh.alias
@@ -17,44 +17,57 @@ fi
 if command -v fzf >/dev/null 2>&1; then
     # Pull Requests interaktiv durchsuchen, auschecken oder im Browser öffnen
     ghpr() {
-        gh pr list --limit 50 | \
+        local pr
+        pr=$(gh pr list --limit 50 | \
             fzf --ansi \
                 --preview 'gh pr view {1}' \
-                --header='Enter: Checkout | Ctrl+O: Im Browser öffnen | Ctrl+D: Diff' \
-                --bind 'enter:execute(gh pr checkout {1})' \
+                --header='Enter: Checkout | Ctrl+O: Browser | Ctrl+D: Diff' \
                 --bind 'ctrl-o:execute-silent(gh pr view {1} --web)' \
-                --bind 'ctrl-d:execute(gh pr diff {1} | bat --color=always -l diff)'
+                --bind 'ctrl-d:execute(gh pr diff {1} | bat --color=always -l diff)' | \
+            awk '{print $1}')
+        
+        [[ -n "$pr" ]] && gh pr checkout "$pr"
     }
     
     # Issues interaktiv durchsuchen, öffnen oder bearbeiten
     ghis() {
-        gh issue list --limit 50 | \
+        local issue
+        issue=$(gh issue list --limit 50 | \
             fzf --ansi \
                 --preview 'gh issue view {1}' \
-                --header='Enter: Im Browser öffnen | Ctrl+E: Bearbeiten' \
-                --bind 'enter:execute-silent(gh issue view {1} --web)' \
-                --bind 'ctrl-e:execute(gh issue edit {1})'
+                --header='Enter: Im Browser | Ctrl+E: Bearbeiten' \
+                --bind 'ctrl-e:execute(gh issue edit {1})' | \
+            awk '{print $1}')
+        
+        [[ -n "$issue" ]] && gh issue view "$issue" --web
     }
     
     # GitHub Actions Workflow-Runs anzeigen, Logs lesen oder wiederholen
     ghrun() {
-        gh run list --limit 20 | \
+        local run
+        run=$(gh run list --limit 20 | \
             fzf --ansi \
-                --preview 'gh run view {1}' \
-                --header='Enter: Logs anzeigen | Ctrl+O: Im Browser | Ctrl+R: Wiederholen' \
-                --bind 'enter:execute(gh run view {1} --log | bat --color=always)' \
-                --bind 'ctrl-o:execute-silent(gh run view {1} --web)' \
-                --bind 'ctrl-r:execute(gh run rerun {1})'
+                --delimiter='\t' \
+                --preview 'gh run view {7}' \
+                --header='Enter: Logs | Ctrl+O: Browser | Ctrl+R: Rerun' \
+                --bind 'ctrl-o:execute-silent(gh run view {7} --web)' \
+                --bind 'ctrl-r:execute(gh run rerun {7})' | \
+            awk -F'\t' '{print $7}')
+        
+        [[ -n "$run" ]] && gh run view "$run" --log | bat --color=always
     }
     
     # Eigene Repositories durchsuchen und schnell klonen
     ghrepo() {
+        local repo
         local query="${1:-}"
-        gh repo list --limit 30 ${query:+--source} | \
+        repo=$(gh repo list --limit 30 ${query:+--source} | \
             fzf --ansi \
                 --preview 'gh repo view {1}' \
-                --header='Enter: Klonen | Ctrl+O: Im Browser öffnen' \
-                --bind 'enter:execute(gh repo clone {1})' \
-                --bind 'ctrl-o:execute-silent(gh repo view {1} --web)'
+                --header='Enter: Klonen | Ctrl+O: Browser' \
+                --bind 'ctrl-o:execute-silent(gh repo view {1} --web)' | \
+            awk '{print $1}')
+        
+        [[ -n "$repo" ]] && gh repo clone "$repo"
     }
 fi

--- a/terminal/.config/alias/git.alias
+++ b/terminal/.config/alias/git.alias
@@ -50,43 +50,55 @@ alias gd='git diff'
 if command -v fzf >/dev/null 2>&1; then
     # Git Log mit Commit-Vorschau
     glog() {
-        git log --oneline --color=always --decorate | \
+        local sha
+        sha=$(git log --oneline --color=always --decorate | \
             fzf --ansi --no-sort --reverse \
                 --preview 'git show --color=always {1} | bat --style=numbers --color=always -l diff' \
                 --header='Enter: Anzeigen | Ctrl+Y: SHA kopieren' \
-                --bind 'enter:execute(git show --color=always {1} | bat --style=numbers --color=always -l diff | less -R)' \
-                --bind 'ctrl-y:execute-silent(echo -n {1} | pbcopy)+abort'
+                --bind 'ctrl-y:execute-silent(echo -n {1} | pbcopy)+abort' | \
+            awk '{print $1}')
+        
+        [[ -n "$sha" ]] && git show --color=always "$sha" | bat --style=numbers --color=always -l diff | less -R
     }
     
     # Git Branch wechseln mit Vorschau
     gbr() {
-        git branch --all --color=always | \
+        local branch
+        branch=$(git branch --all --color=always | \
             grep -v HEAD | \
             fzf --ansi \
                 --preview 'git log --oneline --color=always {1} | head -20' \
                 --header='Enter: Wechseln | Ctrl+D: Löschen' \
-                --bind 'enter:execute(git checkout {1})' \
-                --bind 'ctrl-d:execute(git branch -d {1})'
+                --bind 'ctrl-d:execute(git branch -d {1})+reload(git branch --all --color=always | grep -v HEAD)' | \
+            sed 's/^[* ]*//' | sed 's|remotes/origin/||')
+        
+        [[ -n "$branch" ]] && git checkout "$branch"
     }
     
     # Git Status mit Diff-Vorschau
     gst() {
-        git -c color.status=always status --short | \
+        local files
+        files=$(git -c color.status=always status --short | \
             fzf --ansi --multi \
                 --preview 'git diff --color=always -- {2} | bat --style=numbers --color=always -l diff' \
                 --header='Tab: Auswählen | Enter: Add | Ctrl+R: Reset' \
-                --bind 'enter:execute(git add {+2})' \
-                --bind 'ctrl-r:execute(git restore {+2})'
+                --bind 'ctrl-r:execute(git restore {+2})+reload(git -c color.status=always status --short)' | \
+            awk '{print $2}')
+        
+        [[ -n "$files" ]] && echo "$files" | xargs git add && echo "Staged: $(echo "$files" | wc -l | tr -d ' ') Datei(en)"
     }
     
     # Stash-Browser
     gstash() {
-        git stash list | \
+        local stash
+        stash=$(git stash list | \
             fzf --ansi \
-                --preview 'git stash show -p {1} | bat --style=numbers --color=always -l diff' \
-                --header='Enter: Anwenden | Ctrl+D: Löschen | Ctrl+P: Pop' \
-                --bind 'enter:execute(git stash apply {1})' \
-                --bind 'ctrl-d:execute(git stash drop {1})' \
-                --bind 'ctrl-p:execute(git stash pop {1})'
+                --preview 'echo {} | cut -d: -f1 | xargs git stash show -p | bat --style=numbers --color=always -l diff' \
+                --header='Enter: Apply | Ctrl+D: Drop | Ctrl+P: Pop' \
+                --bind 'ctrl-d:execute(echo {} | cut -d: -f1 | xargs git stash drop)+reload(git stash list)' \
+                --bind 'ctrl-p:execute(echo {} | cut -d: -f1 | xargs git stash pop)+abort' | \
+            cut -d: -f1)
+        
+        [[ -n "$stash" ]] && git stash apply "$stash"
     }
 fi

--- a/terminal/.config/alias/homebrew.alias
+++ b/terminal/.config/alias/homebrew.alias
@@ -76,10 +76,12 @@ if command -v fzf >/dev/null 2>&1; then
     
     # Pakete suchen mit Info-Vorschau und direkter Installation
     bsp() {
-        brew search "${1:-}" | fzf \
+        local pkg
+        pkg=$(brew search "${1:-}" | fzf \
             --preview 'brew info {}' \
             --header='Enter: Installieren | Ctrl+O: Homepage' \
-            --bind 'enter:execute(brew install {})' \
-            --bind 'ctrl-o:execute-silent(brew home {})'
+            --bind 'ctrl-o:execute-silent(brew home {})')
+        
+        [[ -n "$pkg" ]] && brew install "$pkg"
     }
 fi

--- a/terminal/.config/fzf/config
+++ b/terminal/.config/fzf/config
@@ -7,7 +7,7 @@
 # ============================================================
 
 # Layout & Darstellung
---height=50%
+--height=~50%
 --layout=reverse
 --border=rounded
 --margin=0,1


### PR DESCRIPTION
## Problem
Multiple fzf-based functions caused terminal issues:
- Terminal hanging on ESC abort in fzf lists
- Ghost text/artifacts remaining after ESC
- `fman` couldn't find man pages (wrong parsing)
- `ghrun` used wrong column for Run ID
- Redundant aliases causing confusion

## Lösung

### FZF Core
- `--height=50%` → `--height=~50%` (tilde enables "minimum height" mode, fixes Terminal.app hanging)
- Added shell keybindings documentation (Ctrl+T, Ctrl+R, Alt+C)

### FZF Functions (execute() → variable-capture pattern)
All fzf functions converted from `execute()` bindings to variable-capture pattern to prevent ghost text:
- `fman`: Fixed man page parsing with `sed 's/(.*//'` instead of `awk`
- `fenv`: Added "Kopiert: VAR" feedback
- `fhist`: Adds command to history with `print -s`

### Git Functions
- `glog`, `gbr`, `gst`, `gstash`: Use variable-capture pattern
- `gbr`: Properly strips `* ` prefix and `remotes/origin/`
- `gst`: Shows "Staged: X Datei(en)" feedback

### GitHub Functions  
- `ghpr`, `ghis`, `ghrepo`: Use variable-capture pattern
- `ghrun`: Fixed Run ID extraction (column 7 with tab delimiter, was column 1)

### Homebrew Functions
- `bsp`: Use variable-capture pattern

### Cleanup Redundant Aliases
- Removed `catp` (confusing name, `catn` covers the use case)
- Removed `fe` (redundant with Ctrl+T + editor)
- Removed `fo` (rarely used, Ctrl+T covers it)

## Tests
- ✅ 68/68 Unit-Tests bestanden
- ✅ Health-Check sauber (38/38)
- ✅ Dokumentation synchronisiert

## Relates to
Closes #47 (fzf-tab investigation - keybindings now documented as alternative)