### PR TITLE
fix(starship): docker_context in Format-String aufnehmen und cmd_duration Style aktivieren

### DIFF
--- a/terminal/.config/starship/starship.toml
+++ b/terminal/.config/starship/starship.toml
@@ -28,6 +28,7 @@ $kotlin\
 $haskell\
 $python\
 [](fg:green bg:sapphire)\
+$docker_context\
 $conda\
 [](fg:sapphire bg:lavender)\
 $time\
@@ -168,8 +169,8 @@ vimcmd_visual_symbol = '[❮](bold fg:yellow)'
 
 [cmd_duration]
 show_milliseconds = true
-format = " in $duration "
-style = "bg:lavender"
+format = " in [$duration]($style) "
+style = "fg:lavender"
 disabled = false
 show_notifications = true
 min_time_to_notify = 45000


### PR DESCRIPTION
## Beschreibung

Starship-Konfiguration hatte zwei Inkonsistenzen:

1. **`[docker_context]`** war mit `bg:sapphire` konfiguriert, aber `$docker_context` fehlte im expliziten `format`-String → Modul wurde nie gerendert. Jetzt im sapphire-Segment zwischen `$python` und `$conda` eingefügt.

2. **`[cmd_duration]`** hatte `style = "bg:lavender"`, aber `format = " in $duration "` referenzierte `$style` nicht → Style war wirkungslos. Jetzt `[$duration]($style)` und Style auf `fg:lavender` geändert (da cmd_duration außerhalb der Powerline-Leiste steht – `bg` würde einen isolierten farbigen Block erzeugen).

## Art der Änderung

- [x] 🐛 Bugfix

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler (122/122)
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Bei neuen Tools: Guard-Check vorhanden

### Bei Theme-/Config-Änderungen (`.config/*`)

- [x] Theme-Quellen-Tabelle in `theme-style` geprüft (Zeile 13-42)
- [x] Status aktualisiert falls Upstream-Abweichung (`upstream+X`)
- [x] Semantische Farben eingehalten (siehe CONTRIBUTING.md → Theming)

## Zusammenhängende Issues

Fixes #244

## Validierung

- TOML-Syntax: ✔ (Python tomli Parser)
- Format-String Module-Reihenfolge verifiziert: `os → username → directory → git_branch → git_status → [c/rust/golang/nodejs/php/java/kotlin/haskell/python] → docker_context → conda → time → cmd_duration → line_break → character`
- Farbübergangs-Kette intakt: red → peach → yellow → green → sapphire → lavender
- Health-Check: 122/122
- Pre-Commit: 7/7