### PR TITLE
fix: address Copilot review feedback

### DIFF
--- a/terminal/.config/alias/fzf.alias
+++ b/terminal/.config/alias/fzf.alias
@@ -78,9 +78,15 @@ fman() {
             --header='Enter: Man-Page öffnen')
     
     if [[ -n "$selection" ]]; then
-        # Extrahiere Seitenname ohne (1), (3), etc.
+        # Extrahiere Seitenname und Section (z.B. "printf(3)" → "3 printf")
+        local page section
         page=$(echo "$selection" | sed 's/(.*//')
-        man "$page"
+        section=$(echo "$selection" | sed -n 's/.*([^0-9]*\([0-9][a-z]*\)).*/\1/p')
+        if [[ -n "$section" ]]; then
+            man "$section" "$page"
+        else
+            man "$page"
+        fi
     fi
 }
 

--- a/terminal/.config/alias/git.alias
+++ b/terminal/.config/alias/git.alias
@@ -70,7 +70,7 @@ if command -v fzf >/dev/null 2>&1; then
                 --preview 'git log --oneline --color=always {1} | head -20' \
                 --header='Enter: Wechseln | Ctrl+D: Löschen' \
                 --bind 'ctrl-d:execute(git branch -d {1})+reload(git branch --all --color=always | grep -v HEAD)' | \
-            sed 's/^[* ]*//' | sed 's|remotes/origin/||')
+            sed 's/^[* ]*//' | sed 's|remotes/[^/]*/||')
         
         [[ -n "$branch" ]] && git checkout "$branch"
     }
@@ -85,7 +85,13 @@ if command -v fzf >/dev/null 2>&1; then
                 --bind 'ctrl-r:execute(git restore {+2})+reload(git -c color.status=always status --short)' | \
             awk '{print $2}')
         
-        [[ -n "$files" ]] && echo "$files" | xargs git add && echo "Staged: $(echo "$files" | wc -l | tr -d ' ') Datei(en)"
+        if [[ -n "$files" ]]; then
+            local count=0
+            while IFS= read -r file; do
+                git add -- "$file" && ((count++))
+            done <<< "$files"
+            echo "Staged: $count Datei(en)"
+        fi
     }
     
     # Stash-Browser


### PR DESCRIPTION
## Copilot Review Feedback von PR #49

Einarbeitung der 3 Vorschläge mit echtem Mehrwert:

### 1. `gbr` - Alle Remotes unterstützen
**Problem:** Nur `origin` wurde gestriped, nicht `upstream`, `fork`, etc.

```diff
- sed 's|remotes/origin/||'
+ sed 's|remotes/[^/]*/||'
```

### 2. `gst` - Leerzeichen in Dateinamen
**Problem:** `xargs git add` bricht bei Dateinamen mit Leerzeichen

```diff
- [[ -n "$files" ]] && echo "$files" | xargs git add && echo "..."
+ while IFS= read -r file; do
+     git add -- "$file" && ((count++))
+ done <<< "$files"
```

### 3. `fman` - Section-Nummer beibehalten
**Problem:** Bei `printf(3)` wurde nur `man printf` aufgerufen → bekommt `printf(1)` statt der C-Library

```diff
+ section=$(echo "$selection" | sed -n 's/.*([^0-9]*\([0-9][a-z]*\)).*/\1/p')
+ if [[ -n "$section" ]]; then
+     man "$section" "$page"
```

## Tests
✅ 68/68 Unit-Tests bestanden