### PR TITLE
chore(health-check,brew): Substring-Match, local-Scope und Kommentar

### DIFF
--- a/terminal/.config/alias/brew.alias
+++ b/terminal/.config/alias/brew.alias
@@ -8,8 +8,8 @@
 # Ersetzt     : -
 # Aliase      : brew-up, brew-list, brew-add, brew-rm, maso, masu, mass, masi, masl
 # ============================================================
-# Hinweis     : Kein Guard für brew – ohne Homebrew ist dieses
-#               dotfiles-Repository ohnehin nicht nutzbar.
+# Hinweis     : Kein Guard – auf Systemen ohne Homebrew werden
+#               diese Funktionen einfach nicht genutzt.
 # ============================================================
 
 # ------------------------------------------------------------


### PR DESCRIPTION
## Beschreibung

Drei Code-Hygiene-Verbesserungen aus Issue #275:

1. **Substring-Match → Suffix-Match** (health-check.sh, 2 Stellen)
   - `*"$expected_target"*` → `*"$expected_target"` — verhindert false-positives bei Symlink-Prüfung (z.B. `config.bak` matched fälschlicherweise `config`)

2. **`local` → `typeset` im Top-Level-Scope** (health-check.sh, 20 Stellen)
   - shellcheck SC2168: `local` ist nur innerhalb von Funktionen gültig
   - ZSH akzeptiert `local` top-level (identisch zu `typeset`), aber es ist ein Anti-Pattern
   - Funktionen (`check_symlink()`, `check_tool()`, `get_tools_from_brewfile()`, `check_theme_registry()`) behalten `local`

3. **brew.alias Kommentar korrigiert**
   - Alt: „ohne Homebrew ist dieses dotfiles-Repository ohnehin nicht nutzbar"
   - Neu: „auf Systemen ohne Homebrew werden diese Funktionen einfach nicht genutzt"
   - Das Repository funktioniert auch auf Linux ohne Homebrew (z.B. 32-bit ARM mit apt)

**Finding 4 (FZF_ALT_C Benennung):** Kein Handlungsbedarf — bereits dreifach dokumentiert (Header, Remap-Block, Sections).

## Art der Änderung

- [x] 🔧 Konfiguration/Maintenance

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler (122 ✔, 0 ⚠, 0 ✖)
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Bei neuen Tools: Guard-Check vorhanden

## Zusammenhängende Issues

Closes #275

## Terminal-Ausgabe

```
✔ Alle Checks bestanden (pre-commit: 8/8)
✔ Health Check erfolgreich (122 bestanden, 0 Warnungen, 0 Fehler)
✔ Dokumentation ist aktuell
```