### PR TITLE
docs: fenv-reload in architecture.md Verzeichnisstruktur ergänzt

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,6 +80,7 @@ dotfiles/
         │   └── ignore           # fd globale Ignore-Patterns
         ├── fzf/
         │   ├── config           # fzf globale Optionen (FZF_DEFAULT_OPTS_FILE)
+        │   ├── fenv-reload      # Helper-Skript für fenv() Ctrl+S Toggle
         │   └── init.zsh         # fzf Shell-Integration (Keybindings, fd-Backend)
         ├── lazygit/
         │   └── config.yml       # lazygit Config mit Catppuccin Mocha


### PR DESCRIPTION
## Problemstellung

Bei einem manuellen Repository-Review wurde festgestellt, dass die Datei `terminal/.config/fzf/fenv-reload` in der Verzeichnisstruktur-Dokumentation fehlte.

**Health-Check Fehler vor dem Fix:**
```
✖ ~/.config/fzf/fenv-reload → fehlt
```

## Recherche

Die Datei `fenv-reload` ist ein Helper-Skript für die `fenv()` Funktion in `fzf.alias`. Sie wird für den `Ctrl+S` Toggle benötigt, der zwischen gefilterten und allen Umgebungsvariablen umschaltet.

**Warum ausgelagert:** Komplexes Shell-Escaping in `fzf --bind` Befehlen – ausgelagerte Skripte sind wartbarer.

## Umsetzung

- [x] `fenv-reload` in `docs/architecture.md` Verzeichnisstruktur ergänzt
- [x] `stow -R terminal` ausgeführt (Symlink erstellt)
- [x] Health-Check: 52/52 bestanden
- [x] Alle Validatoren: ✅ bestanden

## Scope

| Kriterium | Bewertung |
|-----------|-----------|
| Komplexität | 🟢 Gering |
| Wartungsaufwand | 🟢 Minimal |
| Testbarkeit | 🟢 Automatisiert (structure.sh Validator) |
| Abhängigkeiten | 🟢 Keine |
| Breaking Risk | 🟢 Keins |

## Verwandte Issues

- Gefunden während Repository-Review (kein Issue vorhanden)
