### PR TITLE
fix(markdownlint): globale Config ohne Repo-Symlink nutzbar

### DIFF
--- a/terminal/.config/alias/markdownlint.alias
+++ b/terminal/.config/alias/markdownlint.alias
@@ -11,17 +11,17 @@
 if ! command -v markdownlint-cli2 >/dev/null 2>&1; then return 0; fi
 
 # ------------------------------------------------------------
-# Aliase
+# Aliase (markdownlint-cli2 findet ~/.config nicht automatisch)
 # ------------------------------------------------------------
 
 # Alle Markdown-Dateien im aktuellen Verzeichnis prüfen
-alias mdl='markdownlint-cli2'
+alias mdl='markdownlint-cli2 --config "${XDG_CONFIG_HOME:-$HOME/.config}/markdownlint-cli2/.markdownlint-cli2.jsonc"'
 
 # Alle Markdown-Dateien rekursiv prüfen
-alias mdla='markdownlint-cli2 "**/*.md"'
+alias mdla='markdownlint-cli2 --config "${XDG_CONFIG_HOME:-$HOME/.config}/markdownlint-cli2/.markdownlint-cli2.jsonc" "**/*.md"'
 
 # Mit Fix-Modus (automatische Korrekturen)
-alias mdlf='markdownlint-cli2 --fix'
+alias mdlf='markdownlint-cli2 --config "${XDG_CONFIG_HOME:-$HOME/.config}/markdownlint-cli2/.markdownlint-cli2.jsonc" --fix'
 
 # Alle Markdown-Dateien rekursiv fixen
-alias mdlaf='markdownlint-cli2 --fix "**/*.md"'
+alias mdlaf='markdownlint-cli2 --config "${XDG_CONFIG_HOME:-$HOME/.config}/markdownlint-cli2/.markdownlint-cli2.jsonc" --fix "**/*.md"'


### PR DESCRIPTION
## Beschreibung

Aliase nutzen jetzt `--config` mit XDG-Pfad, damit markdownlint-cli2 die globale Config findet.

## Änderungen

- Aliase (`mdl`, `mdla`, `mdlf`, `mdlaf`) mit explizitem Config-Pfad
- Kein Symlink im Repo nötig (XDG-konform)

## Checkliste

- [x] `./github/scripts/generate-docs.sh --check` läuft
- [x] `./.github/scripts/health-check.sh` läuft
- [x] Pre-Commit Hooks durchlaufen