### PR TITLE
fix(eza): XDG_CONFIG_HOME und EZA_CONFIG_DIR setzen für Theme-Support

### DIFF
--- a/terminal/.zshenv
+++ b/terminal/.zshenv
@@ -8,6 +8,22 @@
 # ============================================================
 
 # ------------------------------------------------------------
+# XDG Base Directory Specification
+# ------------------------------------------------------------
+# Standard-Pfad für Konfigurationsdateien. Wichtig für:
+# - bat (config)
+# - btop (btop.conf, themes)
+# - fzf (config)
+# - ripgrep (config)
+# - und weitere Tools die XDG_CONFIG_HOME respektieren
+# Docs: https://specifications.freedesktop.org/basedir-spec/latest/
+export XDG_CONFIG_HOME="$HOME/.config"
+
+# eza nutzt dirs::config_dir() was auf macOS ~/Library/Application Support
+# zurückgibt statt XDG_CONFIG_HOME zu respektieren - daher explizit setzen
+export EZA_CONFIG_DIR="$XDG_CONFIG_HOME/eza"
+
+# ------------------------------------------------------------
 # macOS Session-Wiederherstellung deaktivieren
 # ------------------------------------------------------------
 # Deaktiviert separate History pro Tab zugunsten einer zentralen


### PR DESCRIPTION
## Problem

Das eza Catppuccin Mocha Theme wurde nicht geladen (`theme_config: None` im Debug-Output).

**Ursache:**
- eza nutzt `dirs::config_dir()` was auf macOS `~/Library/Application Support` zurückgibt
- Unsere `theme.yml` liegt aber in `~/.config/eza/`
- `dirs::config_dir()` respektiert `XDG_CONFIG_HOME` auf macOS **nicht**

## Lösung

In `.zshenv` hinzugefügt:
- `XDG_CONFIG_HOME=$HOME/.config` - Standard für XDG-konforme Tools
- `EZA_CONFIG_DIR=$XDG_CONFIG_HOME/eza` - Explizit für eza da es XDG nicht respektiert

## Verifizierung

Vorher:
```
theme_config: None
```

Nachher:
```
EZA_CONFIG_DIR: ~/.config/eza
theme_config: Some(location: "~/.config/eza/theme.yml")
```

Das Catppuccin Mocha Theme wird jetzt korrekt geladen und Verzeichnisse erscheinen in Mauve (#cba6f7).