### PR TITLE
docs: XDG Base Directory Specification als Architektur-Richtlinie

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -82,6 +82,23 @@ Vollständige Palette: [catppuccin.com/palette](https://catppuccin.com/palette)
 - **Modularität**: Ein Tool = Eine Alias-Datei (z.B. `bat.alias`, `fd.alias`)
 - **Symlinks**: Via GNU Stow mit `--no-folding` (keine Verzeichnis-Symlinks)
 - **Design**: Catppuccin Mocha als einheitliches Farbschema
+- **XDG Base Directory**: Alle Configs in `~/.config/` (XDG-konform)
+
+### XDG Base Directory Specification
+
+Alle Tool-Konfigurationen folgen der [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/):
+
+| Variable | Wert | Gesetzt in |
+|----------|------|------------|
+| `XDG_CONFIG_HOME` | `$HOME/.config` | `.zshenv` |
+| `EZA_CONFIG_DIR` | `$XDG_CONFIG_HOME/eza` | `.zshenv` |
+| `RIPGREP_CONFIG_PATH` | `$XDG_CONFIG_HOME/ripgrep/config` | `.zshrc` |
+| `BAT_CONFIG_PATH` | (nutzt XDG automatisch) | – |
+
+**Wichtig für macOS:**
+- `dirs::config_dir()` in Rust gibt `~/Library/Application Support` zurück, **nicht** `~/.config`
+- Tools wie `eza` respektieren `XDG_CONFIG_HOME` nicht – daher explizit `EZA_CONFIG_DIR` setzen
+- Alle Configs liegen in `terminal/.config/` und werden via Stow nach `~/.config/` verlinkt
 
 ### Verzeichnisstruktur
 ```
@@ -94,12 +111,15 @@ dotfiles/
 │   └── catppuccin-mocha.terminal # Terminal.app Profil
 ├── terminal/
 │   ├── .zshrc                   # Shell-Konfiguration
-│   ├── .zshenv                  # Environment (wird zuerst geladen)
+│   ├── .zshenv                  # Environment (XDG_CONFIG_HOME, EZA_CONFIG_DIR)
 │   ├── .zprofile                # Login-Shell (Homebrew-Pfade)
 │   └── .config/
 │       ├── alias/*.alias        # Tool-Aliase (10 Dateien)
 │       ├── bat/config           # bat-Konfiguration
+│       ├── bat/themes/          # bat Catppuccin Theme
+│       ├── btop/btop.conf       # btop-Konfiguration
 │       ├── btop/themes/         # btop Catppuccin Theme
+│       ├── eza/theme.yml        # eza Catppuccin Theme
 │       ├── fd/ignore            # fd-Ignoreliste
 │       ├── fzf/config           # fzf-Optionen + Catppuccin Farben
 │       ├── ripgrep/config       # ripgrep-Optionen

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -106,6 +106,27 @@ Das Bootstrap-Skript ist **idempotent** – es kann beliebig oft ausgeführt wer
 - Font-Check prüft Existenz vor Installation
 - Terminal-Profil-Import ist wiederholbar
 
+### XDG Base Directory Specification
+
+Alle Tool-Konfigurationen folgen der [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/):
+
+| Variable | Wert | Gesetzt in |
+|----------|------|------------|
+| `XDG_CONFIG_HOME` | `$HOME/.config` | `.zshenv` |
+| `EZA_CONFIG_DIR` | `$XDG_CONFIG_HOME/eza` | `.zshenv` |
+| `RIPGREP_CONFIG_PATH` | `$XDG_CONFIG_HOME/ripgrep/config` | `.zshrc` |
+| `BAT_CONFIG_PATH` | (nutzt XDG automatisch) | – |
+
+**macOS-Besonderheit:**
+
+Die Rust-Library `dirs` gibt auf macOS `~/Library/Application Support` zurück statt `~/.config`. Tools wie `eza` nutzen diese Library und respektieren `XDG_CONFIG_HOME` nicht direkt. Daher wird `EZA_CONFIG_DIR` explizit in `.zshenv` gesetzt.
+
+**Warum XDG:**
+- Standardisierter Pfad für alle CLI-Tools
+- Configs in `terminal/.config/` werden via Stow nach `~/.config/` verlinkt
+- Keine Konflikte mit macOS-Standard (`~/Library/Application Support`)
+- Einheitliche Struktur für alle Tools (bat, btop, fzf, ripgrep, eza, fd, gh)
+
 ### Stow statt manuelle Symlinks
 
 [GNU Stow](https://www.gnu.org/software/stow/) verwaltet Symlinks deklarativ:


### PR DESCRIPTION
## Änderungen

XDG Base Directory Specification als Architektur-Richtlinie in die Dokumentation aufgenommen.

### Copilot-Instructions (`.github/copilot-instructions.md`)
- XDG als Architektur-Entscheidung hinzugefügt
- Tabelle mit Environment-Variablen und wo sie gesetzt werden
- macOS-Besonderheit dokumentiert (`dirs::config_dir()` Problem)
- Verzeichnisstruktur aktualisiert (eza/theme.yml, btop/btop.conf, bat/themes/)

### Architecture Docs (`docs/architecture.md`)
- Neuer Abschnitt "XDG Base Directory Specification"
- Erklärt warum `EZA_CONFIG_DIR` explizit gesetzt werden muss
- Begründung warum XDG verwendet wird

## Hintergrund

Nach dem Fix für das eza-Theme (PR #60) wurde klar, dass die XDG-Konformität als Architektur-Prinzip dokumentiert werden sollte:

- macOS-Standard ist `~/Library/Application Support`
- Wir nutzen bewusst `~/.config/` (XDG-Standard)
- Einige Tools (wie eza) respektieren `XDG_CONFIG_HOME` nicht
- Diese Entscheidungen sollten in den Richtlinien festgehalten sein