### PR TITLE
feat: Issues #63, #64, #65 - Terminal-Profil, lazygit, Security-Doku

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -122,6 +122,7 @@ dotfiles/
 │       ├── eza/theme.yml        # eza Catppuccin Theme
 │       ├── fd/ignore            # fd-Ignoreliste
 │       ├── fzf/config           # fzf-Optionen + Catppuccin Farben
+│       ├── lazygit/config.yml   # lazygit Config + Catppuccin Theme
 │       ├── ripgrep/config       # ripgrep-Optionen
 │       └── zsh/                 # zsh-syntax-highlighting Theme
 ├── scripts/
@@ -132,7 +133,7 @@ dotfiles/
 ```
 
 ### Installierte Tools (Brewfile)
-`bat`, `btop`, `eza`, `fd`, `fzf`, `gh`, `ripgrep`, `starship`, `stow`, `zoxide`
+`bat`, `btop`, `eza`, `fd`, `fzf`, `gh`, `lazygit`, `ripgrep`, `starship`, `stow`, `zoxide`
 
 Plus: `mas` (Mac App Store), `zsh-syntax-highlighting`, `zsh-autosuggestions`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ dotfiles/
 ├── setup/                  # Bootstrap & Installation
 │   ├── bootstrap.sh        # Hauptskript
 │   ├── Brewfile            # Homebrew-Abhängigkeiten
-│   └── tshofmann.terminal  # Terminal.app Profil
+│   └── catppuccin-mocha.terminal  # Terminal.app Profil
 ├── terminal/               # Dotfiles (werden nach ~ verlinkt)
 │   ├── .zlogin
 │   ├── .zprofile
@@ -265,7 +265,7 @@ gh pr create
 
 1. Terminal.app → Einstellungen → Profil anpassen
 2. Rechtsklick → "Exportieren…"
-3. Als `setup/tshofmann.terminal` speichern (überschreiben)
+3. Als `setup/catppuccin-mocha.terminal` speichern (überschreiben)
 
 > ⚠️ **Niemals** die `.terminal`-Datei direkt editieren – enthält binäre Daten.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,7 +42,7 @@ dotfiles/
 ├── setup/
 │   ├── bootstrap.sh             # Automatisiertes Setup-Skript
 │   ├── Brewfile                 # Homebrew-Abhängigkeiten
-│   └── tshofmann.terminal       # Terminal.app Profil
+│   └── catppuccin-mocha.terminal  # Terminal.app Profil
 └── terminal/
     ├── .zshenv                  # Umgebungsvariablen (wird zuerst geladen)
     ├── .zprofile                # Login-Shell Konfiguration
@@ -53,6 +53,8 @@ dotfiles/
         │   └── config           # fzf globale Optionen (FZF_DEFAULT_OPTS_FILE)
         ├── bat/
         │   └── config           # bat native Config
+        ├── lazygit/
+        │   └── config.yml       # lazygit Config mit Catppuccin Mocha
         ├── ripgrep/
         │   └── config           # ripgrep native Config (RIPGREP_CONFIG_PATH)
         └── alias/
@@ -62,6 +64,7 @@ dotfiles/
             ├── ripgrep.alias    # ripgrep-Aliase (grep-Ersatz)
             ├── fd.alias         # fd-Aliase (find-Ersatz)
             ├── fzf.alias        # fzf Tool-Kombinationen (20+ Funktionen)
+            ├── git.alias        # Git-Aliase + lazygit
             └── btop.alias       # btop-Aliase (top-Ersatz)
 ```
 
@@ -162,7 +165,7 @@ Die visuelle Terminal-Darstellung basiert auf drei eng gekoppelten Komponenten:
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                    Terminal.app Profil                      │
-│                   (tshofmann.terminal)                      │
+│                (catppuccin-mocha.terminal)                  │
 │         Font: MesloLGLDZNerdFont (binär kodiert)            │
 └────────────────────────┬────────────────────────────────────┘
                          │ referenziert
@@ -221,7 +224,7 @@ Die visuelle Terminal-Darstellung basiert auf drei eng gekoppelten Komponenten:
 
 ### Technische Details
 
-> **Wichtig:** Die Datei `tshofmann.terminal` enthält Base64-kodierte NSArchiver-Daten (Apple plist-Format). Font-Einstellungen können **nicht** durch direktes Editieren geändert werden – nur über die Terminal.app GUI mit anschließendem Export.
+> **Wichtig:** Die Datei `catppuccin-mocha.terminal` enthält Base64-kodierte NSArchiver-Daten (Apple plist-Format). Font-Einstellungen können **nicht** durch direktes Editieren geändert werden – nur über die Terminal.app GUI mit anschließendem Export.
 
 Siehe [Konfiguration → Schriftart wechseln](configuration.md#schriftart-wechseln) für den vollständigen Workflow.
 
@@ -237,6 +240,7 @@ Das Setup verwendet `brew bundle` für deklaratives Package-Management:
 # CLI-Tools
 brew "fzf"                       # Fuzzy Finder
 brew "gh"                        # GitHub CLI
+brew "lazygit"                   # Terminal-UI für Git
 brew "stow"                      # Symlink-Manager
 brew "starship"                  # Shell-Prompt
 brew "zoxide"                    # Smartes cd
@@ -559,6 +563,51 @@ STARSHIP_PRESET="tokyo-night" ./setup/bootstrap.sh
 - Preset wird dynamisch generiert
 - Erlaubt lokale Anpassungen ohne Git-Konflikte
 - Kann bei Bedarf versioniert werden (siehe [Konfiguration](configuration.md))
+
+---
+
+## Nicht-versionierte Konfigurationen
+
+Einige Konfigurationen enthalten sensitive Daten oder werden dynamisch generiert und sind daher **nicht** im Repository enthalten:
+
+### Sensitive Dateien (`~/.config/gh/`)
+
+Die GitHub CLI speichert OAuth-Tokens und Session-Daten:
+
+```
+~/.config/gh/
+├── config.yml      # Einstellungen (git_protocol, editor, aliases)
+└── hosts.yml       # OAuth-Tokens für github.com (SENSITIVE!)
+```
+
+| Datei | Inhalt | Sensitivität |
+|-------|--------|--------------|
+| `config.yml` | Allgemeine Einstellungen | ⚠️ Kann versioniert werden |
+| `hosts.yml` | OAuth-Tokens | 🔴 **Niemals versionieren!** |
+
+**Wiederherstellung:** Nach `gh auth login` werden beide Dateien automatisch erstellt.
+
+### Dynamisch generierte Dateien
+
+| Datei | Generiert durch | Funktion |
+|-------|-----------------|----------|
+| `~/.config/starship.toml` | `starship preset catppuccin-powerline -o ~/.config/starship.toml` | Shell-Prompt Konfiguration |
+| `~/.zoxide.db` | zoxide automatisch | Verzeichnis-History für `z` |
+| `~/Library/Application Support/lazygit/config.yml` | Stow (symlinked von `~/.config/lazygit/`) | lazygit Theme + Einstellungen |
+
+> **Hinweis:** `starship.toml` wird beim Bootstrap generiert. Lokale Anpassungen bleiben bei Updates erhalten, solange das Preset nicht erneut ausgeführt wird.
+
+### Backup-Empfehlung
+
+Für Rechner-Migration diese Dateien sichern (ohne OAuth-Tokens):
+
+```zsh
+# Sichere nicht-sensitive gh-Config
+cp ~/.config/gh/config.yml ~/backup/
+
+# hosts.yml NICHT sichern – neu authentifizieren mit:
+# gh auth login
+```
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,7 +46,7 @@ Das Bootstrap-Skript führt folgende Aktionen in dieser Reihenfolge aus:
 | Homebrew | Installiert/prüft Homebrew unter `/opt/homebrew` | ❌ Exit |
 | Brewfile | Installiert CLI-Tools via `brew bundle` | ❌ Exit |
 | Font-Verifikation | Prüft MesloLG Nerd Font Installation | ❌ Exit |
-| Terminal-Profil | Importiert `tshofmann.terminal` als Standard | ⚠️ Warnung |
+| Terminal-Profil | Importiert `catppuccin-mocha.terminal` als Standard | ⚠️ Warnung |
 | Starship-Theme | Generiert `~/.config/starship.toml` | ⚠️ Warnung |
 | ZSH-Sessions | Prüft SHELL_SESSIONS_DISABLE in ~/.zshenv | ⚠️ Warnung |
 
@@ -183,7 +183,7 @@ cd ~/dotfiles
 | **CLI-Tools** | Alle Formulae aus Brewfile | `setup/Brewfile` (dynamisch) |
 | **ZSH-Plugins** | zsh-syntax-highlighting, zsh-autosuggestions | Homebrew-Verzeichnis |
 | **Nerd Font** | MesloLG Nerd Font | `~/Library/Fonts/` |
-| **Terminal-Profil** | `tshofmann` als Standard | Terminal.app defaults |
+| **Terminal-Profil** | `catppuccin-mocha` als Standard | Terminal.app defaults |
 | **Starship** | `~/.config/starship.toml` vorhanden | Dateisystem |
 | **ZSH-Sessions** | `SHELL_SESSIONS_DISABLE=1` | `~/.zshenv` |
 | **Brewfile** | Alle Abhängigkeiten erfüllt | `brew bundle check` |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -92,6 +92,7 @@ Diese Tools werden via Brewfile installiert:
 | **fd** | Schneller `find`-Ersatz (respektiert `.gitignore`) | [github.com/sharkdp/fd](https://github.com/sharkdp/fd) |
 | **fzf** | Fuzzy Finder für Kommandozeile und Dateien | [github.com/junegunn/fzf](https://github.com/junegunn/fzf) |
 | **gh** | GitHub CLI – Issues, PRs, Repos von der Kommandozeile | [cli.github.com](https://cli.github.com/) |
+| **lazygit** | Terminal-UI für Git – interaktives Staging, Commits, Branches | [github.com/jesseduffield/lazygit](https://github.com/jesseduffield/lazygit) |
 | **mas** | Mac App Store CLI – Apps installieren und updaten | [github.com/mas-cli/mas](https://github.com/mas-cli/mas) |
 | **ripgrep** | Ultraschneller `grep`-Ersatz (respektiert `.gitignore`) | [github.com/BurntSushi/ripgrep](https://github.com/BurntSushi/ripgrep) |
 | **starship** | Schneller, anpassbarer Shell-Prompt | [starship.rs](https://starship.rs/) |
@@ -205,8 +206,9 @@ Verfügbare Aliase aus `~/.config/alias/`:
 | `gbr` | Branch wechseln: Log-Vorschau, Ctrl+D=Branch löschen |
 | `gst` | Status mit Diff-Vorschau (bat): Enter=Add, Ctrl+R=Restore |
 | `gstash` | Stash-Browser: Enter=Apply, Ctrl+D=Drop, Ctrl+P=Pop |
+| `lg` | **lazygit**: Vollständige Terminal-UI für Git |
 
-> **Hinweis:** Die interaktiven Funktionen benötigen fzf und nutzen bat für Syntax-Highlighting in der Diff-Vorschau.
+> **Hinweis:** Die interaktiven Funktionen benötigen fzf und nutzen bat für Syntax-Highlighting in der Diff-Vorschau. `lg` startet lazygit mit Catppuccin Mocha Theme.
 
 ### eza.alias
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -44,7 +44,7 @@ brew reinstall font-meslo-lg-nerd-font
 
 Falls das Problem weiterhin besteht:
 
-1. Terminal.app → Einstellungen → Profile → `tshofmann`
+1. Terminal.app → Einstellungen → Profile → `catppuccin-mocha`
 2. Tab "Text" → Schrift ändern → "MesloLGLDZ Nerd Font" auswählen (oder andere installierte Nerd Font-Variante)
 
 ---
@@ -53,7 +53,7 @@ Falls das Problem weiterhin besteht:
 
 ### Symptom
 
-- Profil `tshofmann` erscheint nicht in Terminal.app
+- Profil `catppuccin-mocha` erscheint nicht in Terminal.app
 - Terminal hat weiterhin Standard-Erscheinung
 
 ### Diagnose
@@ -71,13 +71,13 @@ osascript -e 'quit app "Terminal"'
 **Schritt 2:** Profil manuell importieren
 
 ```zsh
-open ~/dotfiles/setup/tshofmann.terminal
+open ~/dotfiles/setup/catppuccin-mocha.terminal
 ```
 
 **Schritt 3:** Als Standard setzen
 
 1. Terminal.app → Einstellungen → Profile
-2. `tshofmann` auswählen
+2. `catppuccin-mocha` auswählen
 3. "Standard" Button klicken
 
 ---

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -196,7 +196,7 @@ fi
 # --- Terminal-Profil ---
 section "Terminal.app Profil"
 
-profile_name="tshofmann"
+profile_name="catppuccin-mocha"
 default_profile=$(defaults read com.apple.Terminal "Default Window Settings" 2>/dev/null || echo "")
 startup_profile=$(defaults read com.apple.Terminal "Startup Window Settings" 2>/dev/null || echo "")
 

--- a/scripts/tests/test_validators.sh
+++ b/scripts/tests/test_validators.sh
@@ -52,7 +52,7 @@ for name in "${expected_core[@]}"; do
 done
 
 # Erwartete Extended-Validatoren
-local -a expected_extended=(alias-names codeblocks structure)
+local -a expected_extended=(alias-names codeblocks copilot-instructions structure style-consistency terminal-profile)
 for name in "${expected_extended[@]}"; do
     assert_contains "$name" EXTENDED_VALIDATORS "Extended-Validator '$name' registriert"
 done

--- a/scripts/validators/extended/terminal-profile.sh
+++ b/scripts/validators/extended/terminal-profile.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env zsh
+# ============================================================
+# terminal-profile.sh - Terminal-Profil Konsistenz Validierung
+# ============================================================
+# Prüft: PROFILE_NAME in bootstrap.sh = health-check.sh = Doku
+# Verhindert Drift zwischen Code und Dokumentation
+# ============================================================
+
+[[ -z "${VALIDATOR_LIB_LOADED:-}" ]] && source "${0:A:h:h}/lib.sh"
+
+check_terminal_profile() {
+    log "Prüfe Terminal-Profil Konsistenz..."
+    
+    local errors=0
+    local bootstrap="$DOTFILES_DIR/setup/bootstrap.sh"
+    local healthcheck="$DOTFILES_DIR/scripts/health-check.sh"
+    
+    # 1. PROFILE_NAME aus bootstrap.sh extrahieren
+    local code_name
+    code_name=$(grep -E '^readonly PROFILE_NAME=' "$bootstrap" 2>/dev/null | cut -d'"' -f2)
+    
+    if [[ -z "$code_name" ]]; then
+        err "PROFILE_NAME nicht in bootstrap.sh gefunden"
+        return 1
+    fi
+    
+    # 2. Profil-Datei existiert?
+    local profile_file="$DOTFILES_DIR/setup/${code_name}.terminal"
+    if [[ ! -f "$profile_file" ]]; then
+        err "Profil-Datei nicht gefunden: setup/${code_name}.terminal"
+        (( errors++ )) || true
+    fi
+    
+    # 3. Health-Check verwendet gleichen Namen?
+    local healthcheck_name
+    healthcheck_name=$(grep -E '^profile_name=' "$healthcheck" 2>/dev/null | cut -d'"' -f2)
+    
+    if [[ -z "$healthcheck_name" ]]; then
+        err "profile_name nicht in health-check.sh gefunden"
+        (( errors++ )) || true
+    elif [[ "$code_name" != "$healthcheck_name" ]]; then
+        err "Health-Check verwendet '$healthcheck_name', erwartet '$code_name'"
+        (( errors++ )) || true
+    fi
+    
+    # 4. Dokumentation prüfen - veraltete Referenzen finden
+    # Suche nach tshofmann (außer in URLs wie github.com/tshofmann)
+    local -a doc_files=("$DOTFILES_DIR/docs"/*.md "$DOTFILES_DIR/CONTRIBUTING.md")
+    local old_refs=0
+    local old_ref_file
+    
+    for doc in "${doc_files[@]}"; do
+        [[ ! -f "$doc" ]] && continue
+        # Filtere GitHub-URLs heraus und zähle restliche Treffer
+        local actual_count=0
+        actual_count=$(grep "tshofmann" "$doc" 2>/dev/null | grep -v "github.com/tshofmann" | wc -l | tr -d ' ') || true
+        (( actual_count > 0 )) && {
+            old_ref_file="${doc##*/}"
+            err "Veraltete 'tshofmann' Referenz in $old_ref_file ($actual_count Stellen)"
+            (( old_refs += actual_count )) || true
+        }
+    done
+    
+    if (( old_refs > 0 )); then
+        (( errors++ )) || true
+    fi
+    
+    # 5. Ergebnis
+    if (( errors == 0 )); then
+        ok "Terminal-Profil konsistent: $code_name"
+        return 0
+    else
+        return 1
+    fi
+}
+
+register_validator "terminal-profile" "check_terminal_profile" "Terminal-Profil Konsistenz"

--- a/setup/Brewfile
+++ b/setup/Brewfile
@@ -20,6 +20,7 @@ brew "bat"                                  # cat mit Syntax-Highlighting
 brew "ripgrep"                              # Ultraschneller grep-Ersatz
 brew "fd"                                   # Schneller find-Ersatz
 brew "btop"                                 # Ressourcen-Monitor (top-Ersatz)
+brew "lazygit"                              # Terminal-UI für Git
 
 # ZSH-Plugins
 brew "zsh-syntax-highlighting"              # Syntax-Highlighting für Kommandos

--- a/terminal/.config/alias/git.alias
+++ b/terminal/.config/alias/git.alias
@@ -108,3 +108,11 @@ if command -v fzf >/dev/null 2>&1; then
         [[ -n "$stash" ]] && git stash apply "$stash"
     }
 fi
+
+# ------------------------------------------------------------
+# lazygit Integration
+# ------------------------------------------------------------
+if command -v lazygit >/dev/null 2>&1; then
+    # Terminal-UI für Git (lazygit)
+    alias lg='lazygit'
+fi

--- a/terminal/.config/lazygit/config.yml
+++ b/terminal/.config/lazygit/config.yml
@@ -1,0 +1,80 @@
+# lazygit Configuration
+# https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md
+#
+# Config location: ~/Library/Application Support/lazygit/config.yml (macOS)
+# This file is symlinked via Stow from ~/.config/lazygit/config.yml
+#
+# Theme: Catppuccin Mocha (Mauve Accent)
+# https://github.com/catppuccin/lazygit
+
+gui:
+  # Catppuccin Mocha Theme mit Mauve Akzent
+  theme:
+    activeBorderColor:
+      - '#cba6f7'  # Mauve
+      - bold
+    inactiveBorderColor:
+      - '#a6adc8'  # Overlay0
+    optionsTextColor:
+      - '#89b4fa'  # Blue
+    selectedLineBgColor:
+      - '#313244'  # Surface0
+    cherryPickedCommitBgColor:
+      - '#45475a'  # Surface1
+    cherryPickedCommitFgColor:
+      - '#cba6f7'  # Mauve
+    unstagedChangesColor:
+      - '#f38ba8'  # Red
+    defaultFgColor:
+      - '#cdd6f4'  # Text
+    searchingActiveBorderColor:
+      - '#f9e2af'  # Yellow
+
+  # UI-Einstellungen
+  showIcons: true
+  nerdFontsVersion: "3"
+  showFileTree: true
+  showRandomTip: false
+  showCommandLog: true
+  showBottomLine: true
+  showPanelJumps: true
+  border: rounded
+
+  # Sprache
+  language: auto
+
+# Author colors für commit log
+authorColors:
+  '*': '#b4befe'  # Lavender
+
+# Git-Einstellungen
+git:
+  paging:
+    colorArg: always
+    pager: delta --dark --paging=never
+  commit:
+    signOff: false
+  merging:
+    manualCommit: false
+    args: ""
+  log:
+    showGraph: always
+    showWholeGraph: false
+
+# Bestätigungen
+confirmOnQuit: false
+
+# OS-spezifisch
+os:
+  editPreset: nvim
+
+# Keybindings (Standard + Anpassungen)
+keybinding:
+  universal:
+    quit: q
+    return: <esc>
+    togglePanel: <tab>
+    prevBlock: <left>
+    nextBlock: <right>
+    scrollUpMain: <pgup>
+    scrollDownMain: <pgdown>


### PR DESCRIPTION
## Zusammenfassung

Dieser PR behebt drei Issues aus der Repository-Analyse:

### Issue #63: Terminal-Profil Konsistenz
- ✅ 12x `tshofmann` → `catppuccin-mocha` in Code und Docs ersetzt
- ✅ Neuer Validator `terminal-profile.sh` verhindert zukünftigen Drift
- ✅ Tests erweitert auf 77/77

**Geänderte Dateien:**
- `scripts/health-check.sh`
- `CONTRIBUTING.md`
- `docs/installation.md`
- `docs/architecture.md`
- `docs/troubleshooting.md`
- `scripts/validators/extended/terminal-profile.sh` (neu)
- `scripts/tests/test_validators.sh`

### Issue #64: lazygit mit Catppuccin Mocha Theme
- ✅ `lazygit` zu Brewfile hinzugefügt
- ✅ Config mit Catppuccin Mocha (Mauve Akzent): `terminal/.config/lazygit/config.yml`
- ✅ Alias `lg` in `git.alias` mit Guard-Check
- ✅ Dokumentation in tools.md, architecture.md, copilot-instructions.md

**Neue Dateien:**
- `terminal/.config/lazygit/config.yml`

### Issue #65: Sensitive Configs Dokumentation
- ✅ Neue Sektion in `docs/architecture.md`: "Nicht-versionierte Konfigurationen"
- ✅ Dokumentiert: `~/.config/gh/hosts.yml` (OAuth-Tokens - niemals versionieren!)
- ✅ Dokumentiert: `~/.config/starship.toml` (dynamisch generiert)
- ✅ Backup-Empfehlungen für Rechner-Migration

## Validierung

```
✅ Health Check: 39/39 bestanden
✅ Validate-Docs: Alle Prüfungen bestanden
✅ Unit-Tests: 77/77 bestanden
✅ Pre-commit Hooks: Alle bestanden
```

## Closes

Closes #63
Closes #64
Closes #65