### PR TITLE
fix(validator): Erlaube Bindestriche in Funktionsnamen

### DIFF
--- a/scripts/validators/lib.sh
+++ b/scripts/validators/lib.sh
@@ -67,7 +67,7 @@ extract_aliases_from_file() {
 # Extrahiere Funktionsnamen aus einer Datei
 extract_functions_from_file() {
     local file="$1"
-    grep -oE "^[[:space:]]*[a-z][a-z0-9_]*\(\)[[:space:]]*\{" "$file" 2>/dev/null | \
+    grep -oE "^[[:space:]]*[a-z][a-z0-9_-]*\(\)[[:space:]]*\{" "$file" 2>/dev/null | \
         sed 's/().*//' | sed 's/^[[:space:]]*//' | sort -u
 }
 


### PR DESCRIPTION
## Problem

Der Validator `extract_functions_from_file()` in `lib.sh` erkannte Funktionsnamen mit Bindestrichen nicht.

**Betroffen:** `bat-preview()` wurde nicht als definierte Funktion erkannt, obwohl sie in `bat.alias` existiert.

## Ursache

Der Regex `[a-z][a-z0-9_]*` erlaubte keine Bindestriche im Funktionsnamen.

## Fix

```diff
- grep -oE "^[[:space:]]*[a-z][a-z0-9_]*\(\)"
+ grep -oE "^[[:space:]]*[a-z][a-z0-9_-]*\(\)"
```

## Validierung

Nach dem Fix: ✅ Alle 18 Validatoren bestanden.