### PR TITLE
refactor(markdownlint): Config-Pfad als Variable (DRY)

### DIFF
--- a/terminal/.config/alias/markdownlint.alias
+++ b/terminal/.config/alias/markdownlint.alias
@@ -14,14 +14,17 @@ if ! command -v markdownlint-cli2 >/dev/null 2>&1; then return 0; fi
 # Aliase (markdownlint-cli2 findet ~/.config nicht automatisch)
 # ------------------------------------------------------------
 
+# Config-Pfad zentral definiert (DRY)
+_MDL_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/markdownlint-cli2/.markdownlint-cli2.jsonc"
+
 # Alle Markdown-Dateien im aktuellen Verzeichnis prüfen
-alias mdl='markdownlint-cli2 --config "${XDG_CONFIG_HOME:-$HOME/.config}/markdownlint-cli2/.markdownlint-cli2.jsonc"'
+alias mdl='markdownlint-cli2 --config "$_MDL_CONFIG"'
 
 # Alle Markdown-Dateien rekursiv prüfen
-alias mdla='markdownlint-cli2 --config "${XDG_CONFIG_HOME:-$HOME/.config}/markdownlint-cli2/.markdownlint-cli2.jsonc" "**/*.md"'
+alias mdla='markdownlint-cli2 --config "$_MDL_CONFIG" "**/*.md"'
 
 # Mit Fix-Modus (automatische Korrekturen)
-alias mdlf='markdownlint-cli2 --config "${XDG_CONFIG_HOME:-$HOME/.config}/markdownlint-cli2/.markdownlint-cli2.jsonc" --fix'
+alias mdlf='markdownlint-cli2 --config "$_MDL_CONFIG" --fix'
 
 # Alle Markdown-Dateien rekursiv fixen
-alias mdlaf='markdownlint-cli2 --config "${XDG_CONFIG_HOME:-$HOME/.config}/markdownlint-cli2/.markdownlint-cli2.jsonc" --fix "**/*.md"'
+alias mdlaf='markdownlint-cli2 --config "$_MDL_CONFIG" --fix "**/*.md"'


### PR DESCRIPTION
## Beschreibung

Adressiert Copilot-Review-Kommentar aus PR #164:
- Wiederholten Config-Pfad in zentrale Variable `_MDL_CONFIG` extrahiert
- Verbessert Wartbarkeit bei Pfadänderungen

## Art der Änderung

- [x] 🔧 Refactoring (Code-Verbesserung ohne Funktionsänderung)

## Checkliste

- [x] `./setup/bootstrap.sh --generate-docs` ausgeführt (keine Änderung nötig)
- [x] `./setup/bootstrap.sh --health-check` bestanden
- [x] Pre-Commit Hooks bestanden

Closes: Copilot-Review-Kommentar aus #164