### PR TITLE
fix(shell): Arithmetik-Operationen gegen set -e absichern

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,6 +44,13 @@
 # RICHTIG:
 (( count++ )) || true
 
+# WARUM? Post-Inkrement gibt den ALTEN Wert zurück:
+# count=0 → (( count++ )) evaluiert zu 0 → Exit-Code 1 → set -e bricht ab!
+# Der Trick: || true fängt Exit-Code 1 ab, count wird trotzdem erhöht.
+
+# Bei Vergleichen ist || true NICHT nötig:
+(( count >= max )) && break  # OK – Vergleich gibt true/false
+
 # fzf Preview mit ZSH-Syntax – explizit wrappen:
 --preview='zsh -c '\''[[ -f "$1" ]] && cat "$1"'\'' -- {}'
 

--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -44,7 +44,7 @@ check_shell_syntax() {
             if ! zsh -n "$file" 2>/dev/null; then
                 err "Syntax-Fehler in: ${file#$DOTFILES_DIR/}"
                 zsh -n "$file" 2>&1 | head -3
-                (( errors++ ))
+                (( errors++ )) || true
             fi
         fi
     done
@@ -94,7 +94,7 @@ check_executable_permissions() {
         if [[ ! -x "$file" ]]; then
             err "fzf/$name: Fehlende Execute-Berechtigung"
             err "  → chmod +x $file"
-            (( errors++ ))
+            (( errors++ )) || true
         fi
     done
 
@@ -104,7 +104,7 @@ check_executable_permissions() {
                 "$DOTFILES_DIR"/.github/scripts/health-check.sh; do
         if [[ -f "$file" && ! -x "$file" ]]; then
             err "$(basename $file): Fehlende Execute-Berechtigung"
-            (( errors++ ))
+            (( errors++ )) || true
         fi
     done
 
@@ -130,13 +130,13 @@ check_alias_format() {
         # Header-Block vorhanden?
         if ! head -3 "$file" | grep -q "^# ===="; then
             err "$name: Kein Header-Block"
-            (( errors++ ))
+            (( errors++ )) || true
         fi
 
         # Guard-Check vorhanden?
         if ! grep -q "command -v.*>/dev/null" "$file"; then
             err "$name: Kein Guard-Check"
-            (( errors++ ))
+            (( errors++ )) || true
         fi
     done
 
@@ -218,7 +218,7 @@ check_header_alignment() {
             if grep -q "^# ${fieldname}[[:space:]]*:" "$file" 2>/dev/null; then
                 if ! grep -q "^# ${field}" "$file" 2>/dev/null; then
                     err "$relpath: '# ${fieldname}' falsch eingerückt (Standard: '# ${field}')"
-                    (( errors++ ))
+                    (( errors++ )) || true
                 fi
             fi
         done
@@ -306,13 +306,13 @@ print ""
 
 failed=0
 
-check_shell_syntax || (( failed++ ))
-check_executable_permissions || (( failed++ ))
-check_docs || (( failed++ ))
-check_alias_format || (( failed++ ))
-check_header_alignment || (( failed++ ))
-check_markdown || (( failed++ ))
-check_health || (( failed++ ))
+check_shell_syntax || { (( failed++ )) || true; }
+check_executable_permissions || { (( failed++ )) || true; }
+check_docs || { (( failed++ )) || true; }
+check_alias_format || { (( failed++ )) || true; }
+check_header_alignment || { (( failed++ )) || true; }
+check_markdown || { (( failed++ )) || true; }
+check_health || { (( failed++ )) || true; }
 
 print ""
 print "${C_OVERLAY0}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${C_RESET}"

--- a/.github/scripts/generators/tldr/alias-helpers.sh
+++ b/.github/scripts/generators/tldr/alias-helpers.sh
@@ -20,7 +20,7 @@ extract_alias_names() {
     while IFS= read -r line; do
         if [[ "$line" =~ "^alias ([a-zA-Z0-9_-]+)=" ]]; then
             aliases+=("${match[1]}")
-            (( count++ ))
+            (( count++ )) || true
             (( count >= max )) && break
         fi
     done < "$file"

--- a/.github/scripts/health-check.sh
+++ b/.github/scripts/health-check.sh
@@ -53,9 +53,9 @@ typeset -i warnings=0
 # ------------------------------------------------------------
 # Ausgabe-Helper
 # ------------------------------------------------------------
-pass()    { echo -e "  ${C_GREEN}✔${C_RESET} $*"; (( passed++ )); }
-fail()    { echo -e "  ${C_RED}✖${C_RESET} $*"; (( failed++ )); }
-warn()    { echo -e "  ${C_YELLOW}⚠${C_RESET} $*"; (( warnings++ )); }
+pass()    { echo -e "  ${C_GREEN}✔${C_RESET} $*"; (( passed++ )) || true; }
+fail()    { echo -e "  ${C_RED}✖${C_RESET} $*"; (( failed++ )) || true; }
+warn()    { echo -e "  ${C_YELLOW}⚠${C_RESET} $*"; (( warnings++ )) || true; }
 section() { print ""; print "${C_MAUVE}━━━ ${C_BOLD}$*${C_RESET}${C_MAUVE} ━━━${C_RESET}"; }
 
 # ------------------------------------------------------------


### PR DESCRIPTION
Problem: Post-Inkrement ((count++)) gibt den ALTEN Wert zurück.
Bei count=0 evaluiert das zu 0, was Exit-Code 1 bedeutet.
Mit set -e (ERR_EXIT) bricht das Skript dann ab.

Lösung: || true nach allen ungeschützten Inkrement-Operationen.

Geänderte Dateien:
- health-check.sh: pass(), fail(), warn() Funktionen
- pre-commit: errors++ und failed++ Zähler
- alias-helpers.sh: count++ in extract_alias_names()
- copilot-instructions.md: Dokumentation erweitert

Fixes #203
