### PR TITLE
ci: Homebrew-Caching implementieren

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -67,10 +67,23 @@ jobs:
           fi
           echo "✔ Execute-Berechtigungen OK"
 
+      - name: Homebrew Cache
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/Homebrew
+          key: ${{ runner.os }}-homebrew-${{ hashFiles('setup/Brewfile') }}
+          restore-keys: |
+            ${{ runner.os }}-homebrew-
+
+      - name: Homebrew-Pakete installieren
+        run: |
+          echo "Installiere benötigte Pakete..."
+          brew install tealdeer markdownlint-cli2
+          echo "✔ Pakete installiert"
+
       - name: tealdeer Cache initialisieren
         run: |
           echo "Initialisiere tealdeer Cache für tldr-Patch/Page-Erkennung..."
-          brew install tealdeer
           tldr --update
           echo "✔ tealdeer Cache bereit"
 
@@ -117,7 +130,6 @@ jobs:
       - name: Markdown prüfen
         run: |
           echo "Prüfe Markdown-Dateien..."
-          brew install markdownlint-cli2
           # Config aus terminal/.config/ (wird lokal via Stow verlinkt)
           markdownlint-cli2 --config terminal/.config/markdownlint-cli2/.markdownlint-cli2.jsonc '**/*.md' '#node_modules'
           echo "✔ Markdown OK"


### PR DESCRIPTION
## Zusammenfassung
Implementiert Homebrew-Caching im CI-Workflow zur Reduzierung der Laufzeit.

## Änderungen
- Neuer Cache-Step mit actions/cache@v4 für ~/Library/Caches/Homebrew
- Intelligenter Cache-Key basiert auf setup/Brewfile-Hash
- Beide Pakete (tealdeer, markdownlint-cli2) in einem zentralen Step

## Erwartete Verbesserung
- Cache-Hit: ~10-30 Sekunden schneller
- Cache-Miss: Keine Verschlechterung

## Checkliste
- [x] generate-docs.sh --check erfolgreich
- [x] health-check.sh ohne Fehler
- [x] Pre-Commit Hooks bestanden

Closes #201