### PR TITLE
docs(README): bat cache --build zum Quickstart hinzufügen

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,30 +29,30 @@ Nach Schritt 3 wird bei jedem Commit automatisch geprüft, ob Dokumentation und 
 
 ```
 dotfiles/
-├── .githooks/              # Git Hooks (versioniert)
-│   └── pre-commit          # Syntax + Docs-Validierung vor Commit
-├── scripts/                # Utility-Scripts (nicht Setup)
-│   ├── health-check.sh     # Installation validieren
-│   ├── validate-docs.sh    # Docs-Code-Synchronisation prüfen
-│   ├── validators/         # Modulare Validierungs-Komponenten
-│   │   ├── lib.sh          # Shared Library
-│   │   ├── core/           # 8 Kern-Validierungen
-│   │   └── extended/       # 4 erweiterte Prüfungen
-│   └── tests/              # Unit-Tests für Validatoren
-│       ├── run-tests.sh    # Test-Runner
-│       ├── test_lib.sh     # Tests für lib.sh
-│       └── test_validators.sh # Integration-Tests
-├── setup/                  # Bootstrap & Installation
-│   ├── bootstrap.sh        # Hauptskript
-│   ├── Brewfile            # Homebrew-Abhängigkeiten
-│   └── catppuccin-mocha.terminal  # Terminal.app Profil
-├── terminal/               # Dotfiles (werden nach ~ verlinkt)
+├── .githooks/                      # Git Hooks (versioniert)
+│   └── pre-commit                  # Syntax + Docs-Validierung vor Commit
+├── scripts/                        # Utility-Scripts (nicht Setup)
+│   ├── health-check.sh             # Installation validieren
+│   ├── validate-docs.sh            # Docs-Code-Synchronisation prüfen
+│   ├── validators/                 # Modulare Validierungs-Komponenten
+│   │   ├── lib.sh                  # Shared Library
+│   │   ├── core/                   # 8 Kern-Validierungen
+│   │   └── extended/               # 4 erweiterte Prüfungen
+│   └── tests/                      # Unit-Tests für Validatoren
+│       ├── run-tests.sh            # Test-Runner
+│       ├── test_lib.sh             # Tests für lib.sh
+│       └── test_validators.sh      # Integration-Tests
+├── setup/                          # Bootstrap & Installation
+│   ├── bootstrap.sh                # Hauptskript
+│   ├── Brewfile                    # Homebrew-Abhängigkeiten
+│   └── catppuccin-mocha.terminal   # Terminal.app Profil
+├── terminal/                       # Dotfiles (werden nach ~ verlinkt)
 │   ├── .zlogin
 │   ├── .zprofile
 │   ├── .zshenv
 │   ├── .zshrc
 │   └── .config/
-└── docs/                   # Dokumentation
+└── docs/                           # Dokumentation
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ curl -fsSL https://github.com/tshofmann/dotfiles/archive/refs/heads/main.tar.gz 
 Nach Terminal-Neustart:
 
 ```zsh
-cd ~/dotfiles && stow --adopt -R terminal && git reset --hard HEAD
+cd ~/dotfiles && stow --adopt -R terminal && git reset --hard HEAD && bat cache --build
 ```
 
 > ⚠️ **Achtung:** `git reset --hard` verwirft lokale Änderungen. Siehe [Installation](docs/installation.md) für Details.


### PR DESCRIPTION
## Problem

Nach PR #71 wurde `bat cache --build` aus dem bootstrap.sh entfernt, da der Befehl vor `stow` ausgeführt wurde und das Catppuccin Theme noch nicht verlinkt war.

Der README Quickstart wurde jedoch nicht aktualisiert.

## Lösung

`bat cache --build` zum Quickstart-Befehl hinzugefügt:

```zsh
cd ~/dotfiles && stow --adopt -R terminal && git reset --hard HEAD && bat cache --build
```

Damit ist der Quickstart wieder vollständig und das Catppuccin Theme für bat funktioniert sofort.