### PR TITLE
fix(yazi): Ändere marker_marked von Teal zu Lavender

### DIFF
--- a/terminal/.config/tealdeer/pages/catppuccin.page.md
+++ b/terminal/.config/tealdeer/pages/catppuccin.page.md
@@ -22,7 +22,7 @@
 `kitty: ~/.config/kitty/current-theme.conf (header)`
 `lazygit: ~/.config/lazygit/config.yml (mauve+selection+header)`
 `starship: ~/.config/starship/starship.toml (palettes+header)`
-`yazi: ~/.config/yazi/theme.toml (mauve+text+header)`
+`yazi: ~/.config/yazi/theme.toml (mauve+text+marker+header)`
 `zsh-syntax: ~/.config/zsh/catppuccin_mocha-* (header)`
 
 - Manuell konfiguriert (basierend auf catppuccin.com/palette):

--- a/terminal/.config/theme-style
+++ b/terminal/.config/theme-style
@@ -26,7 +26,7 @@
 #   lazygit      | ~/.config/lazygit/config.yml       | github.com/catppuccin/lazygit                 | upstream+mauve+selection+header
 #   starship     | ~/.config/starship/starship.toml   | github.com/catppuccin/starship                | upstream-palettes+header
 #   tealdeer     | ~/.config/tealdeer/config.toml     | manual                                        | manual
-#   yazi         | ~/.config/yazi/theme.toml          | github.com/catppuccin/yazi                    | upstream+mauve+text+header
+#   yazi         | ~/.config/yazi/theme.toml          | github.com/catppuccin/yazi                    | upstream+mauve+text+marker+header
 #   zsh-syntax   | ~/.config/zsh/catppuccin_mocha-*   | github.com/catppuccin/zsh-syntax-highlighting | upstream+header
 #   Terminal.app | ~/dotfiles/setup/                  | github.com/catppuccin/Terminal.app            | upstream
 #   Xcode        | ~/dotfiles/setup/                  | github.com/catppuccin/xcode                   | upstream+header
@@ -192,8 +192,7 @@ typeset -gx RGB_SURFACE1="69;71;90"
 #   marker_selected=#cba6f7       # Mauve (Auswahl-Indikator)
 #   marker_copied=#a6e3a1         # Green (Kopiert)
 #   marker_cut=#f38ba8            # Red (Ausgeschnitten)
-#   # HINWEIS: marker_marked verwendet Teal #94E2D5 (Upstream)
-#   # Issue #223 trackt Änderung zu Lavender für Konsistenz
+#   marker_marked=#b4befe         # Lavender (Multi-Select, wie fzf)
 #
 # eza:
 #   directory=#cba6f7             # Mauve (wie fzf/yazi)

--- a/terminal/.config/yazi/theme.toml
+++ b/terminal/.config/yazi/theme.toml
@@ -19,7 +19,7 @@ find_position = { fg = "#f5c2e7", bg = "reset", italic = true }
 
 marker_copied   = { fg = "#a6e3a1", bg = "#a6e3a1" }
 marker_cut      = { fg = "#f38ba8", bg = "#f38ba8" }
-marker_marked   = { fg = "#94e2d5", bg = "#94e2d5" }
+marker_marked   = { fg = "#b4befe", bg = "#b4befe" }
 marker_selected = { fg = "#cba6f7", bg = "#cba6f7" }
 
 count_copied   = { fg = "#1e1e2e", bg = "#a6e3a1" }


### PR DESCRIPTION
## Beschreibung

Ändert `marker_marked` in yazi von **Teal** (`#94e2d5`) zu **Lavender** (`#b4befe`) für Konsistenz mit fzf Multi-Select Markern.

## Art der Änderung

- [x] Bugfix (nicht-breaking Change, der ein Issue behebt)

## Checkliste

### Allgemein

- [x] Mein Code folgt den Stil-Guidelines dieses Projekts
- [x] Pre-Commit Hooks laufen ohne Fehler durch
- [x] `./scripts/health-check.sh` zeigt keine Fehler

### Bei Theme-/Config-Änderungen (`.config/*`)

- [x] Theme-Quellen-Tabelle in `theme-style` geprüft (Zeile 13-42)
- [x] Status aktualisiert: `upstream+mauve+text+marker+header`
- [x] Semantische Farben eingehalten (Lavender für Multi-Select Marker)

## Zusammenhängende Issues

Schließt #223

## Änderungen

| Datei | Änderung |
|-------|----------|
| `terminal/.config/yazi/theme.toml` | `marker_marked`: `#94e2d5` → `#b4befe` |
| `terminal/.config/theme-style` | Status + Dokumentation aktualisiert |
| `terminal/.config/tealdeer/pages/catppuccin.page.md` | Auto-generiert |

## Semantische Begründung

| Element | Farbe | Bedeutung |
|---------|-------|-----------|
| `marker_selected` | Mauve | Aktuelle Cursor-Position |
| `marker_copied` | Green | Erfolgreich kopiert |
| `marker_cut` | Red | Zum Ausschneiden markiert |
| `marker_marked` | **Lavender** | Multi-Select (wie fzf) |