### PR TITLE
feat(fd): restore fo function for quick file opening

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -168,6 +168,7 @@ Verfügbare Aliase aus `~/.config/alias/`:
 | Funktion | Beschreibung |
 |----------|--------------|
 | `cdf [path]` | **Fuzzy CD**: fd + fzf + eza – Verzeichnisnavigation mit Baum-Vorschau |
+| `fo [path]` | **Fuzzy Open**: fd + fzf + open – Datei mit Standard-App öffnen (PDFs, Bilder, etc.) |
 
 > **Hinweis:** fd respektiert automatisch `.gitignore` und ist deutlich schneller als find. Zusätzlich werden Patterns aus `~/.config/fd/ignore` global ausgeschlossen (z.B. `.git/`, `node_modules/`, `__pycache__/`). Mit `fd -u` (unrestricted) werden alle Ignore-Dateien umgangen.
 >
@@ -309,7 +310,7 @@ fzf ist als "Enhancer" in die jeweiligen Tool-Alias-Dateien integriert. Diese Da
 Die folgenden Funktionen nutzen fzf, sind aber nach ihrem primären Zweck in den jeweiligen Tool-Dateien organisiert:
 
 - **ripgrep.alias**: `rgf`
-- **fd.alias**: `cdf`
+- **fd.alias**: `cdf`, `fo`
 - **git.alias**: `glog`, `gbr`, `gst`, `gstash`
 - **homebrew.alias**: `bip`, `bup`, `brp`, `bsp`
 - **gh.alias**: `ghpr`, `ghis`, `ghrun`, `ghrepo`

--- a/terminal/.config/alias/fd.alias
+++ b/terminal/.config/alias/fd.alias
@@ -65,4 +65,14 @@ if command -v fzf >/dev/null 2>&1; then
         
         [[ -n "$dir" ]] && cd "$dir"
     }
+
+    # Datei mit Standard-App öffnen (fo [pfad])
+    # Ideal für PDFs, Bilder, Office-Dokumente etc.
+    fo() {
+        local file
+        file=$(fd --type f --hidden --follow --exclude .git . "${1:-.}" | \
+            fzf --preview 'bat --style=numbers --color=always {} 2>/dev/null || file {}')
+        
+        [[ -n "$file" ]] && open "$file"
+    }
 fi


### PR DESCRIPTION
## Änderung
`fo` Funktion wieder hinzugefügt - war zu Unrecht als redundant entfernt worden.

## Begründung
`Ctrl+T` ersetzt `fo` **nicht**, da:
- `Ctrl+T` fügt nur den Pfad ein → User muss `open ` vorher tippen
- `fo` führt `open` direkt aus → Ein-Schritt-Workflow

## Anwendungsfall
Schnelles Öffnen von PDFs, Bildern, Office-Dokumenten mit der Standard-App:
```bash
fo ~/Downloads  # Datei auswählen → öffnet mit Preview/Adobe/etc.
```

## Tests
✅ 68/68 Unit-Tests
✅ Dokumentation synchron (80 Aliase/Funktionen)