### PR TITLE
feat(fzf): --freeze-left für glog, rgf, fkill

### DIFF
--- a/terminal/.config/alias/fzf.alias
+++ b/terminal/.config/alias/fzf.alias
@@ -60,13 +60,14 @@ fi
 # KILL + FZF: Prozess-Management
 # ------------------------------------------------------------
 # Prozesse interaktiv suchen und beenden (Tab für Mehrfachauswahl)
-# Ctrl+S: Toggle Apps ↔ Alle Prozesse
+# Ctrl+S: Toggle Apps ↔ Alle Prozesse (PID bleibt beim Scrollen sichtbar)
 fkill() {
     local pid
     local helper="${XDG_CONFIG_HOME:-$HOME/.config}/fzf/fkill-list"
     
     pid=$("$helper" apps | \
         fzf -m \
+            --freeze-left=1 \
             --prompt='Apps> ' \
             --header='Enter: Beenden | Tab: Mehrfach | Ctrl+S: Apps/Alle' \
             --bind "ctrl-s:transform:[[ \$FZF_PROMPT == 'Apps> ' ]] && echo 'reload($helper all)+change-prompt(Alle> )' || echo 'reload($helper apps)+change-prompt(Apps> )'" | \

--- a/terminal/.config/alias/git.alias
+++ b/terminal/.config/alias/git.alias
@@ -48,11 +48,12 @@ alias gd='git diff'
 # Interaktive Funktionen (mit fzf)
 # ------------------------------------------------------------
 if command -v fzf >/dev/null 2>&1; then
-    # Git Log mit Commit-Vorschau
+    # Git Log mit Commit-Vorschau (SHA bleibt beim Scrollen sichtbar)
     glog() {
         local sha
         sha=$(git log --oneline --color=always --decorate | \
             fzf --ansi --no-sort --reverse \
+                --freeze-left=1 \
                 --preview 'git show --color=always {1} | bat --style=numbers --color=always -l diff 2>/dev/null || git show --color=always {1}' \
                 --header='Enter: Anzeigen | Ctrl+Y: SHA kopieren' \
                 --bind 'ctrl-y:execute-silent(echo -n {1} | pbcopy)+abort' | \

--- a/terminal/.config/alias/rg.alias
+++ b/terminal/.config/alias/rg.alias
@@ -62,7 +62,7 @@ alias rggo='rg -t go'
 # ------------------------------------------------------------
 # Interaktive Suche (mit fzf)
 # ------------------------------------------------------------
-# rgf: Live-Grep mit fzf + bat Vorschau
+# rgf: Live-Grep mit fzf + bat Vorschau (Datei:Zeile bleibt beim Scrollen sichtbar)
 # Verwendung: rgf [initiale-suche]
 if command -v fzf >/dev/null 2>&1; then
     rgf() {
@@ -73,6 +73,7 @@ if command -v fzf >/dev/null 2>&1; then
             --bind "start:reload:$rg_prefix {q} || true" \
             --bind "change:reload:sleep 0.1; $rg_prefix {q} || true" \
             --delimiter : \
+            --freeze-left=1 \
             --preview "$preview_cmd" \
             --preview-window 'up,60%,border-bottom,+{2}+3/3,~3' \
             --header='Enter: Datei öffnen | Ctrl+Y: Pfad kopieren' \


### PR DESCRIPTION
## Änderung

Nutzt das neue `--freeze-left` Feature von fzf 0.67.0, um wichtige Identifier beim horizontalen Scrollen sichtbar zu halten.

## Betroffene Funktionen

| Funktion | Datei | Freeze-Feld |
|----------|-------|-------------|
| `glog` | `git.alias` | SHA (1. Feld) |
| `rgf` | `rg.alias` | Datei:Zeile (1. Feld) |
| `fkill` | `fzf.alias` | PID (1. Feld) |

## UX-Verbesserung

Wenn eine Zeile breiter als das Terminal ist und fzf zum Match scrollt, bleibt das erste Feld (SHA, Datei:Zeile, PID) links fixiert sichtbar.

## Voraussetzung

- fzf ≥ 0.67.0 (bereits via Homebrew installiert)

Closes #119