### PR TITLE
feat(tealdeer): Custom Pages Verzeichnis konfigurieren

### DIFF
--- a/terminal/.config/tealdeer/config.toml
+++ b/terminal/.config/tealdeer/config.toml
@@ -55,6 +55,14 @@ foreground = { rgb = { r = 203, g = 166, b = 247 } }  # #CBA6F7 Mauve
 italic = true
 
 # ------------------------------------------------------------
+# Verzeichnisse
+# ------------------------------------------------------------
+[directories]
+# Custom Pages relativ zur Config-Datei
+# Siehe: https://github.com/tealdeer-rs/tealdeer/pull/395
+custom_pages_dir = "./pages"
+
+# ------------------------------------------------------------
 # Updates
 # ------------------------------------------------------------
 [updates]

--- a/terminal/.config/tealdeer/pages/.gitkeep
+++ b/terminal/.config/tealdeer/pages/.gitkeep
@@ -1,0 +1,1 @@
+# Platzhalter für Custom Pages


### PR DESCRIPTION
## Änderung

Konfiguriert das Custom Pages Verzeichnis für tealdeer mit relativen Pfaden.

## Neue Config

```toml
[directories]
custom_pages_dir = "./pages"
```

## Hintergrund

- tealdeer v1.8.0 (PR [#395](https://github.com/tealdeer-rs/tealdeer/pull/395)) ermöglicht relative Pfade
- `./pages` wird relativ zur Config-Datei aufgelöst
- Dadurch portabel und Stow-kompatibel

## Dateien

| Datei | Änderung |
|-------|----------|
| `config.toml` | `[directories]` Sektion hinzugefügt |
| `pages/.gitkeep` | Leeres Verzeichnis für Custom Pages |

## Nächste Schritte

Issue #93 bleibt offen für das tatsächliche Erstellen der Custom Pages (z.B. `brewup.page.md`, `help.page.md`).

Ref: #93