### PR TITLE
refactor(fzf): Preview-Window optimieren

### DIFF
--- a/terminal/.config/alias/7z.alias
+++ b/terminal/.config/alias/7z.alias
@@ -43,7 +43,6 @@ alias unrar='7zz x'
     local archive
     archive=$(fd -e zip -e 7z -e rar -e tar -e gz -e xz -e bz2 -e tgz -e tbz2 . "${1:-.}" 2>/dev/null | \
         fzf --preview='zsh -c '\''7zz l -- "$1" 2>/dev/null | head -50'\'' -- {}' \
-            --preview-window='right:60%' \
             --header='Enter=Entpacken │ Ctrl+Y=Pfad kopieren' \
             --bind='ctrl-y:execute-silent(zsh -c '\''echo -n "$1" | pbcopy'\'' -- {})+abort')
 

--- a/terminal/.config/alias/fzf.alias
+++ b/terminal/.config/alias/fzf.alias
@@ -119,7 +119,6 @@ cmds() {
         --prompt='tldr> ' \
         --header='Enter: Befehl übernehmen | Ctrl+S: tldr ↔ Code' \
         --preview "[[ \$FZF_PROMPT == 'code> ' ]] && zsh '$fzf_dir/cmds' preview code {} || zsh '$fzf_dir/cmds' preview tldr {}" \
-        --preview-window='right:50%:wrap' \
         --bind "ctrl-s:transform:[[ \$FZF_PROMPT == 'tldr> ' ]] && echo 'change-prompt(code> )+refresh-preview' || echo 'change-prompt(tldr> )+refresh-preview'")
 
     # Bei Enter: Befehl ins Edit-Buffer (kann editiert/ausgeführt werden)
@@ -174,7 +173,6 @@ vars() {
             else
                 echo "$v"
             fi' \
-        --preview-window='right:50%,wrap' \
         --bind='ctrl-y:execute-silent(n=$(echo {} | cut -d"│" -f1 | xargs); printenv "$n" | pbcopy)+abort')
 
     if [[ -n "$selection" ]]; then

--- a/terminal/.config/fzf/config
+++ b/terminal/.config/fzf/config
@@ -36,7 +36,8 @@
 # Vorschau-Fenster
 # ------------------------------------------------------------
 # Standard für alle Funktionen (kann per --preview-window überschrieben werden)
---preview-window=right:60%:wrap
+# 50% ist optimal für 120-Spalten-Terminals (Kitty: initial_window_width=120c)
+--preview-window=right:50%:wrap
 
 # ------------------------------------------------------------
 # Tastenkürzel (universell)


### PR DESCRIPTION
Optimiert fzf Preview-Window für 120-Spalten-Terminals. Preview-Breite 60%→50%, redundante lokale Einstellungen entfernt (Single Source of Truth).