### PR TITLE
docs(configuration): Entferne irreführenden Auto-Generierungs-Hinweis

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,9 +2,6 @@
 
 Diese Anleitung erklärt, wie du die dotfiles an deine Bedürfnisse anpassen kannst.
 
-> Diese Dokumentation wird automatisch aus dem Code generiert.
-> Änderungen direkt in den Config-Dateien vornehmen.
-
 ---
 
 ## Catppuccin Mocha Theme

--- a/scripts/generators/configuration.sh
+++ b/scripts/generators/configuration.sh
@@ -57,9 +57,6 @@ generate_configuration_md() {
 
 Diese Anleitung erklärt, wie du die dotfiles an deine Bedürfnisse anpassen kannst.
 
-> Diese Dokumentation wird automatisch aus dem Code generiert.
-> Änderungen direkt in den Config-Dateien vornehmen.
-
 ---
 
 ## Catppuccin Mocha Theme


### PR DESCRIPTION
## Zusammenfassung

Entfernt den irreführenden Hinweis aus `configuration.md`:

> Diese Dokumentation wird automatisch aus dem Code generiert.
> Änderungen direkt in den Config-Dateien vornehmen.

## Problem

Der Hinweis war falsch, weil `configuration.md` hauptsächlich **statische Anleitungen** enthält (Schriftart wechseln, Aliase anpassen, fzf konfigurieren etc.), die direkt im Generator-Script `configuration.sh` hardcodiert sind – nicht aus externen Config-Dateien extrahiert werden.

Die anderen Dokumentationen haben korrekte, spezifische Hinweise:
- `installation.md`: "Änderungen direkt in `setup/bootstrap.sh` und `setup/Brewfile` vornehmen." ✅
- `tools.md`: "Änderungen direkt im Code (`.alias`-Dateien, `Brewfile`) vornehmen." ✅
- `architecture.md`: "Änderungen an der Verzeichnisstruktur werden automatisch reflektiert." ✅

## Änderungen

- `scripts/generators/configuration.sh`: Hinweis-Block aus HEADER entfernt
- `docs/configuration.md`: Regeneriert (Hinweis entfernt)