### PR TITLE
fix(tldr): ZSH Array-Join vor Sortierung trennen

### DIFF
--- a/.github/scripts/generators/tldr.sh
+++ b/.github/scripts/generators/tldr.sh
@@ -444,11 +444,13 @@ generate_dotfiles_page() {
     done
 
     output+="- Tools mit dotfiles-Patches (tldr <tool>):\n\n"
-    output+="\`${(j:, :)${(o)patches}}\`\n\n"
+    local sorted_patches=(${(o)patches})
+    output+="\`${(j:, :)sorted_patches}\`\n\n"
 
     if (( ${#pages[@]} > 0 )); then
         output+="- Eigene Seiten:\n\n"
-        output+="\`${(j:, :)${(o)pages}}, dotfiles\`\n"
+        local sorted_pages=(${(o)pages})
+        output+="\`${(j:, :)sorted_pages}, dotfiles\`\n"
     fi
 
     echo -e "$output"

--- a/terminal/.config/tealdeer/pages/dotfiles.page.md
+++ b/terminal/.config/tealdeer/pages/dotfiles.page.md
@@ -77,8 +77,8 @@
 
 - Tools mit dotfiles-Patches (tldr <tool>):
 
-`bat brew btop eza fastfetch fd fzf gh git lazygit rg zoxide`
+`bat, brew, btop, eza, fastfetch, fd, fzf, gh, git, lazygit, rg, zoxide`
 
 - Eigene Seiten:
 
-`catppuccin markdownlint, dotfiles`
+`catppuccin, markdownlint, dotfiles`


### PR DESCRIPTION
## Beschreibung

Fix für fehlerhaften ZSH Array-Join in dotfiles.page.md.

## Problem

```
Vorher:  catppuccin markdownlint, dotfiles
Nachher: catppuccin, markdownlint, dotfiles
```

## Ursache

`${(j:, :)${(o)array}}` funktioniert in ZSH nicht korrekt – die Kombination von Sort `(o)` und Join `(j)` in einer Expression führt dazu, dass der Join ignoriert wird.

## Lösung

Erst sortieren, dann joinen (zwei separate Schritte):
```zsh
local sorted=(${(o)array})
output="${(j:, :)sorted}"
```

## Checkliste

- [x] Pre-Commit Hooks bestanden
- [x] `tldr dotfiles` zeigt korrekte Ausgabe