### PR TITLE
style: Redundantes 'Theme:' im Hinweis-Feld entfernt

### DIFF
--- a/terminal/.config/lazygit/config.yml
+++ b/terminal/.config/lazygit/config.yml
@@ -5,7 +5,7 @@
 # Pfad    : ~/.config/lazygit/config.yml
 # Docs    : https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md
 # ============================================================
-# Hinweis : Theme: Catppuccin Mocha (Mauve Akzent)
+# Hinweis : Catppuccin Mocha Theme (Mauve Akzent)
 #           https://github.com/catppuccin/lazygit
 # ============================================================
 


### PR DESCRIPTION
Umsetzung des Copilot-Review-Kommentars aus PR #105.

## Änderung

```diff
-# Hinweis : Theme: Catppuccin Mocha (Mauve Akzent)
+# Hinweis : Catppuccin Mocha Theme (Mauve Akzent)
```

Redundantes `Theme:` im Hinweis-Feld entfernt für konsistentere Formatierung mit anderen Config-Dateien.