### PR TITLE
fix(lazygit): Korrigiere Farbkommentar Overlay0 → Subtext0

### DIFF
--- a/terminal/.config/lazygit/config.yml
+++ b/terminal/.config/lazygit/config.yml
@@ -18,7 +18,7 @@ gui:
       - '#cba6f7' # Mauve
       - bold
     inactiveBorderColor:
-      - '#a6adc8' # Overlay0
+      - '#a6adc8' # Subtext0
     optionsTextColor:
       - '#89b4fa' # Blue
     selectedLineBgColor:


### PR DESCRIPTION
## Summary

- Korrigiert falschen Farbkommentar in lazygit config
- `#a6adc8` ist laut offizieller Catppuccin-Palette **Subtext0**, nicht Overlay0
- Der Hex-Wert selbst war korrekt (Upstream-konform), nur der Kommentar war falsch

## Analyse

| Farbe | Hex | Dokumentiert als |
|-------|-----|------------------|
| **Subtext0** | `#A6ADC8` | Hinweise, Metadaten |
| Overlay0 | `#6C7086` | Deaktiviert, Kommentare |

Referenz: https://catppuccin.com/palette

## Änderung

```diff
inactiveBorderColor:
-  - '#a6adc8' # Overlay0
+  - '#a6adc8' # Subtext0
```

## Test plan

- [x] Pre-Commit Hook: Alle 7 Checks bestanden
- [x] Hex-Wert gegen offizielle Catppuccin-Palette verifiziert
- [x] Keine Änderung an theme-style nötig (Palette dort korrekt)
