### PR TITLE
docs: CONTRIBUTING.md um Pfad-Pattern, fzf-Helper und .zshrc-Init erweitert

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,16 @@
 # Copilot Instructions für dotfiles
 
+## Vor größeren Änderungen
+
+**Lies zuerst `CONTRIBUTING.md`** bei:
+
+- Neue `.alias`-Datei erstellen
+- Neues Tool zum Brewfile hinzufügen
+- Änderungen an `.zshrc` oder `.zshenv`
+- fzf-Funktionen mit Preview/Bindings
+
+---
+
 ## DOs ✓
 
 | Regel | Beispiel |


### PR DESCRIPTION
## Beschreibung

Erweitert CONTRIBUTING.md um fehlende Dokumentation für AI-Coding-Assistenten und Entwickler:

- **Pfad-Pattern**: Erklärt wann `$DOTFILES_DIR` vs `$XDG_CONFIG_HOME` verwendet wird
- **fzf Helper-Skripte**: Dokumentiert wiederverwendbare Skripte in `~/.config/fzf/`
- **Tool-Initialisierung in .zshrc**: Pattern für Tools mit Shell-Integration

Außerdem wird `copilot-instructions.md` um einen Verweis auf CONTRIBUTING.md erweitert.

## Art der Änderung

- [ ] 🐛 Bugfix
- [ ] ✨ Neues Feature
- [x] 📝 Dokumentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Konfiguration/Maintenance

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Bei neuen Tools: Guard-Check vorhanden

## Zusammenhängende Issues

n/a

## Screenshots / Terminal-Ausgabe

Pre-commit hooks erfolgreich:
```
✔ Shell-Syntax OK
✔ Dokumentation ist aktuell
✔ Alias-Format OK
✔ Markdown OK
✔ Alle Checks bestanden
```