### PR TITLE
feat: visual-studio-code und shellcheck hinzugefügt

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -164,6 +164,7 @@ ff                                  # System-Info anzeigen
 | [`resvg`](https://github.com/RazrFalcon/resvg) | SVG-Rendering |
 | [`ripgrep`](https://github.com/BurntSushi/ripgrep) | grep-Ersatz, schnellste Textsuche |
 | [`sevenzip`](https://7-zip.org/) | Archiv-Extraktion |
+| [`shellcheck`](https://www.shellcheck.net/) | Shell-Script-Linter (für Bash) |
 | [`starship`](https://starship.rs/) | Shell-Prompt |
 | [`stow`](https://www.gnu.org/software/stow/) | Symlink-Manager |
 | [`tealdeer`](https://tealdeer-rs.github.io/tealdeer/) | tldr-Client |
@@ -178,6 +179,7 @@ ff                                  # System-Info anzeigen
 | Paket | Beschreibung |
 | ----- | ------------ |
 | [`claude-code`](https://docs.anthropic.com/en/docs/claude-code) | Agentic Coding |
+| [`visual-studio-code`](https://code.visualstudio.com/) | Editor |
 | [`font-meslo-lg-nerd-font`](https://github.com/ryanoasis/nerd-fonts) | Nerd Font für Prompt, eza, yazi |
 
 ### Mac App Store

--- a/setup/Brewfile
+++ b/setup/Brewfile
@@ -28,6 +28,7 @@ brew "poppler"                              # PDF-Rendering | https://poppler.fr
 brew "resvg"                                # SVG-Rendering | https://github.com/RazrFalcon/resvg
 brew "ripgrep"                              # grep-Ersatz, schnellste Textsuche | https://github.com/BurntSushi/ripgrep
 brew "sevenzip"                             # Archiv-Extraktion | https://7-zip.org/
+brew "shellcheck"                           # Shell-Script-Linter (für Bash) | https://www.shellcheck.net/
 brew "starship"                             # Shell-Prompt | https://starship.rs/
 brew "stow"                                 # Symlink-Manager | https://www.gnu.org/software/stow/
 brew "tealdeer"                             # tldr-Client | https://tealdeer-rs.github.io/tealdeer/
@@ -41,6 +42,7 @@ brew "mas"                                  # Mac App Store CLI | https://github
 # Homebrew Casks
 # ------------------------------------------------------------
 cask "claude-code"                          # Agentic Coding | https://docs.anthropic.com/en/docs/claude-code
+cask "visual-studio-code"                   # Editor | https://code.visualstudio.com/
 cask "font-meslo-lg-nerd-font"              # Nerd Font für Prompt, eza, yazi | https://github.com/ryanoasis/nerd-fonts
 
 # ------------------------------------------------------------

--- a/terminal/.config/shellcheckrc
+++ b/terminal/.config/shellcheckrc
@@ -1,0 +1,23 @@
+# ============================================================
+# ShellCheck - Konfiguration
+# ============================================================
+# Zweck   : Linting für Bash/sh/dash/ksh-Skripte
+# Pfad    : ~/.config/shellcheckrc (Symlink via Stow)
+# Docs    : https://www.shellcheck.net/wiki/
+# ============================================================
+# HINWEIS: ShellCheck unterstützt KEIN ZSH!
+#          ZSH-Skripte produzieren SC1071 (kann nicht deaktiviert
+#          werden, da Parser-Fehler). Einfach ignorieren.
+# ============================================================
+
+# ------------------------------------------------------------
+# Sinnvolle Ausnahmen für Bash-Projekte
+# ------------------------------------------------------------
+# SC1090: Can't follow non-constant source
+#         → Dynamische source-Pfade sind üblich
+# SC1091: Not following: file not found
+#         → Externe Dateien existieren zur Laufzeit
+# SC2034: Variable appears unused
+#         → Variablen werden oft in anderen Skripten genutzt
+
+disable=SC1090,SC1091,SC2034


### PR DESCRIPTION
## Änderungen

- **visual-studio-code** als Cask im Brewfile
- **shellcheck** für Bash-Linting (ZSH nicht unterstützt)
- **shellcheckrc** in `~/.config/` (XDG-konform)

## Hinweis

ShellCheck unterstützt kein ZSH – SC1071 bei ZSH-Shebangs ist nicht vermeidbar.
Die Config deaktiviert nur sinnvolle Warnungen für Bash-Projekte (SC1090, SC1091, SC2034).