### PR TITLE
fix: Dokumentations-Inkonsistenzen korrigiert

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,10 +54,11 @@ Gilt für **jede** Änderung – Features, Bugfixes, Refactoring, Dokumentation:
 ### Catppuccin Mocha – Designrichtlinie
 Catppuccin Mocha ist das **verbindliche Farbschema** für alle Tools:
 - **Terminal.app**: `setup/catppuccin-mocha.terminal`
-- **bat**: Theme in `terminal/.config/bat/themes/` (via Stow, Cache-Build in bootstrap.sh)
+- **bat**: Theme in `terminal/.config/bat/themes/` (via Stow, `bat cache --build` nach Stow)
 - **fzf**: Farben in `terminal/.config/fzf/config`
 - **btop**: Theme in `terminal/.config/btop/themes/` (via Stow)
 - **eza**: Theme in `terminal/.config/eza/theme.yml` (via Stow)
+- **lazygit**: Theme in `terminal/.config/lazygit/config.yml` (via Stow)
 - **zsh-syntax-highlighting**: Theme in `terminal/.config/zsh/` (via Stow)
 - **Starship**: `catppuccin-powerline` Preset
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,23 +49,35 @@ dotfiles/
     ├── .zshrc                   # Interactive Shell Konfiguration
     ├── .zlogin                  # Post-Login (Background-Optimierungen)
     └── .config/
+        ├── alias/               # Tool-Aliase (10 Dateien)
+        │   ├── bat.alias        # bat-Aliase (cat-Ersatz)
+        │   ├── btop.alias       # btop-Aliase (top-Ersatz)
+        │   ├── eza.alias        # eza-Aliase (ls-Ersatz)
+        │   ├── fd.alias         # fd-Aliase (find-Ersatz)
+        │   ├── fzf.alias        # fzf Tool-Kombinationen
+        │   ├── gh.alias         # GitHub CLI Funktionen
+        │   ├── git.alias        # Git-Aliase + lazygit
+        │   ├── help.alias       # Help-System
+        │   ├── homebrew.alias   # Homebrew + mas Aliase
+        │   └── ripgrep.alias    # ripgrep-Aliase (grep-Ersatz)
+        ├── bat/
+        │   ├── config           # bat native Config
+        │   └── themes/          # Catppuccin Mocha Theme
+        ├── btop/
+        │   ├── btop.conf        # btop Konfiguration
+        │   └── themes/          # Catppuccin Mocha Theme
+        ├── eza/
+        │   └── theme.yml        # eza Catppuccin Theme
+        ├── fd/
+        │   └── ignore           # fd globale Ignore-Patterns
         ├── fzf/
         │   └── config           # fzf globale Optionen (FZF_DEFAULT_OPTS_FILE)
-        ├── bat/
-        │   └── config           # bat native Config
         ├── lazygit/
         │   └── config.yml       # lazygit Config mit Catppuccin Mocha
         ├── ripgrep/
         │   └── config           # ripgrep native Config (RIPGREP_CONFIG_PATH)
-        └── alias/
-            ├── homebrew.alias   # Homebrew + mas Aliase
-            ├── eza.alias        # eza-Aliase (ls-Ersatz)
-            ├── bat.alias        # bat-Aliase (cat-Ersatz)
-            ├── ripgrep.alias    # ripgrep-Aliase (grep-Ersatz)
-            ├── fd.alias         # fd-Aliase (find-Ersatz)
-            ├── fzf.alias        # fzf Tool-Kombinationen (20+ Funktionen)
-            ├── git.alias        # Git-Aliase + lazygit
-            └── btop.alias       # btop-Aliase (top-Ersatz)
+        └── zsh/
+            └── catppuccin_mocha-zsh-syntax-highlighting.zsh  # Syntax-Highlighting Theme
 ```
 
 > **Wichtig:** Das Bootstrap-Skript erwartet exakt diese Struktur. Es befindet sich in `setup/` und referenziert das übergeordnete Verzeichnis (`..`) als `DOTFILES_DIR`. Ein Verschieben oder Umbenennen der Ordner führt zu Fehlern.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -139,11 +139,15 @@ Nach erfolgreicher Installation sind folgende Symlinks aktiv:
 | `~/.zprofile` | `terminal/.zprofile` | Login Shell (Homebrew Init) |
 | `~/.zshrc` | `terminal/.zshrc` | Interactive Shell Konfiguration |
 | `~/.zlogin` | `terminal/.zlogin` | Post-Login (Background-Optimierungen) |
-| `~/.config/alias/*.alias` | `terminal/.config/alias/*.alias` | 7 Alias-Dateien (homebrew, eza, bat, ripgrep, fd, fzf, btop) |
-| `~/.config/fzf/config` | `terminal/.config/fzf/config` | fzf globale Optionen |
-| `~/.config/bat/config` | `terminal/.config/bat/config` | bat Theme und Style |
-| `~/.config/ripgrep/config` | `terminal/.config/ripgrep/config` | ripgrep Defaults |
-| `~/.config/fd/ignore` | `terminal/.config/fd/ignore` | fd globale Ignore-Patterns |
+| `~/.config/alias/` | `terminal/.config/alias/` | 10 Alias-Dateien (bat, btop, eza, fd, fzf, gh, git, help, homebrew, ripgrep) |
+| `~/.config/bat/` | `terminal/.config/bat/` | bat Config + Catppuccin Mocha Theme |
+| `~/.config/btop/` | `terminal/.config/btop/` | btop Config + Catppuccin Mocha Theme |
+| `~/.config/eza/` | `terminal/.config/eza/` | eza Catppuccin Theme |
+| `~/.config/fd/` | `terminal/.config/fd/` | fd globale Ignore-Patterns |
+| `~/.config/fzf/` | `terminal/.config/fzf/` | fzf globale Optionen |
+| `~/.config/lazygit/` | `terminal/.config/lazygit/` | lazygit mit Catppuccin Theme |
+| `~/.config/ripgrep/` | `terminal/.config/ripgrep/` | ripgrep Defaults |
+| `~/.config/zsh/` | `terminal/.config/zsh/` | zsh-syntax-highlighting Theme |
 
 ### Symlinks prüfen
 

--- a/scripts/validators/core/symlinks.sh
+++ b/scripts/validators/core/symlinks.sh
@@ -21,12 +21,16 @@ check_symlinks() {
     [[ -f "$terminal_dir/.zprofile" ]] && ((code_count++)) || true
     [[ -f "$terminal_dir/.zlogin" ]] && ((code_count++)) || true
     
-    # Config-Verzeichnisse
+    # Config-Verzeichnisse (alle in terminal/.config/)
     [[ -d "$terminal_dir/.config/alias" ]] && ((code_count++)) || true
-    [[ -d "$terminal_dir/.config/fzf" ]] && ((code_count++)) || true
     [[ -d "$terminal_dir/.config/bat" ]] && ((code_count++)) || true
-    [[ -d "$terminal_dir/.config/ripgrep" ]] && ((code_count++)) || true
+    [[ -d "$terminal_dir/.config/btop" ]] && ((code_count++)) || true
+    [[ -d "$terminal_dir/.config/eza" ]] && ((code_count++)) || true
     [[ -d "$terminal_dir/.config/fd" ]] && ((code_count++)) || true
+    [[ -d "$terminal_dir/.config/fzf" ]] && ((code_count++)) || true
+    [[ -d "$terminal_dir/.config/lazygit" ]] && ((code_count++)) || true
+    [[ -d "$terminal_dir/.config/ripgrep" ]] && ((code_count++)) || true
+    [[ -d "$terminal_dir/.config/zsh" ]] && ((code_count++)) || true
     
     local docs_count
     docs_count=$(sed -n '/## Ergebnis: Symlink/,/^### /p' "$install_doc" | grep -cE "^\| \`~/" 2>/dev/null || echo 0)


### PR DESCRIPTION
## Zusammenfassung

Systematische Korrektur aller Dokumentations-Inkonsistenzen nach Zeile-für-Zeile-Abgleich zwischen Code und Dokumentation.

## Gefundene und behobene Inkonsistenzen

| Datei | Problem | Lösung |
|-------|---------|--------|
| `docs/installation.md` | "7 Alias-Dateien" | → "10 Alias-Dateien" |
| `docs/installation.md` | Symlink-Tabelle unvollständig | + btop, eza, lazygit, zsh |
| `.github/copilot-instructions.md` | "Cache-Build in bootstrap.sh" | → "nach Stow" |
| `.github/copilot-instructions.md` | lazygit fehlte in Catppuccin-Liste | + lazygit |
| `docs/architecture.md` | .config Struktur unvollständig | Alle 9 Verzeichnisse + 10 Alias-Dateien |
| `scripts/validators/core/symlinks.sh` | Nur 5 Config-Dirs geprüft | → 9 Config-Dirs |

## Änderungen

### installation.md
- Alias-Anzahl: 7 → 10
- Symlink-Tabelle: 9 → 13 Kategorien
- Konsolidiert auf Verzeichnis-Ebene (nicht einzelne Dateien)

### architecture.md
- Vollständige .config/ Struktur mit allen 9 Verzeichnissen
- Alle 10 Alias-Dateien alphabetisch aufgelistet
- bat/themes/, btop/, eza/, zsh/ hinzugefügt

### copilot-instructions.md
- bat Cache-Build: "in bootstrap.sh" → "`bat cache --build` nach Stow"
- lazygit zur Catppuccin-Designrichtlinie hinzugefügt

### symlinks.sh (Validator)
- Erweitert um: btop, eza, lazygit, zsh Verzeichnisse
- Prüft jetzt 13 Symlink-Kategorien (4 Shell + 9 Config)

## Validierung

- ✅ `./scripts/validate-docs.sh` (Dokumentation synchron)
- ✅ `./scripts/health-check.sh` (39/39 bestanden)
- ✅ `./scripts/tests/run-tests.sh` (77/77 Tests bestanden)