### PR TITLE
fix(zshrc): EXTENDED_GLOB explizit setzen für (#q...) Syntax

### DIFF
--- a/terminal/.zshrc
+++ b/terminal/.zshrc
@@ -29,6 +29,13 @@ setopt HIST_REDUCE_BLANKS    # Überflüssige Leerzeichen entfernen
 setopt HIST_SAVE_NO_DUPS     # Keine Duplikate in Datei speichern
 
 # ------------------------------------------------------------
+# Globbing-Optionen
+# ------------------------------------------------------------
+# Extended Glob aktiviert #, ##, ^, ~ als Pattern-Operatoren
+# Benötigt für (#q...) Glob-Qualifier-Syntax (z.B. bei compinit)
+setopt EXTENDED_GLOB
+
+# ------------------------------------------------------------
 # Completion-System initialisieren
 # ------------------------------------------------------------
 # Tab-Vervollständigung mit täglicher Cache-Erneuerung


### PR DESCRIPTION
Der compinit Glob-Qualifier (#qN.mh+24) erfordert laut ZSH-Dokumentation explizit die Option EXTENDED_GLOB.

**Änderungen:**
- Neuer Abschnitt 'Globbing-Optionen' mit setopt EXTENDED_GLOB
- Dokumentierende Kommentare zu #, ##, ^, ~ Pattern-Operatoren

**Validierung:** Health-Check ✔ | Pre-Commit ✔ | Keine Seiteneffekte

Fixes #197