### PR TITLE
feat(git): git-amend Alias hinzufügen

### DIFF
--- a/terminal/.config/alias/git.alias
+++ b/terminal/.config/alias/git.alias
@@ -6,7 +6,7 @@
 # Docs        : https://git-scm.com/docs
 # Nutzt       : fzf (Interactive), bat (Diff-Highlighting)
 # Ersetzt     : -
-# Aliase      : git-add, git-commit, git-cm, git-acm, git-push, git-pull, git-co, git-status, git-diff, git-log, git-branch, git-stage, git-stash
+# Aliase      : git-add, git-commit, git-cm, git-acm, git-amend, git-push, git-pull, git-co, git-status, git-diff, git-log, git-branch, git-stage, git-stash
 # ============================================================
 # Hinweis     : Interaktive Git-Funktionen (mit fzf) sind unten
 #               definiert: git-log, git-branch, git-stage, git-stash
@@ -31,6 +31,9 @@ alias git-cm='git commit -m'
 
 # Alle Änderungen stagen und einen Commit erstellen
 alias git-acm='git add --all && git commit -m'
+
+# Letzten Commit ergänzen (staged Dateien hinzufügen, Message beibehalten)
+alias git-amend='git commit --amend --no-edit'
 
 # Änderungen pushen
 alias git-push='git push'

--- a/terminal/.config/tealdeer/pages/git.patch.md
+++ b/terminal/.config/tealdeer/pages/git.patch.md
@@ -16,6 +16,10 @@
 
 `git-acm`
 
+- dotfiles: Letzten Commit ergänzen (staged Dateien hinzufügen, Message beibehalten):
+
+`git-amend`
+
 - dotfiles: Änderungen pushen:
 
 `git-push`


### PR DESCRIPTION
## Beschreibung

Fügt `git-amend` als Alias für `git commit --amend --no-edit` hinzu — staged Dateien zum letzten Commit ergänzen ohne Message-Änderung.

Passt in die bestehende Reihe der 1:1 Git-Aliase (`git-add`, `git-commit`, `git-cm`, `git-acm`, …) und reduziert den Tippaufwand von 30 auf 9 Zeichen.

## Art der Änderung

- [x] ✨ Neues Feature

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Pre-Commit-Hooks: 8/8 bestanden

## Zusammenhängende Issues

Closes #285