### PR TITLE
fix(docs): claude-code dokumentieren und Validator dynamisieren

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -118,6 +118,15 @@ Diese Tools werden via Brewfile installiert:
 | **zsh-autosuggestions** | History-basierte Befehlsvorschläge beim Tippen | [github.com/zsh-users/zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) |
 | **zsh-syntax-highlighting** | Echtzeit Syntax-Highlighting für Kommandos | [github.com/zsh-users/zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting) |
 
+### Casks (Fonts & Tools)
+
+Diese Pakete werden via `brew install --cask` installiert:
+
+| App | Beschreibung | Dokumentation |
+|-----|--------------|---------------|
+| **claude-code** | Terminal-basierter KI-Coding-Assistent von Anthropic | [github.com/anthropics/claude-code](https://github.com/anthropics/claude-code) |
+| **font-meslo-lg-nerd-font** | Nerd Font für Terminal-Icons und Powerline-Symbole | [github.com/ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts) |
+
 ### Mac App Store Apps
 
 Diese Apps werden via `mas` installiert (Benutzer muss im App Store angemeldet sein):


### PR DESCRIPTION
## Problemstellung

Das Tool `claude-code` war im Brewfile und in `architecture.md` enthalten, fehlte aber in `docs/tools.md`. Der Validator hat dies nicht erkannt, da er nur eine statische Tool-Liste prüfte.

## Umsetzung

### Dokumentation
- Neuer Abschnitt **"Casks (Fonts & Tools)"** in `tools.md` (zwischen ZSH-Plugins und Mac App Store Apps)
- `claude-code` und `font-meslo-lg-nerd-font` dokumentiert

### Validator
- `brewfile.sh`: Statische Liste durch dynamische Extraktion ersetzt
- Neue Hilfsfunktion `_extract_brewfile_names()` extrahiert alle Einträge aus Brewfile
- Prüft jetzt **alle** `brew`, `cask` und `mas` Einträge gegen `tools.md`
- Fehlerausgabe mit Typ-Prefix: `brew:name`, `cask:name`, `mas:name`

## Zukunftssicherheit

Der Validator erkennt automatisch wenn neue Pakete zum Brewfile hinzugefügt werden und die Dokumentation nicht nachgezogen wurde.

## Scope

| Kriterium | Bewertung |
|-----------|-----------|
| Komplexität | 🟢 Gering |
| Wartungsaufwand | 🟢 Minimal |
| Testbarkeit | 🟢 Automatisiert |
| Abhängigkeiten | 🟢 Keine |
| Breaking Risk | 🟢 Keins |

Closes #102