### PR TITLE
fix(poppler): pdfmerge mit optionalem Output-Parameter

### DIFF
--- a/terminal/.config/alias/poppler.alias
+++ b/terminal/.config/alias/poppler.alias
@@ -65,16 +65,26 @@ pdfsplit() {
     pdfseparate "$input" "$pattern"
 }
 
-# PDFs zusammenfügen(pdf, pdf, ...) – Ausgabe: merged.pdf, Überschreibschutz
+# PDFs zusammenfügen(pdf, pdf, ..., output?) – Standard: merged.pdf, Überschreibschutz
 pdfmerge() {
     if [[ $# -lt 2 ]]; then
-        echo "Verwendung: pdfmerge <pdf1> <pdf2> [pdf3 ...]" >&2
+        echo "Verwendung: pdfmerge <pdf1> <pdf2> [... output.pdf]" >&2
+        echo "Ohne Ausgabe-Datei wird 'merged.pdf' erzeugt." >&2
         return 1
     fi
     local output="merged.pdf"
+    local -a inputs
+    inputs=("$@")
+
+    # Letztes Argument als Output, wenn >= 3 Argumente und Datei nicht existiert
+    if [[ $# -ge 3 && ! -e "${@[-1]}" ]]; then
+        output="${@[-1]}"
+        inputs=("${@[1,-2]}")
+    fi
+
     if [[ -e "$output" ]]; then
         echo "Fehler: $output existiert bereits" >&2
         return 1
     fi
-    pdfunite "$@" "$output"
+    pdfunite "${inputs[@]}" "$output"
 }

--- a/terminal/.config/tealdeer/pages/poppler.page.md
+++ b/terminal/.config/tealdeer/pages/poppler.page.md
@@ -25,6 +25,6 @@
 
 `pdfsplit {{pdf, muster}}`
 
-- dotfiles: PDFs zusammenfügen (Ausgabe: merged.pdf, Überschreibschutz):
+- dotfiles: PDFs zusammenfügen (Standard: merged.pdf, Überschreibschutz):
 
-`pdfmerge {{pdf, pdf, ...}}`
+`pdfmerge {{pdf, pdf, ..., output}}`


### PR DESCRIPTION
## Beschreibung

Adressiert den Copilot-Review-Kommentar aus PR #292: `pdfmerge` akzeptiert jetzt einen optionalen Ausgabe-Dateinamen.

### Logik

Das **letzte Argument** wird als Output behandelt, wenn:
1. Mindestens **3 Argumente** übergeben werden (mind. 2 Inputs nötig)
2. Die Datei noch **nicht existiert** (existierende Dateien = Inputs)

| Aufruf | Output | Warum |
|--------|--------|-------|
| `pdfmerge a.pdf b.pdf` | `merged.pdf` | Nur 2 Args → Default |
| `pdfmerge a.pdf b.pdf c.pdf` | `merged.pdf` | `c.pdf` existiert → Input |
| `pdfmerge a.pdf b.pdf result.pdf` | `result.pdf` | `result.pdf` existiert nicht → Output |
| `pdfmerge a.pdf b.pdf c.pdf out.pdf` | `out.pdf` | `out.pdf` existiert nicht → Output |

### Sicherheit

- Überschreibschutz bleibt: `[[ -e "$output" ]]` → Fehler
- Existierende Dateien werden nie als Output interpretiert → kein Datenverlust

## Art der Änderung

- [x] ✨ Neues Feature

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Pre-Commit-Hooks: 8/8 bestanden

## Zusammenhängende Issues

Follow-up zu PR #292 (Copilot-Review-Kommentar)