### PR TITLE
docs: Clipboard-Überschreibung im Health-Check als bewusst dokumentieren

### DIFF
--- a/.github/scripts/health-check.sh
+++ b/.github/scripts/health-check.sh
@@ -449,6 +449,7 @@ fi
 rm -f "$test_file"
 
 # clip/clippaste: Roundtrip-Test (nur wenn Display vorhanden)
+# HINWEIS: Überschreibt den aktuellen Clipboard-Inhalt – unvermeidbar für einen echten Roundtrip-Test.
 if [[ "$_PLATFORM_OS" == "macos" ]]; then
   local test_str="health-check-$$"
   if echo "$test_str" | clip && [[ "$(clippaste)" == "$test_str" ]]; then


### PR DESCRIPTION
## Beschreibung

Der Health-Check führt einen Roundtrip-Test für `clip`/`clippaste` durch, der zwangsläufig den aktuellen Clipboard-Inhalt überschreibt. Dies ist eine bewusste Konsequenz – ein echter Funktionstest ist ohne Clipboard-Zugriff nicht möglich.

Dieser PR fügt einen `HINWEIS`-Kommentar hinzu, damit zukünftige Contributors das Verhalten nicht als Bug behandeln.

Ergebnis der Deep-Analyse (Finding M1).

## Art der Änderung

- [ ] 🐛 Bugfix
- [ ] ✨ Neues Feature
- [x] 📝 Dokumentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Konfiguration/Maintenance

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [ ] Neue Aliase/Funktionen haben Beschreibungskommentare
- [ ] Bei neuen Tools: Guard-Check vorhanden

## Zusammenhängende Issues

Bezieht sich auf die Deep-Analyse (Finding M1 – Clipboard-Überschreibung).