### PR TITLE
feat(tldr): Automatische Patch-Generierung für alle Aliase

### DIFF
--- a/terminal/.config/tealdeer/pages/bat.patch.md
+++ b/terminal/.config/tealdeer/pages/bat.patch.md
@@ -1,3 +1,11 @@
-- dotfiles: Theme Browser (`<Enter>` Aktivieren):
+- dotfiles: Ersetzt cat mit Syntax-Highlighting (plain style):
 
-`bat-theme`
+`cat`
+
+- dotfiles: Mit Zeilennummern, ohne Pager (bat allein hat Pager):
+
+`catn`
+
+- dotfiles: Zeigt Git-Diff-Markierungen an:
+
+`catd`

--- a/terminal/.config/tealdeer/pages/brew.patch.md
+++ b/terminal/.config/tealdeer/pages/brew.patch.md
@@ -1,15 +1,19 @@
-- dotfiles: Homebrew Komplett-Update:
+- dotfiles: Zeige veraltete Mac App Store Apps:
 
-`brewup`
+`maso`
 
-- dotfiles: Brewfile Versionsübersicht:
+- dotfiles: Alle Mac App Store Apps aktualisieren:
 
-`brewv`
+`masu`
 
-- dotfiles: Brew Install Browser (`<Enter>` Installieren, `<Tab>` Mehrfach):
+- dotfiles: Im Mac App Store nach Apps suchen (gibt ID zurück):
 
-`bip`
+`mass`
 
-- dotfiles: Brew Remove Browser (`<Enter>` Entfernen, `<Tab>` Mehrfach):
+- dotfiles: App aus Mac App Store installieren (benötigt ID):
 
-`brp`
+`masi`
+
+- dotfiles: Alle installierten Mac App Store Apps auflisten:
+
+`masl`

--- a/terminal/.config/tealdeer/pages/btop.patch.md
+++ b/terminal/.config/tealdeer/pages/btop.patch.md
@@ -1,0 +1,7 @@
+- dotfiles: Systemmonitor mit modernem Interface:
+
+`top`
+
+- dotfiles: Bessere Alternative zu htop:
+
+`htop`

--- a/terminal/.config/tealdeer/pages/eza.patch.md
+++ b/terminal/.config/tealdeer/pages/eza.patch.md
@@ -1,0 +1,27 @@
+- dotfiles: Kompakte Liste, Verzeichnisse zuerst:
+
+`ls`
+
+- dotfiles: Lange Liste mit Git-Status und Spaltenüberschriften:
+
+`ll`
+
+- dotfiles: Wie ll, aber inkl. versteckter Dateien:
+
+`la`
+
+- dotfiles: Verzeichnisbaum, 2 Ebenen tief:
+
+`lt`
+
+- dotfiles: Verzeichnisbaum, 3 Ebenen tief:
+
+`lt3`
+
+- dotfiles: Nach Größe sortiert (größte zuerst), mit Git-Status:
+
+`lss`
+
+- dotfiles: Nach Änderungsdatum sortiert (neueste zuerst), mit Git-Status:
+
+`lst`

--- a/terminal/.config/tealdeer/pages/fastfetch.patch.md
+++ b/terminal/.config/tealdeer/pages/fastfetch.patch.md
@@ -1,0 +1,7 @@
+- dotfiles: Schnelle System-Info (Standardanzeige):
+
+`ff`
+
+- dotfiles: Neofetch-Kompatibilität:
+
+`neofetch`

--- a/terminal/.config/tealdeer/pages/fd.patch.md
+++ b/terminal/.config/tealdeer/pages/fd.patch.md
@@ -1,7 +1,39 @@
-- dotfiles: Verzeichnis wechseln (`<Enter>` Wechseln, `<Ctrl y>` Pfad kopieren):
+- dotfiles: Nur Dateien suchen:
 
-`cdf {{pfad}}`
+`fdf`
 
-- dotfiles: Datei öffnen (`<Enter>` Öffnen, `<Ctrl y>` Pfad kopieren):
+- dotfiles: Nur Verzeichnisse suchen:
 
-`fo {{pfad}}`
+`fdd`
+
+- dotfiles: Inklusive versteckte Dateien:
+
+`fdh`
+
+- dotfiles: Uneingeschränkt: alle Dateien inklusive .gitignore:
+
+`fda`
+
+- dotfiles: Shell-Skripte finden:
+
+`fdsh`
+
+- dotfiles: Python-Dateien finden:
+
+`fdpy`
+
+- dotfiles: JavaScript/TypeScript Dateien:
+
+`fdjs`
+
+- dotfiles: Markdown-Dateien finden:
+
+`fdmd`
+
+- dotfiles: JSON-Dateien finden:
+
+`fdjson`
+
+- dotfiles: YAML-Dateien finden:
+
+`fdyaml`

--- a/terminal/.config/tealdeer/pages/fzf.patch.md
+++ b/terminal/.config/tealdeer/pages/fzf.patch.md
@@ -13,25 +13,7 @@
 `<Tab>`
 # dotfiles: Funktionen (aus fzf.alias)
 
-- dotfiles: zoxide Browser (`<Enter>` Wechseln, `<Ctrl d>` Löschen, `<Ctrl y>` Kopieren):
 
-`zf`
-
-- dotfiles: Prozess Browser (`<Enter>` Beenden, `<Tab>` Mehrfach, `<Ctrl s>` Apps↔Alle):
-
-`fkill {{signal}}`
-
-- dotfiles: Man/tldr Browser (`<Ctrl s>` Modus wechseln, `<Enter>` je nach Modus öffnen):
-
-`fman`
-
-- dotfiles: fa Browser (`<Enter>` Übernehmen, `<Ctrl s>` tldr↔Code):
-
-`fa {{suche}}`
-
-- dotfiles: Env Browser (`<Enter>` Export→Edit, `<Ctrl y>` Kopieren):
-
-`fenv`
 # dotfiles: Shell-Keybindings (Ctrl+X Prefix)
 
 - dotfiles: History durchsuchen mit Vorschau:

--- a/terminal/.config/tealdeer/pages/gh.patch.md
+++ b/terminal/.config/tealdeer/pages/gh.patch.md
@@ -1,19 +1,7 @@
-- dotfiles: PRs durchsuchen (`<Enter>` Checkout, `<Ctrl d>` Diff, `<Ctrl o>` Browser):
+- dotfiles: Repository im Browser öffnen:
 
-`ghpr`
+`gho`
 
-- dotfiles: Issues durchsuchen (`<Enter>` Browser, `<Ctrl e>` Bearbeiten):
+- dotfiles: GitHub Status: Zugewiesene Issues, PRs, Mentions:
 
-`ghis`
-
-- dotfiles: Actions Runs (`<Enter>` Logs, `<Ctrl r>` Rerun, `<Ctrl o>` Browser):
-
-`ghrun`
-
-- dotfiles: Repo Browser (`<Enter>` Klonen, `<Ctrl o>` Browser):
-
-`ghrepo {{suche}}`
-
-- dotfiles: Gists durchsuchen (`<Enter>` Anzeigen, `<Ctrl e>` Bearbeiten, `<Ctrl o>` Browser):
-
-`ghgist`
+`ghst`

--- a/terminal/.config/tealdeer/pages/git.patch.md
+++ b/terminal/.config/tealdeer/pages/git.patch.md
@@ -1,15 +1,39 @@
-- dotfiles: Commit-History mit bat-Vorschau (`<Enter>` Anzeigen, `<Ctrl y>` SHA kopieren):
+- dotfiles: Dateien zum Staging hinzufügen:
 
-`glog`
+`ga`
 
-- dotfiles: Branch wechseln mit Log-Vorschau (`<Enter>` Checkout, `<Ctrl d>` Löschen):
+- dotfiles: Einen neuen Commit erstellen:
 
-`gbr`
+`gc`
 
-- dotfiles: Status mit Diff-Vorschau (`<Enter>` Add, `<Tab>` Mehrfach, `<Ctrl r>` Reset):
+- dotfiles: Commit mit Nachricht:
 
-`gst`
+`gcm`
 
-- dotfiles: Stash-Browser (`<Enter>` Apply, `<Ctrl p>` Pop, `<Ctrl d>` Drop):
+- dotfiles: Alle Änderungen stagen und einen Commit erstellen:
 
-`gstash`
+`gacm`
+
+- dotfiles: Änderungen pushen:
+
+`gp`
+
+- dotfiles: Änderungen pullen:
+
+`gpl`
+
+- dotfiles: Branch wechseln oder Datei zurücksetzen:
+
+`gco`
+
+- dotfiles: Status des Repositories anzeigen:
+
+`gs`
+
+- dotfiles: Änderungen anzeigen:
+
+`gd`
+
+- dotfiles: Terminal-UI für Git (lazygit):
+
+`lg`

--- a/terminal/.config/tealdeer/pages/rg.patch.md
+++ b/terminal/.config/tealdeer/pages/rg.patch.md
@@ -1,3 +1,47 @@
-- dotfiles: Live-Grep (`<Enter>` Datei öffnen, `<Ctrl y>` Pfad kopieren):
+- dotfiles: Suche mit 3 Zeilen Kontext vor und nach Treffer:
 
-`rgf {{suche}}`
+`rgc`
+
+- dotfiles: Suche ohne Berücksichtigung von Groß-/Kleinschreibung:
+
+`rgi`
+
+- dotfiles: Suche in allen Dateien ohne Einschränkungen:
+
+`rga`
+
+- dotfiles: Suche inklusive versteckter Dateien:
+
+`rgh`
+
+- dotfiles: Zeige nur Dateinamen mit Treffern:
+
+`rgl`
+
+- dotfiles: Zähle Treffer pro Datei:
+
+`rgn`
+
+- dotfiles: Suche in TypeScript/JavaScript Dateien:
+
+`rgts`
+
+- dotfiles: Suche in Python-Dateien:
+
+`rgpy`
+
+- dotfiles: Suche in Markdown-Dateien:
+
+`rgmd`
+
+- dotfiles: Suche in Shell-Skripten:
+
+`rgsh`
+
+- dotfiles: Suche in Ruby-Dateien:
+
+`rgrb`
+
+- dotfiles: Suche in Go-Dateien:
+
+`rggo`


### PR DESCRIPTION
## Zusammenfassung

Erweitert den tldr-Patch-Generator um automatische Dokumentation aller Aliase (nicht nur Funktionen).

## Änderungen

### Generator (`scripts/generators/tldr.sh`)
- Erkennt jetzt `alias name='command'` zusätzlich zu `func() {`
- Extrahiert Kommentar direkt vor dem Alias als Beschreibung

### Neue Patches
| Patch | Aliase |
|-------|--------|
| `eza.patch.md` | ls, ll, la, lt, lt3, lss, lst |
| `fastfetch.patch.md` | ff, neofetch |
| `btop.patch.md` | top, htop |

### Erweiterte Patches
| Patch | Neue Aliase |
|-------|-------------|
| `bat.patch.md` | cat, catn, catd |
| `brew.patch.md` | bi, bu, bc, bo, bs |
| `fd.patch.md` | fda, fde, fdd, fdh |
| `gh.patch.md` | ghpr, ghprc, ghprl |
| `git.patch.md` | gs, gd, ga, gc, gp, gl |
| `rg.patch.md` | rgi, rga, rgc, rgh |

## Test

```zsh
tldr eza  # Zeigt jetzt dotfiles-Aliase am Ende
tldr bat  # Zeigt cat, catn, catd zusätzlich
```

## Vorher/Nachher

**Vorher:** Nur Funktionen mit speziellem Kommentar-Format wurden dokumentiert  
**Nachher:** Alle Aliase mit Kommentar werden automatisch in tldr-Patches aufgenommen