### PR TITLE
feat(brew): brew-rm mit Cask-Support symmetrisch zu brew-add

### DIFF
--- a/terminal/.config/alias/brew.alias
+++ b/terminal/.config/alias/brew.alias
@@ -249,7 +249,7 @@ if command -v fzf >/dev/null 2>&1; then
 
         [[ -z "$selection" ]] && return 0
 
-        echo "$selection" | while read -r line; do
+        while read -r line; do
             type="${line:1:1}"
             pkg="${line:4}"
             if [[ "$type" == "C" ]]; then
@@ -257,7 +257,7 @@ if command -v fzf >/dev/null 2>&1; then
             else
                 brew install "$pkg"
             fi
-        done
+        done <<< "$selection"
     }
 
     # Brew Remove Browser(suche?) – Enter=Entfernen, Tab=Mehrfach
@@ -273,7 +273,7 @@ if command -v fzf >/dev/null 2>&1; then
 
         [[ -z "$selection" ]] && return 0
 
-        echo "$selection" | while read -r line; do
+        while read -r line; do
             type="${line:1:1}"
             pkg="${line:4}"
             if [[ "$type" == "C" ]]; then
@@ -281,6 +281,6 @@ if command -v fzf >/dev/null 2>&1; then
             else
                 brew uninstall "$pkg"
             fi
-        done
+        done <<< "$selection"
     }
 fi


### PR DESCRIPTION
## Beschreibung

Erweitert `brew-rm` um Cask-Support — symmetrisch zu `brew-add`, das bereits Formulae und Casks unterstützt.

### Vorher

```
brew leaves → fzf → brew uninstall
```
Nur Formulae. Casks konnten nicht interaktiv deinstalliert werden.

### Nachher

```
brew leaves      → [F] paket
brew list --cask → [C] paket
                 → fzf → brew uninstall [--cask]
```

Identisches UX-Muster wie `brew-add`: Typ-Marker `[F]`/`[C]`, typabhängige Preview via `brew info [--cask]`, explizites `--cask`-Flag bei Cask-Deinstallation.

### Technischer Hintergrund

- Casks haben keinen Dependency-Graphen → kein `brew leaves`-Äquivalent nötig → `brew list --cask` ist das vollständige Gegenstück
- `brew uninstall` erkennt den Typ automatisch, aber explizites `--cask`-Flag ist defensiv und konsistent zu `brew-add`

### Commit 2: Typabhängige Preview (Copilot-Review)

Fix in **beiden** Funktionen (`brew-add` + `brew-rm`): Preview nutzt jetzt `case {1}` um bei `[C]`-Einträgen `brew info --cask` aufzurufen. Verhindert falsche Preview bei Namenskollisionen.

## Art der Änderung

- [ ] 🐛 Bugfix
- [x] ✨ Neues Feature
- [ ] 📝 Dokumentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Konfiguration/Maintenance

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler (122/122)
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Pre-Commit-Hooks: 8/8 bestanden

## Zusammenhängende Issues

Closes #288