### PR TITLE
fix: Alias-Header Konsistenz korrigieren

### DIFF
--- a/terminal/.config/alias/bat.alias
+++ b/terminal/.config/alias/bat.alias
@@ -7,7 +7,7 @@
 # Config      : ~/.config/bat/config
 # Nutzt       : fzf (Theme-Browser)
 # Ersetzt     : cat (mit Syntax-Highlighting)
-# Aliase      : cat, catn, catd
+# Aliase      : cat, catn, catd, bat-theme
 # ============================================================
 
 # Guard   : Nur wenn bat installiert ist

--- a/terminal/.config/alias/brew.alias
+++ b/terminal/.config/alias/brew.alias
@@ -5,7 +5,7 @@
 # Pfad        : ~/.config/alias/brew.alias
 # Docs        : https://docs.brew.sh/Manpage
 # Nutzt       : fzf (Interactive), theme-style (Farben für brew-list)
-# Aliase      : brew-up, brew-list, brew-add, brew-rm
+# Aliase      : brew-up, brew-list, brew-add, brew-rm, maso, masu, mass, masi, masl
 # ============================================================
 # Hinweis     : Kein Guard für brew – ohne Homebrew ist dieses
 #           dotfiles-Repository ohnehin nicht nutzbar.

--- a/terminal/.config/alias/eza.alias
+++ b/terminal/.config/alias/eza.alias
@@ -6,7 +6,7 @@
 # Docs        : https://eza.rocks
 # Config      : ~/.config/eza/theme.yml
 # Ersetzt     : ls (mit Icons und Git-Status)
-# Aliase      : ls, ll, la, lt, lt3, lss, lsn
+# Aliase      : ls, ll, la, lt, lt3, lss, lst
 #
 # Git-Integration:
 #   --git ist standardmäßig aktiv in allen -l Aliase. Performance:

--- a/terminal/.config/alias/rg.alias
+++ b/terminal/.config/alias/rg.alias
@@ -7,7 +7,7 @@
 # Config      : ~/.config/ripgrep/config
 # Nutzt       : fzf (Interactive), bat (Preview)
 # Ersetzt     : grep (schneller, respektiert .gitignore)
-# Aliase      : rg, rgc, rgi
+# Aliase      : rgc, rgi, rga, rgh, rgl, rgn, rgts, rgpy, rgmd, rgsh, rgrb, rggo, rg-live
 # ============================================================
 
 # Guard   : Nur wenn rg installiert ist

--- a/terminal/.config/tealdeer/pages/dotfiles.page.md
+++ b/terminal/.config/tealdeer/pages/dotfiles.page.md
@@ -49,11 +49,11 @@
 
 - cat → bat (mit Syntax-Highlighting):
 
-`cat, catn, catd`
+`cat, catn, catd, bat-theme`
 
 - ls → eza (mit Icons und Git-Status):
 
-`ls, ll, la, lt, lt3, lss, lsn`
+`ls, ll, la, lt, lt3, lss, lst`
 
 - find → fd (schneller, intuitive Syntax):
 
@@ -61,7 +61,7 @@
 
 - grep → rg (schneller, respektiert .gitignore):
 
-`rg, rgc, rgi`
+`rgc, rgi, rga, rgh, rgl, rgn, rgts, rgpy, rgmd, rgsh, rgrb, rggo, rg-live`
 
 - cd → zoxide (lernt häufige Verzeichnisse):
 


### PR DESCRIPTION
## Beschreibung

Korrigiert Inkonsistenzen zwischen den `# Aliase :` Header-Feldern und den tatsächlich definierten Aliase/Funktionen.

## Änderungen

| Datei | Problem | Korrektur |
|-------|---------|-----------|
| `eza.alias` | Tippfehler `lsn` | → `lst` (korrekter Alias-Name) |
| `bat.alias` | Funktion fehlte | `bat-theme` hinzugefügt |
| `brew.alias` | MAS-Aliase fehlten | `maso, masu, mass, masi, masl` hinzugefügt |
| `rg.alias` | Nur 3 von 13 gelistet | Alle 12 Aliase + `rg-live` Funktion |

## Gefunden durch

Systematisches Code-Review: Jede `.alias`-Datei wurde auf Konsistenz zwischen Header und Inhalt geprüft.

## Checkliste

- [x] `generate-docs.sh --generate` ausgeführt
- [x] Pre-Commit-Hooks erfolgreich
- [x] Keine Breaking Changes

## Labels

`bug`, `documentation`