### PR TITLE
📝 Doku: Regel für persönliche Daten in öffentlichen Inhalten

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,6 +11,7 @@ Diese Regeln gelten **immer** – keine Ausnahmen:
 | **Niemals `--no-verify`** | Pre-Commit Hooks müssen durchlaufen |
 | **Niemals Annahmen treffen** | Im Terminal verifizieren, nicht vermuten |
 | **Niemals statische Zahlen in Docs** | Veralten sofort – dynamische Verweise nutzen |
+| **Niemals persönliche Daten in Issues/PRs** | Öffentlich sichtbar – `~` oder `$HOME` statt `/Users/<name>` |
 
 ### Arbeitsweise (Grundprinzip)
 


### PR DESCRIPTION
## Änderung

Neue kritische Regel in den Copilot Instructions:

> **Niemals persönliche Daten in Issues/PRs** | Öffentlich sichtbar – `~` oder `$HOME` statt `/Users/<name>`

## Hintergrund

In Issue #93 waren Kommentare mit absoluten Pfaden inkl. Benutzername öffentlich sichtbar. Diese wurden gelöscht und durch anonymisierte Versionen ersetzt.

## Betroffene Dateien

- `.github/copilot-instructions.md`: Neue Zeile in der kritischen Regeln-Tabelle

## Checklist

- [x] Regel formuliert
- [x] Alte Kommentare in Issue #93 gelöscht
- [x] Neuer anonymisierter Kommentar in Issue #93 erstellt
- [x] Pre-commit Hooks bestanden