### PR TITLE
feat: Catppuccin Mocha Theme für eza hinzufügen

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,6 +57,7 @@ Catppuccin Mocha ist das **verbindliche Farbschema** für alle Tools:
 - **bat**: Theme in `terminal/.config/bat/themes/` (via Stow, Cache-Build in bootstrap.sh)
 - **fzf**: Farben in `terminal/.config/fzf/config`
 - **btop**: Theme in `terminal/.config/btop/themes/` (via Stow)
+- **eza**: Theme in `terminal/.config/eza/theme.yml` (via Stow)
 - **zsh-syntax-highlighting**: Theme in `terminal/.config/zsh/` (via Stow)
 - **Starship**: `catppuccin-powerline` Preset
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ Das gesamte Setup verwendet [Catppuccin Mocha](https://catppuccin.com/) als einh
 | **bat** | `~/.config/bat/themes/Catppuccin Mocha.tmTheme` | Via Stow verlinkt (+ Cache-Build) |
 | **fzf** | `~/.config/fzf/config` | Farben in Config-Datei (via Stow) |
 | **btop** | `~/.config/btop/themes/catppuccin_mocha.theme` | Via Stow verlinkt |
+| **eza** | `~/.config/eza/theme.yml` | Via Stow verlinkt |
 | **zsh-syntax-highlighting** | `~/.config/zsh/catppuccin_mocha-zsh-syntax-highlighting.zsh` | Via Stow verlinkt |
 
 ### Farbpalette (Referenz)

--- a/terminal/.config/eza/theme.yml
+++ b/terminal/.config/eza/theme.yml
@@ -1,0 +1,102 @@
+colourful: true
+
+filekinds:
+  normal: {foreground: "#cdd6f4"}
+  directory: {foreground: "#cba6f7"}
+  symlink: {foreground: "#89b4fa"}
+  pipe: {foreground: "#bac2de"}
+  block_device: {foreground: "#eba0ac"}
+  char_device: {foreground: "#eba0ac"}
+  socket: {foreground: "#bac2de"}
+  special: {foreground: "#cba6f7"}
+  executable: {foreground: "#a6e3a1"}
+  mount_point: {foreground: "#94e2d5"}
+
+perms:
+  user_read: {foreground: "#f38ba8", is_bold: true}
+  user_write: {foreground: "#f9e2af", is_bold: true}
+  user_execute_file: {foreground: "#a6e3a1", is_bold: true}
+  user_execute_other: {foreground: "#a6e3a1", is_bold: true}
+  group_read: {foreground: "#f38ba8"}
+  group_write: {foreground: "#f9e2af"}
+  group_execute: {foreground: "#a6e3a1"}
+  other_read: {foreground: "#f38ba8"}
+  other_write: {foreground: "#f9e2af"}
+  other_execute: {foreground: "#a6e3a1"}
+  special_user_file: {foreground: "#cba6f7"}
+  special_other: {foreground: "#7f849c"}
+  attribute: {foreground: "#9399b2"}
+
+size:
+  major: {foreground: "#a6adc8"}
+  minor: {foreground: "#89dceb"}
+  number_byte: {foreground: "#bac2de"}
+  number_kilo: {foreground: "#a6adc8"}
+  number_mega: {foreground: "#89b4fa"}
+  number_giga: {foreground: "#cba6f7"}
+  number_huge: {foreground: "#cba6f7"}
+  unit_byte: {foreground: "#a6adc8"}
+  unit_kilo: {foreground: "#89dceb"}
+  unit_mega: {foreground: "#cba6f7"}
+  unit_giga: {foreground: "#cba6f7"}
+  unit_huge: {foreground: "#94e2d5"}
+
+users:
+  user_you: {foreground: "#cdd6f4"}
+  user_root: {foreground: "#f38ba8"}
+  user_other: {foreground: "#eba0ac"}
+  group_yours: {foreground: "#a6adc8"}
+  group_other: {foreground: "#9399b2"}
+  group_root: {foreground: "#f38ba8"}
+
+links:
+  normal: {foreground: "#89b4fa"}
+  multi_link_file: {foreground: "#89b4fa"}
+
+git:
+  new: {foreground: "#a6e3a1"}
+  modified: {foreground: "#f9e2af"}
+  deleted: {foreground: "#eba0ac"}
+  renamed: {foreground: "#94e2d5"}
+  typechange: {foreground: "#f5c2e7"}
+  ignored: {foreground: "#7f849c"}
+  conflicted: {foreground: "#fab387"}
+
+git_repo:
+  branch_main: {foreground: "#a6adc8"}
+  branch_other: {foreground: "#cba6f7"}
+  git_clean: {foreground: "#a6e3a1"}
+  git_dirty: {foreground: "#eba0ac"}
+
+security_context:
+  colon: {foreground: "#6c7086"}
+  user: {foreground: "#7f849c"}
+  role: {foreground: "#cba6f7"}
+  typ: {foreground: "#585b70"}
+  range: {foreground: "#cba6f7"}
+
+file_type:
+  image: {foreground: "#f9e2af"}
+  video: {foreground: "#f38ba8"}
+  music: {foreground: "#a6e3a1"}
+  lossless: {foreground: "#94e2d5"}
+  crypto: {foreground: "#7f849c"}
+  document: {foreground: "#cdd6f4"}
+  compressed: {foreground: "#f5c2e7"}
+  temp: {foreground: "#eba0ac"}
+  compiled: {foreground: "#74c7ec"}
+  source: {foreground: "#89b4fa"}
+
+punctuation: {foreground: "#6c7086"}
+date: {foreground: "#f9e2af"}
+inode: {foreground: "#a6adc8"}
+blocks: {foreground: "#6c7086"}
+header: {foreground: "#cdd6f4"}
+octal: {foreground: "#94e2d5"}
+flags: {foreground: "#cba6f7"}
+
+symlink_path: {foreground: "#89dceb"}
+control_char: {foreground: "#74c7ec"}
+broken_symlink: {foreground: "#f38ba8"}
+broken_path_overlay: {foreground: "#585b70"}
+


### PR DESCRIPTION
## Zusammenfassung

Fügt das fehlende Catppuccin Mocha Theme für eza hinzu.

## Änderungen

- `terminal/.config/eza/theme.yml` - Catppuccin Mocha Theme (Mauve Akzent)
- Dokumentation aktualisiert

## Vorher/Nachher

| Vorher | Nachher |
|--------|---------|
| Verzeichnisse: blau | Verzeichnisse: mauve (lila) |
| Standard eza Farben | Catppuccin Mocha Palette |

## Theme-Quelle

Offizielles Catppuccin Theme: https://github.com/catppuccin/eza