### PR TITLE
fix(fzf): Validierung für Zeilennummern in preview

### DIFF
--- a/terminal/.config/fzf/preview
+++ b/terminal/.config/fzf/preview
@@ -97,7 +97,8 @@ _preview_file() {
     # ----------------------------------------------------------------
     # Text/Code-Vorschau (bat/cat)
     # ----------------------------------------------------------------
-    if [[ -n "$line" ]] && command -v bat >/dev/null 2>&1; then
+    # Validierung: $line muss positive Ganzzahl sein (mindestens 1)
+    if [[ -n "$line" && "$line" =~ ^[1-9][0-9]*$ ]] && command -v bat >/dev/null 2>&1; then
         bat --color=always --highlight-line "$line" -- "$file" 2>/dev/null || cat -- "$file"
     elif command -v bat >/dev/null 2>&1; then
         bat --style=numbers --color=always -- "$file" 2>/dev/null || cat -- "$file"


### PR DESCRIPTION
## Beschreibung

Fügt defensive Validierung für den Zeilennummer-Parameter in `terminal/.config/fzf/preview` hinzu.

## Änderungen

- Validiert `$line` mit Regex `^[1-9][0-9]*$` (nur positive Ganzzahlen ≥1)
- Ungültige Werte führen zu Vorschau ohne Hervorhebung statt Fehlermeldungen

## Motivation

`bat --highlight-line` gibt Fehlermeldungen bei ungültigen Werten aus:
- `"abc"` → `[bat error]: invalid digit found in string`
- `"-5"` → `error: unexpected argument '-5' found`
- `""` → `[bat error]: Empty line range`

Die Validierung verhindert diese Fehler defensiv, obwohl die aktuellen Aufrufer (z.B. `rg-live`) nur valide Werte liefern.

## Checkliste

- [x] `generate-docs` ausgeführt (nicht betroffen)
- [x] `health-check` läuft durch
- [x] Manuell getestet (`rg-live`, direkter Preview-Aufruf)

## Art der Änderung

- [x] Bugfix (non-breaking)
- [ ] Feature (non-breaking)
- [ ] Breaking Change

Fixes #200