### PR TITLE
fix: macOS-spezifische Pfade und Befehle plattformübergreifend machen

### DIFF
--- a/.github/scripts/generators/tldr/parsers.sh
+++ b/.github/scripts/generators/tldr/parsers.sh
@@ -12,10 +12,17 @@
 # Helper: Prüfe ob offizielle tldr-Seite existiert
 # ------------------------------------------------------------
 # Prüft im tealdeer-Cache ob eine offizielle Seite vorhanden ist
-# Cache-Pfad: ~/Library/Caches/tealdeer/tldr-pages/pages.{lang}/{platform}/
+# Cache-Pfad: macOS  → ~/Library/Caches/tealdeer/tldr-pages/
+#             Linux  → ${XDG_CACHE_HOME:-~/.cache}/tealdeer/tldr-pages/
 has_official_tldr_page() {
     local tool_name="$1"
-    local cache_base="${HOME}/Library/Caches/tealdeer/tldr-pages"
+    local cache_base
+
+    # Plattform-spezifischer Cache-Pfad (tealdeer nutzt OS-Konventionen)
+    case "$OSTYPE" in
+        darwin*) cache_base="${HOME}/Library/Caches/tealdeer/tldr-pages" ;;
+        *)       cache_base="${XDG_CACHE_HOME:-$HOME/.cache}/tealdeer/tldr-pages" ;;
+    esac
 
     # Prüfe in allen Sprachen und Plattformen
     for lang_dir in "$cache_base"/pages.*(N); do

--- a/setup/restore.sh
+++ b/setup/restore.sh
@@ -75,11 +75,11 @@ get_manifest_count() {
 # Prüft ob ein Pfad ein Symlink ins dotfiles-Repo ist
 # ------------------------------------------------------------
 is_dotfiles_symlink() {
-    local path="$1"
-    [[ -L "$path" ]] || return 1
+    local filepath="$1"
+    [[ -L "$filepath" ]] || return 1
 
     local target
-    target=$(/usr/bin/readlink "$path" 2>/dev/null) || return 1
+    target=$(/usr/bin/readlink "$filepath" 2>/dev/null) || return 1
 
     # Prüfe verschiedene Varianten
     [[ "$target" == "${DOTFILES_DIR}/"* ]] && return 0
@@ -87,7 +87,7 @@ is_dotfiles_symlink() {
 
     # Auflösen für relative Symlinks (ZSH :A modifier = realpath)
     local resolved
-    resolved="${path:A}"
+    resolved="${filepath:A}"
     [[ "$resolved" == "${DOTFILES_DIR}/"* ]] && return 0
 
     return 1


### PR DESCRIPTION
## Beschreibung

Behebt zwei macOS-spezifische Stellen, die auf Linux fehlschlagen oder falsche Ergebnisse liefern, plus einen dabei entdeckten ZSH-Bug mit der Spezialvariable `$path`.

### Finding 1: `has_official_tldr_page()` — macOS-Cache-Pfad

Der tealdeer-Cache-Pfad war auf `~/Library/Caches/` hardcodiert. Auf Linux nutzt tealdeer `${XDG_CACHE_HOME:-~/.cache}/tealdeer/`. Ohne Fix würden auf Linux **alle** Tools fälschlich als `.page.md` generiert.

**Fix:** `$OSTYPE`-basierte Fallunterscheidung (darwin → Library/Caches, sonst → XDG).

### Finding 2: `_get_permissions()` — BSD-`stat` Syntax

`stat -f \"%OLp\"` ist BSD-spezifisch. Auf Linux (GNU coreutils) lautet der Befehl `stat -c \"%a\"`. Der Fallback `644` verschleierte, dass auf Linux immer falsche Permissions ins Manifest geschrieben wurden.

**Fix:** `is_macos()`-basierte Verzweigung für BSD vs GNU stat.

### Bonus-Fix: ZSH-Spezialvariable `$path`

Beim Testen entdeckt: `local path=\"$1\"` in 4 Funktionen (`_get_file_type`, `_is_dotfiles_symlink`, `_get_permissions`, `is_dotfiles_symlink`) schattet die ZSH-Spezialvariable `$path` (tied to `$PATH`), wodurch `$PATH` auf den Dateinamen gesetzt wird. Externe Befehle (wie `stat`) wurden dadurch nicht gefunden.

**Fix:** Alle `local path` → `local filepath` umbenannt.

## Art der Änderung

- [x] 🐛 Bugfix

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler (122/122)
- [x] Pre-Commit-Hook: 7/7 bestanden

## Qualifizierung

### Finding 1: `has_official_tldr_page()`
| Test | Ergebnis |
|---|---|
| macOS: bat (offizielle Seite) | ✔ Gefunden |
| macOS: nonexistent-tool (keine Seite) | ✔ Korrekt nicht gefunden |
| macOS: Cache-Verzeichnis existiert | ✔ ~/Library/Caches/tealdeer/tldr-pages |
| Linux-Simulation: XDG-Pfad | ✔ ~/.cache/tealdeer/tldr-pages |
| Linux-Simulation: XDG_CACHE_HOME Override | ✔ /custom/cache/tealdeer/tldr-pages |

### Finding 2: `_get_permissions()` + `local path`-Bug
| Test | Vorher | Nachher |
|---|---|---|
| macOS stat 755 | ❌ 644 (PATH kaputt) | ✔ 755 |
| macOS stat 600 | ❌ 644 (PATH kaputt) | ✔ 600 |
| Nicht-existierende Datei | ✔ 644 (Fallback) | ✔ 644 (Fallback) |

### Root Cause `local path`:
```zsh
# ZSH: $path ist Spezialvariable (tied to $PATH)
local path=\"/tmp/foo\"  # → $PATH wird \"/tmp/foo\"!
stat ...               # → \"command not found\" → Fallback 644
```

## Zusammenhängende Issues

Fixes #243"