### PR TITLE
fix(stow): stderr nicht mehr unterdrücken – Fehler werden strukturiert geloggt

### DIFF
--- a/setup/modules/stow.sh
+++ b/setup/modules/stow.sh
@@ -156,9 +156,11 @@ run_stow() {
     else
         warn "Stow hatte Probleme (Exit-Code: $stow_rc):"
         # Jede Zeile einzeln loggen für konsistente Formatierung
-        local line
+        # warn() nutzt print -P: % vor Ausgabe escapen, um Prompt-Escapes zu vermeiden
+        local line safe_line
         while IFS= read -r line; do
-            [[ -n "$line" ]] && warn "  $line"
+            safe_line=${line//\%/%%}
+            [[ -n "$safe_line" ]] && warn "  $safe_line"
         done <<< "$stow_output"
         # Stash trotzdem wiederherstellen bei Fehler
         _restore_stashed_changes


### PR DESCRIPTION
## Beschreibung

`stow --adopt -R ... 2>/dev/null` schluckte **alle** Fehlermeldungen – Symlink-Konflikte, fehlende Packages und Berechtigungsfehler waren komplett unsichtbar. `2>/dev/null` verschleierte den tatsächlichen Exit-Code-Pfad nicht (stow gab rc≠0 zurück), aber die Fehlerbeschreibung ging verloren.

### Vorher
```
⚠ Stow hatte Probleme – prüfe manuell
```
Keinerlei Hinweis *was* das Problem war.

### Nachher
```
⚠ Stow hatte Probleme (Exit-Code: 2):
⚠   stow: ERROR: The stow directory dotfiles does not contain package xyz
```
Strukturierte Ausgabe mit Exit-Code und jeder Fehlerzeile einzeln via `warn()`.

### Implementierung

- stderr+stdout werden per `$()` mit `2>&1` in Variable aufgefangen
- Exit-Code separat via `$?` erfasst
- Bei rc=0: normaler Erfolgspfad (unverändert)
- Bei rc≠0: Fehleroutput zeilenweise via `warn()` geloggt, leere Zeilen gefiltert

## Art der Änderung

- [x] 🐛 Bugfix

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler (122/122)
- [x] Pre-Commit-Hook: 7/7 bestanden

## Qualifizierung

| Test | Ergebnis |
|---|---|
| Gültige Packages (`terminal editor`) → rc=0 | ✔ |
| Ungültiges Package → rc=2 | ✔ |
| Fehlermeldung wird erfasst statt geschluckt | ✔ |
| Leere Zeilen werden gefiltert | ✔ |
| stdout+stderr landen in Variable | ✔ |

### Andere `2>/dev/null` in stow.sh (bewusst beibehalten)

| Zeile | Kommando | Grund |
|---|---|---|
| 47 | `git status --porcelain 2>/dev/null` | Erkennung ob Git-Repo vorhanden |
| 60/66 | `git stash list 2>/dev/null` | Stash-Zähler, Fehler via Logik abgefangen |
| 162 | `git diff HEAD --quiet 2>/dev/null` | Nur Bool-Check, kein Info-Verlust |

## Zusammenhängende Issues

Fixes #245