### PR TITLE
docs: verbessere README-Struktur und korrigiere Generatoren

### DIFF
--- a/.github/scripts/generators/readme.sh
+++ b/.github/scripts/generators/readme.sh
@@ -10,6 +10,37 @@
 source "${0:A:h}/common.sh"
 
 # ------------------------------------------------------------
+# Helper: Tool-Ersetzungen aus .alias-Dateien extrahieren
+# ------------------------------------------------------------
+# Parst "# Ersetzt : original (beschreibung)" aus allen .alias-Dateien
+generate_tool_replacements_table() {
+    local -A replacements=()
+
+    for alias_file in "$ALIAS_DIR"/*.alias(N); do
+        local tool_name=$(basename "$alias_file" .alias)
+        local ersetzt=$(parse_header_field "$alias_file" "Ersetzt")
+
+        # Format: "original (beschreibung)" → extrahiere beides
+        if [[ -n "$ersetzt" && "$ersetzt" == *"("* ]]; then
+            local original="${ersetzt%% \(*}"
+            local desc="${ersetzt#*\(}"
+            desc="${desc%\)}"
+            replacements[$original]="${tool_name}|${desc}"
+        fi
+    done
+
+    # Sortiert ausgeben
+    echo "| Vorher | Nachher | Vorteil |"
+    echo "| ------ | ------- | ------- |"
+    for original in ${(ko)replacements}; do
+        local data="${replacements[$original]}"
+        local tool="${data%%|*}"
+        local desc="${data#*|}"
+        echo "| \`${original}\` | \`${tool}\` | ${desc} |"
+    done
+}
+
+# ------------------------------------------------------------
 # Haupt-Generator für README.md
 # ------------------------------------------------------------
 generate_readme_md() {
@@ -20,8 +51,8 @@ generate_readme_md() {
     macos_min_name=$(get_macos_codename "$macos_min")
     macos_tested_name=$(get_macos_codename "$macos_tested")
 
-    # dothelp-Kategorien aus echten Quellen
-    local dothelp_categories=$(get_dothelp_categories)
+    # Tool-Ersetzungen dynamisch generieren
+    local tool_replacements=$(generate_tool_replacements_table)
 
     cat << EOF
 # 🍎 dotfiles
@@ -31,36 +62,39 @@ generate_readme_md() {
 [![macOS](https://img.shields.io/badge/macOS-${macos_min}%2B-black?logo=apple)](https://www.apple.com/macos/)
 [![Shell: zsh](https://img.shields.io/badge/Shell-zsh-green?logo=gnubash)](https://www.zsh.org/)
 
-> ${PROJECT_DESCRIPTION}
+**Dein Mac-Terminal mit modernen Tools, einheitlichem Theme und Dokumentation.**
 
-## Quickstart
+## ✨ Was du bekommst
+
+${tool_replacements}
+
+Dazu: **[Catppuccin Mocha](https://catppuccin.com/) Theme** überall, **Hilfe im Terminal** via \`dothelp\`, **fzf-Integration** für alles.
+
+Alle installierten Pakete: [\`setup/Brewfile\`](setup/Brewfile)
+
+## 🚀 Installation
 
 \`\`\`zsh
 curl -fsSL https://github.com/tshofmann/dotfiles/archive/refs/heads/main.tar.gz | tar -xz -C ~ && mv ~/dotfiles-main ~/dotfiles && ~/dotfiles/setup/bootstrap.sh
 \`\`\`
 
-Nach Terminal-Neustart:
+Danach **Terminal neu starten** (Cmd+Q). Fertig!
 
-\`\`\`zsh
-cd ~/dotfiles && stow --adopt -R terminal editor && git reset --hard HEAD && bat cache --build && tldr --update
-\`\`\`
-
-> ⚠️ **Achtung:** \`git reset --hard\` verwirft lokale Änderungen. Siehe [Setup](docs/setup.md) für Details.
-
-## Voraussetzungen
+### Voraussetzungen
 
 - **Apple Silicon Mac** (arm64)
 - **macOS ${macos_min}+** (${macos_min_name}) – getestet auf macOS ${macos_tested} (${macos_tested_name})
 - **Internetverbindung** & Admin-Rechte
 
-## Hilfe & Dokumentation
+## 📖 Dokumentation
 
-| Thema | Beschreibung |
-| ----- | ------------ |
-| \`dothelp\` | Hilfe/Dokumentation im Terminal: ${dothelp_categories} |
-| [Setup](docs/setup.md) | Schritt-für-Schritt Anleitung |
-| [Anpassung](docs/customization.md) | Starship, Aliase, ZSH anpassen |
-| [Contributing](CONTRIBUTING.md) | Für Entwickler: Architektur, Hooks, Workflow |
+| Befehl | Was es zeigt |
+| ------ | ------------ |
+| \`dothelp\` | Schnellreferenz: Keybindings, Tool-Ersetzungen, Wartung |
+| \`cmds\` | Alle Aliase und Funktionen interaktiv durchsuchen |
+| \`tldr <tool>\` | Vollständige Tool-Doku mit dotfiles-Erweiterungen |
+
+Mehr: [Setup](docs/setup.md) · [Anpassung](docs/customization.md) · [Contributing](CONTRIBUTING.md)
 
 ## Lizenz
 

--- a/.github/scripts/generators/setup.sh
+++ b/.github/scripts/generators/setup.sh
@@ -96,7 +96,6 @@ Das Bootstrap-Skript führt folgende Aktionen in dieser Reihenfolge aus:
 
 | Aktion | Beschreibung | Bei Fehler |
 | ------ | ------------ | ---------- |
-| Architektur-Check | Prüft ob arm64 (Apple Silicon) | ❌ Exit |
 PART2
 
     # Dynamische Bootstrap-Schritte-Tabelle aus Modulen generieren

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -509,7 +509,7 @@ Diese Regeln gelten für alle Shell-Dateien:
 
 | Regel | Format | Beispiel |
 | ------- | -------- | ---------- |
-| **Metadaten-Felder** | 8 Zeichen + `:` | `# Docs    :`, `# Guard   :` |
+| **Metadaten-Felder** | 12 Zeichen + `:` | `# Zweck       :`, `# Docs        :` |
 | **Guard-Kommentar** | Mit Tool-Name | `# Guard   : Nur wenn X installiert ist` |
 | **Sektions-Trenner** | `----` (60 Zeichen) | `# --------------------------------------------------------` |
 | **Header-Block** | `====` nur oben | Erste Zeilen der Datei |

--- a/README.md
+++ b/README.md
@@ -5,36 +5,45 @@
 [![macOS](https://img.shields.io/badge/macOS-26%2B-black?logo=apple)](https://www.apple.com/macos/)
 [![Shell: zsh](https://img.shields.io/badge/Shell-zsh-green?logo=gnubash)](https://www.zsh.org/)
 
-> Automatisiertes Dotfile-Setup mit modernen CLI-Ersetzungen.
+**Dein Mac-Terminal mit modernen Tools, einheitlichem Theme und Dokumentation.**
 
-## Quickstart
+## ✨ Was du bekommst
+
+| Vorher | Nachher | Vorteil |
+| ------ | ------- | ------- |
+| `cat` | `bat` | mit Syntax-Highlighting |
+| `cd` | `zoxide` | lernt häufige Verzeichnisse |
+| `find` | `fd` | schneller, intuitive Syntax |
+| `grep` | `rg` | schneller, respektiert .gitignore |
+| `ls` | `eza` | mit Icons und Git-Status |
+
+Dazu: **[Catppuccin Mocha](https://catppuccin.com/) Theme** überall, **Hilfe im Terminal** via `dothelp`, **fzf-Integration** für alles.
+
+Alle installierten Pakete: [`setup/Brewfile`](setup/Brewfile)
+
+## 🚀 Installation
 
 ```zsh
 curl -fsSL https://github.com/tshofmann/dotfiles/archive/refs/heads/main.tar.gz | tar -xz -C ~ && mv ~/dotfiles-main ~/dotfiles && ~/dotfiles/setup/bootstrap.sh
 ```
 
-Nach Terminal-Neustart:
+Danach **Terminal neu starten** (Cmd+Q). Fertig!
 
-```zsh
-cd ~/dotfiles && stow --adopt -R terminal editor && git reset --hard HEAD && bat cache --build && tldr --update
-```
-
-> ⚠️ **Achtung:** `git reset --hard` verwirft lokale Änderungen. Siehe [Setup](docs/setup.md) für Details.
-
-## Voraussetzungen
+### Voraussetzungen
 
 - **Apple Silicon Mac** (arm64)
 - **macOS 26+** (Tahoe) – getestet auf macOS 26 (Tahoe)
 - **Internetverbindung** & Admin-Rechte
 
-## Hilfe & Dokumentation
+## 📖 Dokumentation
 
-| Thema | Beschreibung |
-| ----- | ------------ |
-| `dothelp` | Hilfe/Dokumentation im Terminal: Aliase, Keybindings, fzf-Shortcuts, Tool-Ersetzungen |
-| [Setup](docs/setup.md) | Schritt-für-Schritt Anleitung |
-| [Anpassung](docs/customization.md) | Starship, Aliase, ZSH anpassen |
-| [Contributing](CONTRIBUTING.md) | Für Entwickler: Architektur, Hooks, Workflow |
+| Befehl | Was es zeigt |
+| ------ | ------------ |
+| `dothelp` | Schnellreferenz: Keybindings, Tool-Ersetzungen, Wartung |
+| `cmds` | Alle Aliase und Funktionen interaktiv durchsuchen |
+| `tldr <tool>` | Vollständige Tool-Doku mit dotfiles-Erweiterungen |
+
+Mehr: [Setup](docs/setup.md) · [Anpassung](docs/customization.md) · [Contributing](CONTRIBUTING.md)
 
 ## Lizenz
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -42,7 +42,6 @@ Das Bootstrap-Skript führt folgende Aktionen in dieser Reihenfolge aus:
 | Aktion | Beschreibung | Bei Fehler |
 | ------ | ------------ | ---------- |
 | Architektur-Check | Prüft ob arm64 (Apple Silicon) | ❌ Exit |
-| Architektur-Check | Prüft ob arm64 (Apple Silicon) | ❌ Exit |
 | macOS-Version-Check | Prüft ob macOS 26+ (Tahoe) installiert ist | ❌ Exit |
 | Netzwerk-Check | Prüft Internetverbindung | ❌ Exit |
 | Schreibrechte-Check | Prüft ob `$HOME` schreibbar ist | ❌ Exit |


### PR DESCRIPTION
- README: Nutzenversprechen an den Anfang, Tool-Ersetzungstabelle dynamisch generiert
- README: Link auf Brewfile (Single Source of Truth), Hilfe-System-Übersicht
- README: Entferne veralteten 'Nach Terminal-Neustart' Block (Bootstrap macht das)
- setup.md: Entferne doppelten Architektur-Check (war statisch + aus Modul generiert)
- CONTRIBUTING.md: Korrigiere Metadaten-Feldbreite 8→12 Zeichen
- readme.sh: Neue generate_tool_replacements_table() Funktion
- setup.sh: Entferne statische erste Tabellenzeile
