### PR TITLE
fix: gh-repo() Query-Parameter an fzf übergeben

### DIFF
--- a/terminal/.config/alias/gh.alias
+++ b/terminal/.config/alias/gh.alias
@@ -97,10 +97,10 @@ if command -v fzf >/dev/null 2>&1; then
 
     # Repo Browser(suche?) – Enter=Klonen, Ctrl+O=Browser
     gh-repo() {
-        local repo
         local query="${1:-}"
-        repo=$(gh repo list --limit 30 ${query:+--source} | \
-            fzf --ansi \
+        local repo
+        repo=$(gh repo list --limit 30 | \
+            fzf --ansi --query="$query" \
                 --preview 'gh repo view {1}' \
                 --header='Enter: Klonen | Ctrl+O: Browser' \
                 --bind 'ctrl-o:execute-silent(gh repo view {1} --web)' | \


### PR DESCRIPTION
## Beschreibung

`gh-repo()` übergibt den optionalen Suchparameter nicht an fzf. Stattdessen wird er als `--source`-Flag an `gh repo list` weitergegeben, was "nur Nicht-Forks anzeigen" bedeutet – hat nichts mit Suche zu tun.

**Vorher:** `gh repo list --limit 30 ${query:+--source}` → Query wird zu `--source` Flag
**Nachher:** `gh repo list --limit 30 | fzf --query="$query"` → Query filtert in fzf

Außerdem wurden die `local`-Deklarationen in die gleiche Reihenfolge gebracht wie bei allen anderen `gh-*` Funktionen (`query` vor `repo`).

## Art der Änderung

- [x] 🐛 Bugfix

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Bei neuen Tools: Guard-Check vorhanden

## Zusammenhängende Issues

Fixes #241
