### PR TITLE
kitty: Font auf MesloLGSDZ wechseln (kleinere Symbole)

### DIFF
--- a/terminal/.config/kitty/kitty.conf
+++ b/terminal/.config/kitty/kitty.conf
@@ -20,12 +20,14 @@ include current-theme.conf
 # ============================================================
 # Font-Auswahl interaktiv: kitten choose-fonts
 # Docs: https://sw.kovidgoyal.net/kitty/conf/#fonts
-
-font_family      MesloLGSDZ Nerd Font Mono
+font_family      MesloLGSDZ Nerd Font
 bold_font        auto
 italic_font      auto
 bold_italic_font auto
 font_size        13.0
+
+# Zeilenhöhe anpassen (Kitty default: 30px)
+modify_font cell_height 4px
 
 # Ligatures: never | cursor | always
 disable_ligatures never


### PR DESCRIPTION
## Änderungen

- Font von `MesloLGS Nerd Font Mono` auf `MesloLGSDZ Nerd Font` gewechselt
- Die DZ-Variante hat kleinere Symbole (z.B. Uhr-Icon)
- Einfache Font-Syntax statt `family="..."`
- `modify_font cell_height 4px` hinzugefügt für passende Zeilenhöhe

## Art der Änderung
- [x] Config-Änderung