### PR TITLE
chore: Issue-Titel-Konvention und Scope-Dokumentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: 🐛 Bug Report
 about: Etwas funktioniert nicht wie erwartet
-title: ''
+title: 'fix: '
 labels: bug
 assignees: ''
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: 💡 Feature Request
 about: Idee für eine Verbesserung oder neues Feature
-title: ''
+title: 'feat: '
 labels: enhancement
 assignees: ''
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -629,7 +629,7 @@ exec zsh
 
 ```zsh
 git add .
-git commit -m "type: beschreibung"
+git commit -m "type(scope): beschreibung"
 ```
 
 **Commit-Typen:**
@@ -639,6 +639,19 @@ git commit -m "type: beschreibung"
 - `docs:` – Nur Dokumentation
 - `refactor:` – Code-Umstrukturierung
 - `chore:` – Maintenance (deps, configs)
+
+**Optionaler Scope:** Betroffenes Tool oder Modul in Klammern:
+
+```text
+feat(starship): Erweiterte Module hinzufügen
+fix(fzf): Sonderzeichen in Vorschau escapen
+refactor(setup): Toter Code in _core.sh entfernen
+docs(readme): Feature-Highlights sichtbar machen
+```
+
+Gängige Scopes: `fzf`, `brew`, `git`, `bat`, `starship`, `stow`, `setup`, `readme`, `restore`
+
+> **Issue-Titel** folgen derselben Konvention wie Commit-Messages.
 
 ### 5. Push & PR
 


### PR DESCRIPTION
## Beschreibung

Issue-Titel und Commit-Messages folgen jetzt einer einheitlichen Konvention mit optionalem Scope: `type(scope): beschreibung`. Die Konvention war implizit durch die Issue-Titel etabliert, aber nicht dokumentiert.

**Änderungen:**
- CONTRIBUTING.md: Scope-Konvention dokumentiert mit Beispielen und gängiger Scope-Liste
- Issue-Templates: Titel-Prefix vorausgefüllt (`fix: ` für Bugs, `feat: ` für Features)

## Art der Änderung

- [x] 📝 Dokumentation
- [x] 🔧 Konfiguration/Maintenance

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [ ] ~~Neue Aliase/Funktionen haben Beschreibungskommentare~~ (nicht zutreffend)
- [ ] ~~Bei neuen Tools: Guard-Check vorhanden~~ (nicht zutreffend)

## Zusammenhängende Issues

Bezieht sich auf alle offenen Issues – Titel wurden parallel korrigiert:
#99, #151, #190, #193, #240, #271, #272