### PR TITLE
feat: Ersetzt-Header-Feld in allen Alias-Dateien konsistent setzen

### DIFF
--- a/.github/scripts/check-alias-format.sh
+++ b/.github/scripts/check-alias-format.sh
@@ -56,8 +56,8 @@ check_alias_format() {
             (( errors++ )) || true
         fi
 
-        # 3. Pflichtfelder im Header (CONTRIBUTING.md: Zweck, Pfad, Docs)
-        for field in Zweck Pfad Docs; do
+        # 3. Pflichtfelder im Header (CONTRIBUTING.md: Zweck, Pfad, Docs, Ersetzt)
+        for field in Zweck Pfad Docs Ersetzt; do
             if ! grep -q "^# ${field}[[:space:]]" "$file"; then
                 err "$name: Pflichtfeld '${field}' fehlt im Header"
                 (( errors++ )) || true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -294,7 +294,7 @@ Alle Shell-Dateien (`.alias`, `.sh`, `.zsh*`) beginnen mit einem standardisierte
 | `Docs` | ✅ | Link zur offiziellen Dokumentation |
 | `Generiert` | ⚪ | Welche Doku wird aus dieser Datei generiert? |
 | `Nutzt` | ⚪ | Abhängigkeiten zu anderen Tools (fzf, bat, etc.) |
-| `Ersetzt` | ⚪ | Welchen Befehl ersetzt das Tool? (cat, find, ls) |
+| `Ersetzt` | ✅ | Welchen Befehl ersetzt das Tool? (`-` wenn keinen) |
 | `Kommandos` | ⚪ | Extern registrierte Befehle (z.B. via `tool init zsh`) |
 | `Aliase` | ⚪ | Liste der **in dieser Datei** definierten Aliase/Funktionen |
 | `Aufruf` | ⚪ | Für Skripte: Wie wird es aufgerufen? |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@
 | `find` | `fd` | schneller, intuitive Syntax |
 | `grep` | `rg` | schneller, respektiert .gitignore |
 | `ls` | `eza` | mit Icons und Git-Status |
+| `neofetch` | `fastfetch` | schnellere System-Übersicht |
+| `top, htop` | `btop` | moderner Ressourcen-Monitor |
+| `unrar` | `7z` | 7-Zip als schnellerer Ersatz |
 
 Dazu: **[Catppuccin Mocha](https://catppuccin.com/) Theme** überall, **Hilfe im Terminal** via `dothelp`, **fzf-Integration** für alles.
 

--- a/terminal/.config/alias/7z.alias
+++ b/terminal/.config/alias/7z.alias
@@ -5,7 +5,7 @@
 # Pfad        : ~/.config/alias/7z.alias
 # Docs        : https://7-zip.org/
 # Nutzt       : fzf (7zf), fd (7zf)
-# Ersetzt     : -
+# Ersetzt     : unrar (7-Zip als schnellerer Ersatz)
 # Aliase      : 7za, 7zx, 7zl, 7zt, unrar, 7zf
 # ============================================================
 

--- a/terminal/.config/alias/brew.alias
+++ b/terminal/.config/alias/brew.alias
@@ -5,6 +5,7 @@
 # Pfad        : ~/.config/alias/brew.alias
 # Docs        : https://docs.brew.sh/Manpage
 # Nutzt       : fzf (Interactive), theme-style (Farben für brew-list)
+# Ersetzt     : -
 # Aliase      : brew-up, brew-list, brew-add, brew-rm, maso, masu, mass, masi, masl
 # ============================================================
 # Hinweis     : Kein Guard für brew – ohne Homebrew ist dieses

--- a/terminal/.config/alias/btop.alias
+++ b/terminal/.config/alias/btop.alias
@@ -5,6 +5,7 @@
 # Pfad        : ~/.config/alias/btop.alias
 # Docs        : https://github.com/aristocratos/btop
 # Config      : ~/.config/btop/btop.conf (Catppuccin Mocha Theme)
+# Ersetzt     : top, htop (moderner Ressourcen-Monitor)
 # Aliase      : top, htop
 # ============================================================
 

--- a/terminal/.config/alias/dotfiles.alias
+++ b/terminal/.config/alias/dotfiles.alias
@@ -5,6 +5,7 @@
 # Pfad        : ~/.config/alias/dotfiles.alias
 # Docs        : https://github.com/tshofmann/dotfiles
 # Nutzt       : tldr (für dothelp), stow (für dotstow)
+# Ersetzt     : -
 # Aliase      : dothelp, dh, dothealth, dotdocs, dotstow
 # ============================================================
 # Hinweis     : Kein globaler Guard – nur dothelp/dh benötigen tldr

--- a/terminal/.config/alias/fastfetch.alias
+++ b/terminal/.config/alias/fastfetch.alias
@@ -5,6 +5,7 @@
 # Pfad        : ~/.config/alias/fastfetch.alias
 # Docs        : https://github.com/fastfetch-cli/fastfetch
 # Config      : ~/.config/fastfetch/config.jsonc
+# Ersetzt     : neofetch (schnellere System-Übersicht)
 # Aliase      : ff, neofetch
 # ============================================================
 

--- a/terminal/.config/alias/fzf.alias
+++ b/terminal/.config/alias/fzf.alias
@@ -6,6 +6,7 @@
 # Docs        : https://github.com/junegunn/fzf
 # Config      : ~/.config/fzf/config
 # Nutzt       : bat, eza, fd, tldr, pdftotext, 7zz, identify, ffprobe
+# Ersetzt     : -
 # ============================================================
 # Tool-spezifische Funktionen in fd/rg/git/brew/gh.alias.
 #

--- a/terminal/.config/alias/gh.alias
+++ b/terminal/.config/alias/gh.alias
@@ -5,6 +5,7 @@
 # Pfad        : ~/.config/alias/gh.alias
 # Docs        : https://cli.github.com/manual/
 # Nutzt       : fzf (Interactive), bat (Diff-Highlighting)
+# Ersetzt     : -
 # Aliase      : gh-open, gh-status, gh-pr, gh-issue, gh-run, gh-repo, gh-gist
 # ============================================================
 # Hinweis     : Erfordert gh auth login für Authentifizierung.

--- a/terminal/.config/alias/git.alias
+++ b/terminal/.config/alias/git.alias
@@ -5,6 +5,7 @@
 # Pfad        : ~/.config/alias/git.alias
 # Docs        : https://git-scm.com/docs
 # Nutzt       : fzf (Interactive), bat (Diff-Highlighting)
+# Ersetzt     : -
 # Aliase      : git-add, git-commit, git-cm, git-acm, git-push, git-pull, git-co, git-status, git-diff, git-log, git-branch, git-stage, git-stash
 # ============================================================
 # Hinweis     : Interaktive Git-Funktionen (mit fzf) sind unten

--- a/terminal/.config/alias/lazygit.alias
+++ b/terminal/.config/alias/lazygit.alias
@@ -5,6 +5,7 @@
 # Pfad        : ~/.config/alias/lazygit.alias
 # Docs        : https://github.com/jesseduffield/lazygit
 # Config      : ~/.config/lazygit/config.yml
+# Ersetzt     : -
 # Aliase      : lg
 # ============================================================
 

--- a/terminal/.config/alias/markdownlint.alias
+++ b/terminal/.config/alias/markdownlint.alias
@@ -5,6 +5,7 @@
 # Pfad        : ~/.config/alias/markdownlint.alias
 # Docs        : https://github.com/DavidAnson/markdownlint-cli2
 # Config      : ~/.config/markdownlint-cli2/.markdownlint-cli2.jsonc
+# Ersetzt     : -
 # Aliase      : mdl, mdla, mdlf, mdlaf
 # ============================================================
 

--- a/terminal/.config/alias/yazi.alias
+++ b/terminal/.config/alias/yazi.alias
@@ -6,6 +6,7 @@
 # Docs        : https://yazi-rs.github.io/
 # Config      : ~/.config/yazi/
 # Nutzt       : fd, rg, fzf, zoxide, ffmpeg, 7zz, jq, poppler, magick, bat
+# Ersetzt     : -
 # Aliase      : y
 # ============================================================
 # Keybindings und Bookmarks: siehe ~/.config/yazi/keymap.toml

--- a/terminal/.config/tealdeer/pages/dotfiles.page.md
+++ b/terminal/.config/tealdeer/pages/dotfiles.page.md
@@ -47,13 +47,25 @@
 
 # Tool-Ersetzungen
 
+- unrar → 7z (7-Zip als schnellerer Ersatz):
+
+`7za, 7zx, 7zl, 7zt, unrar, 7zf`
+
 - cat → bat (mit Syntax-Highlighting):
 
 `cat, catn, catd, bat-theme`
 
+- top, htop → btop (moderner Ressourcen-Monitor):
+
+`top, htop`
+
 - ls → eza (mit Icons und Git-Status):
 
 `ls, ll, la, lt, lt3, lss, lst`
+
+- neofetch → fastfetch (schnellere System-Übersicht):
+
+`ff, neofetch`
 
 - find → fd (schneller, intuitive Syntax):
 


### PR DESCRIPTION
## Beschreibung

`Ersetzt`-Header-Feld in allen 20 Alias-Dateien konsistent setzen und als Pflichtfeld etablieren.

### Änderungen

**10 Alias-Dateien** mit fehlendem `Ersetzt`-Feld ergänzt:
- `btop.alias` → `top, htop (moderner Ressourcen-Monitor)`
- `fastfetch.alias` → `neofetch (schnellere System-Übersicht)`
- 8 weitere → `-` (brew, dotfiles, fzf, gh, git, lazygit, markdownlint, yazi)

**1 Korrektur:** `7z.alias` hatte `Ersetzt: -`, obwohl `alias unrar='7zz x'` definiert ist → korrigiert zu `unrar (7-Zip als schnellerer Ersatz)`

**Infrastruktur:**
- `CONTRIBUTING.md`: `Ersetzt` von ⚪ optional auf ✅ Pflicht geändert
- `check-alias-format.sh`: `Ersetzt` zum Pflichtfeld-Check hinzugefügt
- Docs neu generiert: README-Ersetzungstabelle + dotfiles.page.md (3 neue Einträge)

## Art der Änderung

- [ ] 🐛 Bugfix
- [x] ✨ Neues Feature
- [x] 📝 Dokumentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Konfiguration/Maintenance

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Bei neuen Tools: Guard-Check vorhanden

## Zusammenhängende Issues

Closes #264