### PR TITLE
fix(fzf): entferne local außerhalb von Funktionen

### DIFF
--- a/terminal/.config/fzf/action
+++ b/terminal/.config/fzf/action
@@ -19,8 +19,8 @@ case "${1:-}" in
     edit)
         # Datei im Editor öffnen (optional mit Zeile)
         shift
-        local file="$1"
-        local line="${2:-}"
+        file="$1"
+        line="${2:-}"
         if [[ -n "$line" ]]; then
             ${EDITOR:-vim} -- "$file" "+$line"
         else


### PR DESCRIPTION
## Zusammenfassung

Entfernt das `local`-Keyword aus dem `action`-Script, da es außerhalb von Funktionen semantisch irreführend ist.

## Was wurde geändert?

```diff
- local file="$1"
- local line="${2:-}"
+ file="$1"
+ line="${2:-}"
```

## Warum ist das wichtig?

Das Wort `local` in Programmiersprachen bedeutet: *"Diese Variable existiert nur hier drinnen und verschwindet danach."*

**Das Problem:** Das `action`-Script ist kein "Drinnen" – es ist ein eigenständiges Programm. `local` zu verwenden ist wie ein Schild "Nur für Mitarbeiter" an einer Tür zu hängen, obwohl das Gebäude nur einen Raum hat.

**Funktional** ändert sich nichts – das Script lief vorher und läuft nachher identisch. Aber der Code sagt jetzt das, was er tut: einfache Variablenzuweisungen ohne falsche Versprechen.

## Checkliste

- [x] `generate-docs` ausgeführt (keine Änderung nötig)
- [x]
Entfernt das `local`-Keyword aus dem `action`-Script, da es außerhalb von Funktionen semantisch irreführend isg


## Was wurde geändert?

```diff
- local file="$1"
- local line="${2:-}"
+ file="$1"
+ line="${2:-}"
al 
```diff
- local fil)
- local fr-- local line="${2 ~+ file="$1"
+ line=\ #+ line="${2e```