### PR TITLE
fix(generators): Funktionen in Tool-Nutzung + Debug-Output entfernen

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -351,15 +351,6 @@ Verfügbare Aliase aus `~/.config/alias/`:
 
 Ausführliche Beispiele für die wichtigsten Tools:
 
-alias_count=3
-alias_count=0
-alias_count=2
-alias_count=9
-alias_count=2
-alias_count=10
-alias_count=0
-alias_count=2
-alias_count=9
 ### bat – bat mit verschiedenen Ausgabe-Stilen
 
 ```zsh
@@ -369,6 +360,7 @@ catn              # Mit Zeilennummern, ohne Pager (bat allein hat Pager)
 catd              # Zeigt Git-Diff-Markierungen an
 
 # Interaktive Funktionen (mit fzf)
+bat-theme         # Theme Browser – Enter=Aktivieren
 ```
 
 > **Hinweis:** Globale Optionen (Theme, Style, Syntax-Mappings) sind in ~/.config/bat/config definiert. Nach Theme-Änderungen: `bat cache --build`
@@ -418,6 +410,8 @@ fdjson            # JSON-Dateien finden
 fdyaml            # YAML-Dateien finden
 
 # Interaktive Funktionen (mit fzf)
+cdf               # Verzeichnis wechseln(pfad=.) – Enter=Wechseln, Ctrl+Y=Pfad kopieren
+fo                # Datei öffnen(pfad=.) – Enter=Öffnen, Ctrl+Y=Pfad kopieren
 ```
 
 > **Hinweis:** Globale Ignore-Patterns (.git/, node_modules/, etc.) sind in ~/.config/fd/ignore definiert. Mit "fd -u" werden alle Ignore-Dateien umgangen.
@@ -439,6 +433,10 @@ gs                # Status des Repositories anzeigen
 gd                # Änderungen anzeigen
 
 # Interaktive Funktionen (mit fzf)
+glog              # Commit-History mit bat-Vorschau – Enter=Anzeigen, Ctrl+Y=SHA kopieren
+gbr               # Branch wechseln mit Log-Vorschau – Enter=Checkout, Ctrl+D=Löschen
+gst               # Status mit Diff-Vorschau (bat) – Enter=Add, Tab=Mehrfach, Ctrl+R=Reset
+gstash            # Stash-Browser – Enter=Apply, Ctrl+P=Pop, Ctrl+D=Drop
 
 # lazygit Integration
 lg                # Terminal-UI für Git (lazygit)
@@ -470,6 +468,7 @@ rgrb              # Suche in Ruby-Dateien
 rggo              # Suche in Go-Dateien
 
 # Interaktive Suche (mit fzf)
+rgf               # Live-Grep(suche?) – Enter=Datei öffnen, Ctrl+Y=Pfad kopieren
 ```
 
 > **Hinweis:** Globale Optionen (--smart-case, --line-number, --heading) sind in ~/.config/ripgrep/config definiert.

--- a/scripts/generators/lib.sh
+++ b/scripts/generators/lib.sh
@@ -305,11 +305,25 @@ extract_usage_codeblock() {
             
             # Alignment (max 18 Zeichen)
             local padding=$((18 - ${#alias_name}))
-            (( padding < 1 )) && padding=1
+            [[ $padding -lt 1 ]] && padding=1
             local spaces=""
             for ((i=0; i<padding; i++)); do spaces+=" "; done
             
             output+="${alias_name}${spaces}# ${desc}\n"
+        fi
+        
+        # Funktion mit vorheriger Beschreibung: name() {
+        if [[ "$trimmed" == [a-z]*"() "* && "$prev_line" == "# "* && "$prev_line" != "# ----"* ]]; then
+            local func_name="${trimmed%%\(*}"
+            local desc="${prev_line#\# }"
+            
+            # Alignment (max 18 Zeichen)
+            local padding=$((18 - ${#func_name}))
+            [[ $padding -lt 1 ]] && padding=1
+            local spaces=""
+            for ((i=0; i<padding; i++)); do spaces+=" "; done
+            
+            output+="${func_name}${spaces}# ${desc}\n"
         fi
         
         prev_prev_line="$prev_line"

--- a/scripts/generators/tools.sh
+++ b/scripts/generators/tools.sh
@@ -18,11 +18,11 @@ generate_tool_usage_section() {
     # Nur für Tools mit mehr als 3 Aliasen
     for alias_file in "$ALIAS_DIR"/*.alias(N); do
         local tool_name=$(basename "$alias_file" .alias)
-        local alias_count
+        local alias_count=0
         alias_count=$(grep -c "^alias " "$alias_file" 2>/dev/null) || alias_count=0
         
         # Mindestens 3 Aliase für eine Nutzungs-Sektion
-        (( alias_count < 3 )) && continue
+        [[ $alias_count -lt 3 ]] && continue
         
         local usage=$(extract_usage_codeblock "$alias_file")
         [[ -z "${usage// /}" ]] && continue


### PR DESCRIPTION
## Zusammenfassung

Behebt Issue #138 – Generator erkennt jetzt interaktive Funktionen und Debug-Output ist entfernt.

## Probleme behoben

### 1. Funktionen wurden nicht erkannt
`extract_usage_codeblock` erkannte nur Aliase, keine Funktionen wie `bat-theme()`.

**Ursache:** Das Regex `^[a-z][a-z0-9_-]*\(\)\ ` funktionierte nicht korrekt in ZSH ERE.

**Lösung:** Glob-Pattern `[a-z]*"() "*` statt Regex verwenden.

### 2. Debug-Output in Dokumentation
`alias_count=3`, `alias_count=0` etc. erschienen in docs/tools.md.

**Ursache:** `local alias_count` ohne Initialisierung + ZSH `set -e` Quirk gibt vorherige Werte aus.

**Lösung:** `local alias_count=0` mit Initialisierung.

## Neu erkannte Funktionen

| Tool | Funktion | Beschreibung |
|------|----------|--------------|
| bat | `bat-theme` | Theme Browser |
| fd | `cdf` | Verzeichnis wechseln |
| fd | `fo` | Datei öffnen |
| git | `glog` | Commit-History Browser |
| git | `gbr` | Branch wechseln |
| git | `gst` | Status mit Diff |
| git | `gstash` | Stash-Browser |
| rg | `rgf` | Live-Grep |

## Tests

- [x] `./scripts/tests/test_generators.sh` – 53 Tests bestanden
- [x] `./scripts/generate-docs.sh` – Dokumentation aktuell
- [x] Pre-commit Hooks bestanden

Closes #138