### PR TITLE
fix: bat cache --build Timing korrigiert

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -462,7 +462,7 @@ build/
 #### bat Config (`~/.config/bat/config`)
 
 ```
---theme="Monokai Extended"
+--theme="Catppuccin Mocha"
 --style="numbers,changes"
 --paging=auto
 --pager="less --RAW-CONTROL-CHARS --quit-if-one-screen"
@@ -470,6 +470,8 @@ build/
 --map-syntax ".zshrc:Bash"
 --map-syntax "Brewfile:Ruby"
 ```
+
+> **Hinweis:** Das Catppuccin Mocha Theme liegt in `terminal/.config/bat/themes/` und wird via Stow verlinkt. Nach dem Stow-Befehl muss `bat cache --build` ausgeführt werden, um das Theme zu registrieren.
 
 #### zoxide (Smarter cd)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -81,6 +81,14 @@ Nach Abschluss des Bootstrap-Skripts:
 cd ~/dotfiles && stow --adopt -R terminal && git reset --hard HEAD
 ```
 
+3. **bat-Cache für Catppuccin Theme bauen:**
+
+```zsh
+bat cache --build
+```
+
+> **💡 Warum dieser Schritt?** Das Catppuccin Mocha Theme für bat liegt in `~/.config/bat/themes/` (via Stow verlinkt). bat erkennt neue Themes erst nach einem Cache-Rebuild.
+
 ### Was diese Befehle machen
 
 | Flag | Bedeutung |

--- a/setup/bootstrap.sh
+++ b/setup/bootstrap.sh
@@ -167,24 +167,6 @@ if ! HOMEBREW_NO_AUTO_UPDATE=1 brew bundle --no-upgrade --file="$BREWFILE"; then
 fi
 ok "Abhängigkeiten installiert"
 
-# ------------------------------------------------------------
-# bat Cache aktualisieren (für Catppuccin Mocha Theme)
-# ------------------------------------------------------------
-# Das Theme liegt im Repository unter terminal/.config/bat/themes/
-# und wird via Stow nach ~/.config/bat/themes/ verlinkt.
-# bat benötigt einen Cache-Rebuild um neue Themes zu erkennen.
-CURRENT_STEP="bat-Cache aktualisieren"
-if command -v bat >/dev/null 2>&1; then
-  log "Baue bat-Cache neu (für Catppuccin Theme)"
-  if bat cache --build >/dev/null 2>&1; then
-    ok "bat-Cache aktualisiert"
-  else
-    warn "bat cache --build fehlgeschlagen"
-  fi
-else
-  warn "bat nicht gefunden, überspringe Cache-Build"
-fi
-
 # Font-Installation verifizieren
 font_installed() {
   # Prüfe User- und System-Font-Verzeichnisse (Homebrew installiert nach ~/Library/Fonts)

--- a/terminal/.config/bat/config
+++ b/terminal/.config/bat/config
@@ -10,7 +10,8 @@
 # Farbschema
 # ------------------------------------------------------------
 # Catppuccin Mocha Theme
-# Installation: bootstrap.sh lädt das Theme automatisch herunter
+# Das Theme liegt in terminal/.config/bat/themes/ und wird via Stow verlinkt.
+# Nach dem Stow-Befehl: bat cache --build (registriert das Theme)
 # Verfügbare Themes anzeigen: bat --list-themes | grep -i catppuccin
 --theme="Catppuccin Mocha"
 


### PR DESCRIPTION
## Zusammenfassung

Korrigiert das Timing von `bat cache --build` – der Befehl wurde in `bootstrap.sh` **vor** dem Stow-Schritt ausgeführt, aber das Catppuccin Mocha Theme wird erst **nach** Stow via Symlink verfügbar.

## Änderungen

| Datei | Änderung |
|-------|----------|
| `setup/bootstrap.sh` | `bat cache --build` Block entfernt (18 Zeilen) |
| `docs/installation.md` | `bat cache --build` als Schritt nach Stow hinzugefügt |
| `docs/architecture.md` | Theme-Name korrigiert (`Monokai Extended` → `Catppuccin Mocha`) |
| `terminal/.config/bat/config` | Kommentar korrigiert (Theme nicht von bootstrap.sh geladen) |

## Problem

```
bootstrap.sh:
  └─ brew bundle        → bat installiert
  └─ bat cache --build  → sucht in ~/.config/bat/themes/ → LEER!
  └─ "Nächste Schritte: stow -R terminal"

Manuell:
  └─ stow -R terminal   → ~/.config/bat/themes/ verlinkt
  └─ (bat cache fehlt!) → Theme nicht registriert ❌
```

## Lösung

```
bootstrap.sh:
  └─ brew bundle        → bat installiert
  └─ "Nächste Schritte: stow -R terminal"

installation.md (neu):
  └─ stow -R terminal   → ~/.config/bat/themes/ verlinkt
  └─ bat cache --build  → Theme registriert ✅
```

## Validierung

- ✅ `zsh -n setup/bootstrap.sh` (Syntax OK)
- ✅ `./scripts/validate-docs.sh` (Dokumentation synchron)
- ✅ `./scripts/health-check.sh` (39/39 bestanden)
- ✅ `./scripts/tests/run-tests.sh` (77/77 Tests bestanden)

Fixes #70