### PR TITLE
fix: Copilot Review-Feedback aus PRs #88 und #96

### DIFF
--- a/terminal/.config/alias/git.alias
+++ b/terminal/.config/alias/git.alias
@@ -105,7 +105,7 @@ if command -v fzf >/dev/null 2>&1; then
         local stash
         stash=$(git stash list | \
             fzf --ansi \
-                --preview 'echo {} | cut -d: -f1 | xargs git stash show -p | bat --style=numbers --color=always -l diff 2>/dev/null || echo {} | cut -d: -f1 | xargs git stash show -p' \
+                --preview 'echo {} | cut -d: -f1 | xargs git stash show -p | { bat --style=numbers --color=always -l diff 2>/dev/null || cat; }' \
                 --header='Enter: Apply | Ctrl+P: Pop | Ctrl+D: Drop' \
                 --bind 'ctrl-d:execute(echo {} | cut -d: -f1 | xargs git stash drop)+reload(git stash list)' \
                 --bind 'ctrl-p:execute(echo {} | cut -d: -f1 | xargs git stash pop)+abort' | \

--- a/terminal/.config/tealdeer/config.toml
+++ b/terminal/.config/tealdeer/config.toml
@@ -30,7 +30,7 @@ languages = ["de", "en"]
 # Catppuccin Mocha Theme
 # ------------------------------------------------------------
 # Farben: https://catppuccin.com/palette
-# tealdeer unterstützt RGB-Werte seit v1.5.0
+# RGB-Werte via TOML-Syntax (r, g, b)
 
 # Beschreibungstext (Subtext0 für subtilen Look)
 [style.description]


### PR DESCRIPTION
## Beschreibung

Umsetzung von übersehenen Copilot Review-Kommentaren aus geschlossenen PRs.

## Änderungen

| Datei | Änderung | Quelle |
|-------|----------|--------|
| `git.alias` | `gstash` Preview-Redundanz behoben | PR #88 |
| `config.toml` | Statische Versionsangabe entfernt | PR #96 |

### 1. `gstash` Preview optimiert

**Vorher** (redundant – gesamte Pipe dupliziert):
```zsh
--preview '... | xargs git stash show -p | bat ... || ... | xargs git stash show -p'
```

**Nachher** (Pattern wie `rgf`):
```zsh
--preview '... | xargs git stash show -p | { bat ... || cat; }'
```

### 2. Statische Version entfernt

**Vorher**:
```toml
# tealdeer unterstützt RGB-Werte seit v1.5.0
```

**Nachher** (Guidelines-konform):
```toml
# RGB-Werte via TOML-Syntax (r, g, b)
```

## Analyse

Aus den letzten 7 closed PRs wurden alle Copilot-Kommentare geprüft:

| Vorschlag | Mehrwert | Status |
|-----------|----------|--------|
| `gstash` Preview | 🟡 Mittel | ✅ Umgesetzt |
| Statische Version | 🟢 Gering | ✅ Umgesetzt |
| `.zshenv` Kommentar erweitern | 🔴 Keiner | ❌ Verworfen (technisch ungenau) |
| `structure.sh` Kommentar | 🔴 Keiner | ❌ Verworfen (funktioniert korrekt) |
| `copilot-instructions.md` | 🔴 Keiner | ❌ Verworfen (DRY-Prinzip) |

## Validierung

- [x] Shell-Syntax (`zsh -n`)
- [x] `validate-docs.sh` bestanden
- [x] Pre-commit Hooks bestanden