### PR TITLE
fix(restore): Explizite Return-Werte in restore_single_file()

### DIFF
--- a/setup/restore.sh
+++ b/setup/restore.sh
@@ -100,6 +100,7 @@ is_dotfiles_symlink() {
 
 # ------------------------------------------------------------
 # Symlink entfernen und ggf. Backup wiederherstellen
+# Rückgabe: 0 = wiederhergestellt, 1 = übersprungen
 # ------------------------------------------------------------
 restore_single_file() {
     local target="$1"
@@ -114,10 +115,10 @@ restore_single_file() {
         log "Entfernt: $target"
     elif [[ -L "$target" ]]; then
         warn "Übersprungen (fremder Symlink): $target"
-        return 0
+        return 1
     elif [[ -e "$target" ]]; then
         warn "Übersprungen (keine Symlink): $target"
-        return 0
+        return 1
     fi
 
     # Backup wiederherstellen wenn vorhanden
@@ -140,15 +141,21 @@ restore_single_file() {
             fi
 
             ok "Wiederhergestellt: $target"
+            return 0
         else
             warn "Backup nicht gefunden: $backup_path"
+            return 1
         fi
     elif [[ "$type" == "symlink" && "$symlink_target" != "null" && -n "$symlink_target" ]]; then
         # Fremden Symlink wiederherstellen
         /bin/mkdir -p "$(dirname "$target")"
         /bin/ln -s "$symlink_target" "$target"
         ok "Symlink wiederhergestellt: $target -> $symlink_target"
+        return 0
     fi
+
+    # Kein Backup nötig/vorhanden
+    return 1
 }
 
 # ------------------------------------------------------------


### PR DESCRIPTION
## Zusammenfassung

Fixt fehlende Return-Werte in `restore_single_file()`, wodurch die Summary-Statistik am Ende der Wiederherstellung korrekte Zahlen anzeigt.

## Änderungen

- `restore_single_file()` gibt jetzt explizit `0` (wiederhergestellt) oder `1` (übersprungen) zurück
- Alle Pfade haben eindeutige Return-Werte:
  - `return 0`: Erfolgreiche Wiederherstellung (Datei/Verzeichnis/Symlink)
  - `return 1`: Übersprungen (fremder Symlink, existiert bereits, Backup nicht gefunden)

## Art der Änderung

- [x] 🐛 Bug-Fix (behebt ein Problem)

## Checkliste

- [x] `./scripts/generate-docs.sh --check` (oder Docs generiert)
- [x] `./scripts/health-check.sh` läuft fehlerfrei
- [x] Pre-Commit Hooks bestanden

## Verwandte Issues

Fixes #215