### PR TITLE
fix: here-doc Terminator in architecture.sh Generator korrigiert

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,29 +46,17 @@ dotfiles/
     ├── .zshrc                   # Interactive Shell Konfiguration
     ├── .zlogin                  # Post-Login (Background-Optimierungen)
     └── .config/
-HEADER
-
-    # Alias-Dateien dynamisch auflisten
-    echo "        ├── alias/               # Tool-Aliase"
-    local alias_count=0
-    for alias_file in "$ALIAS_DIR"/*.alias(N); do
-        (( alias_count++ )) || true
-    done
-    
-    local i=0
-    for alias_file in "$ALIAS_DIR"/*.alias(N); do
-        (( i++ )) || true
-        local name="${alias_file:t}"
-        local desc=$(parse_header_field "$alias_file" "Zweck")
-        [[ -z "$desc" ]] && desc="${name%.alias}-Aliase"
-        
-        local connector="│   ├──"
-        (( i == alias_count )) && connector="│   └──"
-        
-        echo "        $connector $name"
-    done
-    
-    cat << 'REST'
+        ├── alias/               # Tool-Aliase
+        │   ├── bat.alias
+        │   ├── brew.alias
+        │   ├── btop.alias
+        │   ├── eza.alias
+        │   ├── fastfetch.alias
+        │   ├── fd.alias
+        │   ├── fzf.alias
+        │   ├── gh.alias
+        │   ├── git.alias
+        │   └── rg.alias
         ├── shell-colors         # Catppuccin Mocha ANSI-Farbvariablen
         ├── bat/
         │   ├── config           # bat native Config

--- a/scripts/generators/architecture.sh
+++ b/scripts/generators/architecture.sh
@@ -135,7 +135,7 @@ HEADER
     ├── .zshrc                   # Interactive Shell Konfiguration
     ├── .zlogin                  # Post-Login (Background-Optimierungen)
     └── .config/
-HEADER
+REST
 
     # Alias-Dateien dynamisch auflisten
     echo "        ├── alias/               # Tool-Aliase"


### PR DESCRIPTION
## Beschreibung

Behebt einen kritischen Bug im Architecture-Generator, der Shell-Code als Literal-Text in die generierte Dokumentation schrieb.

## Änderungen

- **scripts/generators/architecture.sh**: Here-doc Terminator von `HEADER` zu `REST` korrigiert (Zeile 138)
- **docs/architecture.md**: Neu generiert – Alias-Dateien werden jetzt korrekt aufgelistet

## Problem

Der Generator verwendete `HEADER` als Terminator für einen here-doc Block, der mit `cat << 'REST'` begann. Das führte dazu, dass der Shell-Code zwischen den Terminatoren als Literal-Text ausgegeben wurde:

```markdown
    └── .config/
HEADER

    # Alias-Dateien dynamisch auflisten
    echo "        ├── alias/               # Tool-Aliase"
    local alias_count=0
    ...
```

## Lösung

Zeile 138: `HEADER` → `REST`

## Verifizierung

- [x] `./scripts/generate-docs.sh --check` ✔
- [x] `./scripts/tests/test_generators.sh` → 53 Tests bestanden
- [x] `./.githooks/pre-commit` → Alle Checks bestanden
- [x] Dokumentation zeigt jetzt die Alias-Dateien korrekt an

## Fixes

Fixes #135