### PR TITLE
refactor(setup): Toter Code, CWD-Seiteneffekt und pipefail-Doku

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -13,6 +13,9 @@
 # zsh ist eine feste Abhängigkeit – keine interaktive Bestätigung.
 # ============================================================
 
+# POSIX sh kennt kein pipefail – Pipes im Skript wurden so
+# konstruiert, dass der Exit-Status der relevanten (letzten)
+# Stufe korrekt durchgereicht wird.
 set -eu
 
 # Script-Verzeichnis ermitteln (POSIX-kompatibel)

--- a/setup/modules/_core.sh
+++ b/setup/modules/_core.sh
@@ -167,40 +167,6 @@ ensure_file_writable() {
 }
 
 # ------------------------------------------------------------
-# Modul-Runner mit Fehlerisolierung
-# ------------------------------------------------------------
-# Führt eine Modul-Funktion aus und fängt Fehler ab
-# Argumente:
-#   $1 - Modul-Name (für Logging)
-#   $2 - Funktions-Name
-# Rückgabe: 0 = Erfolg, 1 = Fehler, 2 = Übersprungen
-# TODO    : Aktuell nicht von load_module() genutzt – Kandidat für
-#           Refactoring: load_module() könnte den Ausführungsteil
-#           hierhin delegieren (konsistentes Status-Logging).
-run_module() {
-    local module="$1"
-    local func="$2"
-
-    # Prüfe ob Funktion existiert
-    if (( ! $+functions[$func] )); then
-        err "Funktion '$func' nicht gefunden in Modul '$module'"
-        return 1
-    fi
-
-    # Führe Funktion aus
-    "$func"
-    local rc=$?
-
-    case $rc in
-        0) ok "Modul '$module' abgeschlossen" ;;
-        2) warn "Modul '$module' übersprungen" ;;
-        *) err "Modul '$module' fehlgeschlagen (Exit $rc)"; return 1 ;;
-    esac
-
-    return $rc
-}
-
-# ------------------------------------------------------------
 # Konfiguration (Pfade für Module)
 # ------------------------------------------------------------
 # Diese Variablen werden von allen Modulen verwendet

--- a/setup/modules/stow.sh
+++ b/setup/modules/stow.sh
@@ -126,8 +126,8 @@ run_stow() {
 
     log "Verlinke Konfigurationsdateien..."
 
-    # Ins dotfiles-Verzeichnis wechseln
-    cd "$DOTFILES_DIR" || {
+    # Ins dotfiles-Verzeichnis wechseln (pushd isoliert den CWD-Wechsel)
+    pushd "$DOTFILES_DIR" >/dev/null || {
         err "Konnte nicht nach $DOTFILES_DIR wechseln"
         return 1
     }
@@ -138,6 +138,7 @@ run_stow() {
 
     if [[ ${#packages[@]} -eq 0 ]]; then
         warn "Keine Stow-Packages gefunden"
+        popd >/dev/null
         return 0
     fi
 
@@ -164,6 +165,7 @@ run_stow() {
         done <<< "$stow_output"
         # Stash trotzdem wiederherstellen bei Fehler
         _restore_stashed_changes
+        popd >/dev/null
         return 0
     fi
 
@@ -183,6 +185,9 @@ run_stow() {
 
     # Gestashte User-Änderungen wiederherstellen
     _restore_stashed_changes
+
+    # CWD wiederherstellen
+    popd >/dev/null
 
     return 0
 }


### PR DESCRIPTION
## Beschreibung

Drei Robustheits-Verbesserungen in den Setup-Modulen:

1. **`_core.sh`:** `run_module()` entfernt – 34 Zeilen toter Code mit TODO-Kommentar, nie von `load_module()` aufgerufen. `main()` in `bootstrap.sh` hat eigenes Status-Handling, Integration wäre redundant gewesen.

2. **`stow.sh`:** `cd "$DOTFILES_DIR"` durch `pushd`/`popd` ersetzt. Der CWD-Wechsel war permanent und hätte nachfolgende Module (git-hooks, font, bat, tealdeer etc.) beeinflussen können, falls diese relative Pfade verwenden. Alle `return`-Pfade (Erfolg, Stow-Fehler, leere Packages) stellen CWD via `popd` wieder her.

3. **`install.sh`:** Dokumentationskommentar ergänzt, warum `pipefail` bei `set -eu` fehlt – POSIX sh kennt `pipefail` nicht, und die Pipes im Skript sind so konstruiert, dass der relevante Exit-Status durchgereicht wird.

## Art der Änderung

- [x] ♻️ Refactoring

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Bei neuen Tools: Guard-Check vorhanden

## Zusammenhängende Issues

Closes #274
