### PR TITLE
fix(config): DOTFILES_DIR dynamisch in .zprofile exportieren

### DIFF
--- a/terminal/.config/alias/dotfiles.alias
+++ b/terminal/.config/alias/dotfiles.alias
@@ -31,5 +31,36 @@ alias dothealth='"${DOTFILES_DIR:-$HOME/dotfiles}/.github/scripts/health-check.s
 # Dokumentation neu generieren
 alias dotdocs='"${DOTFILES_DIR:-$HOME/dotfiles}/.github/scripts/generate-docs.sh" --generate'
 
-# Symlinks neu verlinken (nach Änderungen in terminal/ oder editor/)
-alias dotstow='cd "${DOTFILES_DIR:-$HOME/dotfiles}" && stow -R terminal editor'
+# Symlinks neu verlinken (nach Änderungen in Stow-Packages)
+dotstow() {
+    local dotdir="${DOTFILES_DIR:-$HOME/dotfiles}"
+    if [[ ! -d "$dotdir" ]]; then
+        echo "Dotfiles-Verzeichnis nicht gefunden: $dotdir" >&2
+        return 1
+    fi
+
+    # Stow-Packages dynamisch erkennen
+    local -a pkgs=()
+    local dir name
+    for dir in "$dotdir"/*/; do
+        [[ -d "$dir" ]] || continue
+        name="${dir%/}"
+        name="${name##*/}"
+
+        # Bekannte Nicht-Packages überspringen
+        [[ "$name" == "setup" || "$name" == "docs" || "$name" == ".git" || "$name" == ".backup" || "$name" == ".github" ]] && continue
+
+        # Prüfe ob es Dotfiles oder .config enthält
+        if [[ -n "$(find "$dir" -maxdepth 1 -name '.*' -not -name '.DS_Store' -type f 2>/dev/null | head -1)" ]] ||
+           [[ -d "${dir}.config" ]]; then
+            pkgs+=("$name")
+        fi
+    done
+
+    if [[ ${#pkgs[@]} -eq 0 ]]; then
+        echo "Keine Stow-Packages gefunden in: $dotdir" >&2
+        return 1
+    fi
+
+    cd "$dotdir" && stow -R "${pkgs[@]}"
+}

--- a/terminal/.config/tealdeer/pages/dotfiles.page.md
+++ b/terminal/.config/tealdeer/pages/dotfiles.page.md
@@ -99,7 +99,7 @@
 
 `dotdocs`
 
-- Symlinks neu verlinken (nach Änderungen in terminal/ oder editor/):
+- Symlinks neu verlinken (nach Änderungen in Stow-Packages):
 
 `dotstow`
 

--- a/terminal/.zprofile
+++ b/terminal/.zprofile
@@ -8,6 +8,18 @@
 # ============================================================
 
 # ------------------------------------------------------------
+# Dotfiles-Repository Pfad (Single Source of Truth)
+# ------------------------------------------------------------
+# .zprofile wird via Stow verlinkt: ~/.zprofile → ~/dotfiles/terminal/.zprofile
+# Über den Symlink leiten wir den Repo-Pfad dynamisch ab.
+if [[ -L "${(%):-%x}" ]]; then
+    # Resolve: ~/.zprofile → ~/dotfiles/terminal/.zprofile → ~/dotfiles
+    export DOTFILES_DIR="${${(%):-%x}:A:h:h}"
+else
+    export DOTFILES_DIR="${DOTFILES_DIR:-$HOME/dotfiles}"
+fi
+
+# ------------------------------------------------------------
 # Homebrew
 # ------------------------------------------------------------
 # Dynamische Erkennung: Apple Silicon → Intel Mac → Linux
@@ -15,7 +27,7 @@ for _brew_path in /opt/homebrew/bin/brew /usr/local/bin/brew /home/linuxbrew/.li
     if [[ -x "$_brew_path" ]]; then
         eval "$("$_brew_path" shellenv)"
         # Brewfile-Pfad für 'brew bundle' (ohne --file Flag nutzbar)
-        export HOMEBREW_BUNDLE_FILE="$HOME/dotfiles/setup/Brewfile"
+        export HOMEBREW_BUNDLE_FILE="$DOTFILES_DIR/setup/Brewfile"
         break
     fi
 done


### PR DESCRIPTION
## Beschreibung

`DOTFILES_DIR` wurde bisher in der interaktiven Shell nie exportiert. Der einzige Ort, der den Repo-Pfad setzte – `bootstrap.sh` – exportiert ihn nur während der Installation. In `.zprofile` war `$HOME/dotfiles` hardcoded, und alle Alias-Dateien nutzten `${DOTFILES_DIR:-$HOME/dotfiles}` als Fallback, der **immer** griff.

### Änderungen im Detail

1. **`DOTFILES_DIR` dynamisch in `.zprofile` ableiten** – Da `.zprofile` via Stow verlinkt wird (`~/.zprofile → ~/dotfiles/terminal/.zprofile`), kann der Repo-Pfad über die Symlink-Resolution abgeleitet werden: `${${(%):-%x}:A:h:h}`. Bei Nicht-Symlink greift `${DOTFILES_DIR:-$HOME/dotfiles}` als Fallback.
2. **`HOMEBREW_BUNDLE_FILE` dynamisch** – Nutzt jetzt `$DOTFILES_DIR/setup/Brewfile` statt hardcoded `$HOME/dotfiles/setup/Brewfile`.
3. **`dotstow` als Funktion** – Ersetzt den statischen Alias (`stow -R terminal editor`) durch eine Funktion mit dynamischer Package-Erkennung. Die Logik ist identisch mit `_get_stow_packages()` aus `backup.sh`: Verzeichnisse mit Dotfiles oder `.config`-Unterverzeichnis werden als Stow-Packages erkannt. `setup/`, `docs/`, `.git/`, `.backup/`, `.github/` werden übersprungen.
4. **tldr-Page aktualisiert** – `dotfiles.page.md` automatisch regeneriert (Kommentaränderung bei `dotstow`).

## Art der Änderung

- [x] 🐛 Bugfix
- [x] ✨ Neues Feature
- [ ] 📝 Dokumentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Konfiguration/Maintenance

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Bei neuen Tools: Guard-Check vorhanden

## Zusammenhängende Issues

Closes #272

## Verifizierung

- ZSH-Syntax: `zsh -n terminal/.zprofile` + `zsh -n terminal/.config/alias/dotfiles.alias` ✔
- Symlink-Resolution getestet: `~/.zprofile → ~/dotfiles/terminal/.zprofile → ~/dotfiles` ✔
- Fallback-Pfad getestet (Datei ohne Symlink sourced) ✔
- `DOTFILES_DIR` nach Source korrekt gesetzt ✔
- Package-Erkennung ergibt `editor terminal` (identisch mit altem Alias) ✔
- Alle 8 Pre-Commit Checks bestanden ✔