### PR TITLE
fix(dotfiles.alias): Guard-Scope auf tldr-abhängige Aliase reduziert

### DIFF
--- a/terminal/.config/alias/dotfiles.alias
+++ b/terminal/.config/alias/dotfiles.alias
@@ -4,20 +4,22 @@
 # Zweck       : Zentrale Einstiegspunkte für dotfiles-Hilfe
 # Pfad        : ~/.config/alias/dotfiles.alias
 # Docs        : https://github.com/tshofmann/dotfiles
-# Nutzt       : tldr (tealdeer)
+# Nutzt       : tldr (für dothelp), stow (für dotstow)
 # Aliase      : dothelp, dh, dothealth, dotdocs, dotstow
 # ============================================================
+# Hinweis     : Kein globaler Guard – nur dothelp/dh benötigen tldr
+# ============================================================
 
-# Guard   : tldr (tealdeer) muss installiert sein für dothelp
-if ! command -v tldr >/dev/null 2>&1; then
-    return 0
+# ------------------------------------------------------------
+# tldr-abhängige Aliase (nur wenn tealdeer installiert)
+# ------------------------------------------------------------
+if command -v tldr >/dev/null 2>&1; then
+    # Schnellreferenz anzeigen (zeigt tldr dotfiles)
+    alias dothelp='tldr dotfiles'
+
+    # Kurzform für dothelp
+    alias dh='dothelp'
 fi
-
-# Schnellreferenz anzeigen (zeigt tldr dotfiles)
-alias dothelp='tldr dotfiles'
-
-# Kurzform für dothelp
-alias dh='dothelp'
 
 # ------------------------------------------------------------
 # Dotfiles Wartung

--- a/terminal/.config/tealdeer/pages/dotfiles.page.md
+++ b/terminal/.config/tealdeer/pages/dotfiles.page.md
@@ -3,7 +3,7 @@
 > Dotfiles mit Catppuccin-Theme und modernen CLI-Tools.
 > Mehr Informationen: <https://github.com/tshofmann/dotfiles>
 
-- dotfiles: Nutzt `tldr (tealdeer)`
+- dotfiles: Nutzt `tldr (für dothelp), stow (für dotstow)`
 
 - Diese Hilfe (Schnellreferenz):
 


### PR DESCRIPTION
## Beschreibung

Der globale Guard in `dotfiles.alias` blockierte **alle 5 Aliase** wenn `tldr` nicht installiert war, obwohl nur `dothelp` und `dh` tatsächlich `tldr` benötigen.

### Änderungen

- **Guard-Logik invertiert**: Nur `dothelp`/`dh` werden bedingt definiert
- **Immer verfügbar**: `dothealth`, `dotdocs`, `dotstow` sind jetzt unabhängig von tldr
- **Header erweitert**: `Nutzt : tldr (für dothelp), stow (für dotstow)`
- **Dokumentation**: Erklärender Hinweis-Kommentar zur Architekturentscheidung

## Art der Änderung

- [x] 🐛 Bugfix

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Bei neuen Tools: Guard-Check vorhanden

## Testplan

| Test | Status |
|------|--------|
| Ohne tldr: `dothealth`, `dotdocs`, `dotstow` funktionieren | ✔ |
| Ohne tldr: `dothelp` und `dh` sind nicht definiert | ✔ |
| Mit tldr: Alle 5 Aliase funktionieren | ✔ |
| ZSH-Syntax (`zsh -n`) | ✔ |
| Pre-Commit Hook | ✔ |
| tldr-Patch generiert korrekt | ✔ |

## Zusammenhängende Issues

Closes #232