### PR TITLE
feat(tealdeer): Config erweitern – Sprache, Titel, Update-Intervall

### DIFF
--- a/terminal/.config/tealdeer/config.toml
+++ b/terminal/.config/tealdeer/config.toml
@@ -16,6 +16,16 @@ compact = false
 # Pager für lange Ausgaben verwenden
 use_pager = false
 
+# Befehlsname oben anzeigen
+show_title = true
+
+# ------------------------------------------------------------
+# Suche
+# ------------------------------------------------------------
+[search]
+# Deutsche Seiten priorisieren, Fallback auf Englisch
+languages = ["de", "en"]
+
 # ------------------------------------------------------------
 # Catppuccin Mocha Theme
 # ------------------------------------------------------------
@@ -50,3 +60,9 @@ italic = true
 [updates]
 # Cache automatisch aktualisieren wenn veraltet
 auto_update = true
+
+# Update-Intervall: wöchentlich (Default: 720h = 30 Tage)
+auto_update_interval_hours = 168
+
+# Gleiche Sprachen wie bei Suche herunterladen
+download_languages = ["de", "en"]


### PR DESCRIPTION
## Beschreibung

Erweitert die tealdeer-Konfiguration um die in #92 besprochenen Optionen.

## Änderungen

| Option | Wert | Begründung |
|--------|------|------------|
| `show_title` | `true` | Befehlsname oben anzeigen |
| `languages` | `["de", "en"]` | Deutsche Seiten priorisieren |
| `auto_update_interval_hours` | `168` | Wöchentlich statt 30 Tage |
| `download_languages` | `["de", "en"]` | Beide Sprachen herunterladen |

## Validierung

```zsh
tldr tar
```
Zeigt jetzt deutsche Seite mit Titel:
```
  tar

  Archivierungstool.
  ...
```

Closes #92