### PR TITLE
docs(copilot): GitHub PR Review-Workflow dokumentiert

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -98,6 +98,22 @@ alias x='command'
 
 ---
 
+## GitHub PRs
+
+| Regel | Begründung |
+|-------|------------|
+| **Review-Threads einzeln beantworten** | Erklärung im Thread dokumentiert, nicht nur global |
+| **Dann erst resolven** | Thread-Historie bleibt nachvollziehbar |
+| **Alle Kommentare prüfen** | `get_review_comments` nicht nur `get_reviews` |
+| **Outdated ≠ Resolved** | Auch veraltete Threads explizit auflösen |
+
+```zsh
+# Review-Threads auflösen via gh CLI:
+gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "PRRT_..."}) { thread { isResolved } } }'
+```
+
+---
+
 ## Verweise
 
 | Thema | Datei |


### PR DESCRIPTION
## Änderung

Fügt Regeln für den PR-Review-Workflow zur `copilot-instructions.md` hinzu.

### Neue Regeln:
| Regel | Begründung |
|-------|------------|
| **Review-Threads einzeln beantworten** | Erklärung im Thread dokumentiert |
| **Dann erst resolven** | Thread-Historie bleibt nachvollziehbar |
| **Alle Kommentare prüfen** | `get_review_comments` nicht nur `get_reviews` |
| **Outdated ≠ Resolved** | Auch veraltete Threads explizit auflösen |

### Hintergrund
Bei PR #133 wurden Review-Threads per GraphQL als resolved markiert, ohne vorher im Thread zu antworten. Das ist suboptimal für die Nachvollziehbarkeit.