### PR TITLE
style: Header-Konsistenz für alle Config-Dateien

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,9 +204,11 @@ Einige Dateien folgen **nicht** dem Standard-Header-Format:
 
 | Datei | Grund |
 |-------|-------|
-| `eza/theme.yml` | Reines YAML-Datenformat – kein Kommentar-Header möglich |
-| `btop/btop.conf` | Natives btop-Format mit `#?`-Kommentaren |
-| `zsh/catppuccin_mocha-zsh-syntax-highlighting.zsh` | Third-Party Theme – nicht modifizieren |
+| `btop/btop.conf` | Wird von btop generiert – `btop --write-config` überschreibt Änderungen |
+| `btop/themes/*.theme` | Third-Party Theme (Catppuccin) – bei Updates überschrieben |
+| `bat/themes/*.tmTheme` | Third-Party Theme (Catppuccin) – bei Updates überschrieben |
+| `zsh/catppuccin_*.zsh` | Third-Party Theme (Catppuccin) – bei Updates überschrieben |
+| `tealdeer/pages/*.patch.md` | Markdown-Format für tldr-Patches – eigenes Schema |
 
 Diese Dateien werden vom `style-consistency` Validator ignoriert.
 

--- a/terminal/.config/eza/theme.yml
+++ b/terminal/.config/eza/theme.yml
@@ -1,3 +1,14 @@
+# ============================================================
+# theme.yml - eza Farbschema (Catppuccin Mocha)
+# ============================================================
+# Zweck   : Dateityp-Farben für eza (ls-Ersatz)
+# Pfad    : ~/.config/eza/theme.yml
+# Docs    : https://github.com/eza-community/eza/blob/main/man/eza_colors.5.md
+# ============================================================
+# Hinweis : EZA_CONFIG_DIR wird in .zshenv gesetzt.
+#           Farben basieren auf Catppuccin Mocha Palette.
+# ============================================================
+
 colourful: true
 
 filekinds:

--- a/terminal/.config/fd/ignore
+++ b/terminal/.config/fd/ignore
@@ -1,10 +1,11 @@
 # ============================================================
-# fd Global Ignore Patterns
+# ignore - fd Global Ignore Patterns
 # ============================================================
 # Zweck   : Globale Ausschlüsse für fd (auch bei --hidden)
 # Pfad    : ~/.config/fd/ignore
 # Docs    : https://github.com/sharkdp/fd#excluding-specific-files-or-directories
-# Tipp    : "fd -u" ignoriert diese Datei (unrestricted mode)
+# ============================================================
+# Hinweis : "fd -u" ignoriert diese Datei (unrestricted mode)
 # ============================================================
 
 # Git internals (bei --hidden nicht durchsuchen)

--- a/terminal/.config/fzf/init.zsh
+++ b/terminal/.config/fzf/init.zsh
@@ -1,14 +1,12 @@
 # ============================================================
-# fzf - Shell-Integration
+# init.zsh - fzf Shell-Integration
 # ============================================================
 # Zweck   : fzf Keybindings und fd-Backend aktivieren
-# Laden   : Via .zshrc
+# Pfad    : ~/.config/fzf/init.zsh
 # Docs    : https://github.com/junegunn/fzf#usage
 # ============================================================
-# Keybindings:
-#   Ctrl+R = History durchsuchen (Ctrl+Y kopiert)
-#   Ctrl+T = Datei suchen
-#   Alt+C  = Verzeichnis wechseln
+# Hinweis : Wird via .zshrc geladen. Keybindings:
+#           Ctrl+R = History, Ctrl+T = Datei, Alt+C = Verzeichnis
 # ============================================================
 
 # Shell-Integration aktivieren

--- a/terminal/.config/lazygit/config.yml
+++ b/terminal/.config/lazygit/config.yml
@@ -1,11 +1,11 @@
 # ============================================================
-# lazygit Config - Terminal-UI für Git
+# config.yml - lazygit Terminal-UI für Git
 # ============================================================
 # Zweck   : lazygit Konfiguration mit Catppuccin Mocha Theme
 # Pfad    : ~/.config/lazygit/config.yml
 # Docs    : https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md
 # ============================================================
-# Theme   : Catppuccin Mocha (Mauve Akzent)
+# Hinweis : Theme: Catppuccin Mocha (Mauve Akzent)
 #           https://github.com/catppuccin/lazygit
 # ============================================================
 

--- a/terminal/.config/shell-colors
+++ b/terminal/.config/shell-colors
@@ -3,7 +3,7 @@
 # ============================================================
 # Zweck   : Zentrale ANSI-Farbvariablen für Shell-Funktionen
 # Pfad    : ~/.config/shell-colors
-# Palette : https://catppuccin.com/palette
+# Docs    : https://catppuccin.com/palette
 # ============================================================
 
 # True Color (24-bit) – Format: \033[38;2;R;G;Bm


### PR DESCRIPTION
## Zusammenfassung

Einheitliche Header-Blöcke für alle eigenen Config-Dateien nach dem Standard aus CONTRIBUTING.md.

## Änderungen

| Datei | Änderung |
|-------|----------|
| `shell-colors` | `Palette` → `Docs` für einheitliche Pflichtfelder |
| `eza/theme.yml` | Header-Block hinzugefügt (YAML unterstützt `#` Kommentare) |
| `fzf/init.zsh` | `Laden` → `Pfad` + `Hinweis`, Dateiname in Titel |
| `fd/ignore` | `Tipp` → `Hinweis`, Dateiname in Titel |
| `lazygit/config.yml` | `Theme` → `Hinweis`, Dateiname in Titel |
| `CONTRIBUTING.md` | Ausnahmen-Tabelle aktualisiert |

## Header-Standard (Pflichtfelder)

Alle eigenen Config-Dateien haben jetzt:
- ✅ `# Zweck   :` (Pflicht)
- ✅ `# Pfad    :` (Pflicht)
- ✅ `# Docs    :` (Pflicht)
- ✅ `# Hinweis :` (Optional, wo sinnvoll)

## Echte Ausnahmen (Third-Party)

Diese Dateien werden nicht modifiziert, da sie bei Updates überschrieben würden:
- `btop/btop.conf` – von btop generiert
- `btop/themes/*.theme` – Catppuccin Third-Party
- `bat/themes/*.tmTheme` – Catppuccin Third-Party
- `zsh/catppuccin_*.zsh` – Catppuccin Third-Party
- `tealdeer/pages/*.patch.md` – eigenes Markdown-Schema

## Validierung

- ✅ Alle Docs-Links erreichbar (HTTP 200)
- ✅ Alle Pfade existieren als Symlinks
- ✅ Pfad-Header stimmen mit Dateipfaden überein
- ✅ `./scripts/validate-docs.sh --all` bestanden