### PR TITLE
refactor(fzf): Keybindings auf Ctrl+X Prefix umstellen

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -366,7 +366,6 @@ fzf ist als "Enhancer" in die jeweiligen Tool-Alias-Dateien integriert. Diese Da
 | `fkill` | **Fuzzy Kill**: Prozesse beenden. Enter=Beenden, Tab=Mehrfach, Ctrl+S=Apps/Alle. Optional: `fkill 9` für SIGKILL |
 | `fman` | **Fuzzy Man**: Man-Pages mit bat-Vorschau. Enter=Öffnen, Ctrl+S=man↔tldr |
 | `fenv` | **Fuzzy Env**: Umgebungsvariablen durchsuchen mit Farbkodierung. Enter=Export→Edit, Ctrl+Y=Wert kopieren |
-| `fhist` | **Fuzzy History**: Shell-History, Enter=Edit-Buffer (editierbar), Ctrl+Y=Kopieren |
 
 **Tool-spezifische fzf-Funktionen:**
 
@@ -377,6 +376,16 @@ Die folgenden Funktionen nutzen fzf, sind aber nach ihrem primären Zweck in den
 - **git.alias**: `glog`, `gbr`, `gst`, `gstash`
 - **brew.alias**: `bip`, `brp`, `brewv`
 - **gh.alias**: `ghpr`, `ghis`, `ghrun`, `ghrepo`, `ghgist`
+
+**Shell-Keybindings (Ctrl+X Prefix):**
+
+Diese Keybindings werden global in `~/.config/fzf/init.zsh` konfiguriert:
+
+| Keybinding | Beschreibung |
+|------------|--------------|
+| `Ctrl+X 1` | **History-Suche**: Shell-History mit fzf, Enter=Edit-Buffer, Ctrl+Y=Kopieren |
+| `Ctrl+X 2` | **Datei-Suche**: Dateien mit bat-Vorschau, Enter=Pfad einfügen |
+| `Ctrl+X 3` | **Verzeichnis-Wechsel**: Verzeichnisse mit eza-Vorschau, Enter=Wechseln |
 
 > **Design-Prinzip:** Aliase werden nach ihrem primären Zweck organisiert, nicht nach den verwendeten Tools. `rgf` nutzt fzf+bat, ist aber primär eine Suche – daher in `rg.alias`.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -371,7 +371,7 @@ exec zsh
 | `ghpr`, `ghis`, `ghrun`, `ghrepo` | fzf, gh |
 | `glog`, `gbr`, `gst`, `gstash` | fzf, git, bat |
 | `bip`, `bup`, `brp`, `bsp` | fzf, brew |
-| `fkill`, `fman`, `fenv`, `fhist` | fzf |
+| `fkill`, `fman`, `fenv` | fzf |
 
 ---
 

--- a/terminal/.config/alias/fzf.alias
+++ b/terminal/.config/alias/fzf.alias
@@ -255,19 +255,3 @@ fenv() {
     fi
 }
 
-# ------------------------------------------------------------
-# HISTORY + FZF: Erweiterte History-Suche
-# ------------------------------------------------------------
-# Befehlshistorie durchsuchen und ins Edit-Buffer laden
-# Community-Pattern: print -z statt eval → Befehl editierbar vor Ausführung
-fhist() {
-    local cmd
-    cmd=$(fc -l 1 | fzf --tac --no-sort -n2.. \
-        --header='Enter: Befehl übernehmen | Ctrl+Y: Befehl kopieren' \
-        --bind 'ctrl-y:execute-silent(echo {2..} | pbcopy)+abort' | \
-        awk '{$1=""; print substr($0,2)}')
-    
-    # print -z: Befehl erscheint in Kommandozeile, editierbar vor Enter
-    [[ -n "$cmd" ]] && print -z "$cmd"
-}
-

--- a/terminal/.config/fzf/init.zsh
+++ b/terminal/.config/fzf/init.zsh
@@ -6,11 +6,18 @@
 # Docs    : https://github.com/junegunn/fzf#usage
 # ============================================================
 # Hinweis : Wird via .zshrc geladen. Keybindings:
-#           Ctrl+R = History, Ctrl+T = Datei, Alt+C = Verzeichnis
+#           Ctrl+X 1 = History, Ctrl+X 2 = Datei, Ctrl+X 3 = Verzeichnis
 # ============================================================
 
 # Shell-Integration aktivieren
 source <(fzf --zsh)
+
+# Keybindings umlegen auf Ctrl+X Prefix (Alt+C funktioniert nicht ohne Meta-Taste)
+bindkey -r '^R'                          # Standard-Binding entfernen
+bindkey -r '^T'                          # Standard-Binding entfernen
+bindkey '^X1' fzf-history-widget         # Ctrl+X 1 = History
+bindkey '^X2' fzf-file-widget            # Ctrl+X 2 = Dateien
+bindkey '^X3' fzf-cd-widget              # Ctrl+X 3 = Verzeichnisse
 
 # fd als Backend (schneller als find, respektiert .gitignore)
 if command -v fd >/dev/null 2>&1; then

--- a/terminal/.config/tealdeer/pages/fzf.patch.md
+++ b/terminal/.config/tealdeer/pages/fzf.patch.md
@@ -34,9 +34,19 @@
 
 `fenv`
 
-- dotfiles: Historie durchsuchen, ins Edit-Buffer laden (`<Enter>` Ins Edit-Buffer, `<Ctrl y>` Kopieren):
+# dotfiles: Shell-Keybindings (Ctrl+X Prefix)
 
-`fhist`
+- dotfiles: Historie durchsuchen (`<Enter>` Ins Edit-Buffer, `<Ctrl y>` Kopieren):
+
+`<Ctrl x> 1`
+
+- dotfiles: Datei suchen (`<Enter>` Pfad einfügen, bat-Vorschau):
+
+`<Ctrl x> 2`
+
+- dotfiles: Verzeichnis wechseln (`<Enter>` Wechseln, eza-Vorschau):
+
+`<Ctrl x> 3`
 
 # dotfiles: Tool-spezifische fzf-Funktionen
 


### PR DESCRIPTION
## Änderungen

- Shell-Keybindings von `Ctrl+R/T`, `Alt+C` auf `Ctrl+X 1/2/3` geändert
- `Alt+C` funktioniert nicht ohne Meta-Taste im macOS Terminal
- `fhist` Funktion entfernt (redundant mit `Ctrl+X 1`)
- Dokumentation aktualisiert

## Neue Keybindings

| Keybinding | Funktion |
|------------|----------|
| `Ctrl+X 1` | History-Suche |
| `Ctrl+X 2` | Datei-Suche |
| `Ctrl+X 3` | Verzeichnis-Wechsel |

## Validierung

- ✅ Alle Keybindings manuell getestet
- ✅ Pre-Commit Hooks durchlaufen

Closes #114