### PR TITLE
feat(gh): State-Toggle für gh-pr und gh-issue

### DIFF
--- a/terminal/.config/alias/gh.alias
+++ b/terminal/.config/alias/gh.alias
@@ -4,7 +4,7 @@
 # Zweck       : Interaktive GitHub-Workflows mit gh CLI
 # Pfad        : ~/.config/alias/gh.alias
 # Docs        : https://cli.github.com/manual/
-# Nutzt       : fzf (Interactive), bat (Diff-Highlighting)
+# Nutzt       : fzf (Interactive), bat (Diff-Highlighting), fzf-Helper (gh)
 # Ersetzt     : -
 # Aliase      : gh-open, gh-status, gh-pr, gh-issue, gh-run, gh-repo, gh-gist
 # ============================================================
@@ -35,7 +35,7 @@ if command -v fzf >/dev/null 2>&1; then
     gh-pr() {
         local query="${1:-}"
         local result pr_num pr_state
-        result=$(gh pr list --limit 50 | \
+        result=$("$FZF_HELPER_DIR/gh" list-pr | \
             fzf --ansi --query="$query" \
                 --delimiter='\t' \
                 --prompt='Open> ' \
@@ -43,7 +43,7 @@ if command -v fzf >/dev/null 2>&1; then
                 --header='Enter: Checkout/Browser | Ctrl+D: Diff | Ctrl+O: Browser | Ctrl+S: Open/Alle' \
                 --bind 'ctrl-o:execute-silent(gh pr view {1} --web)' \
                 --bind 'ctrl-d:execute(gh pr diff {1} | bat --color=always -l diff)' \
-                --bind "ctrl-s:transform:[[ \$FZF_PROMPT == 'Open> ' ]] && echo 'reload(gh pr list --state all --limit 50)+change-prompt(Alle> )' || echo 'reload(gh pr list --state open --limit 50)+change-prompt(Open> )'"
+                --bind "ctrl-s:transform:[[ \$FZF_PROMPT == 'Open> ' ]] && echo 'reload($FZF_HELPER_DIR/gh list-pr all)+change-prompt(Alle> )' || echo 'reload($FZF_HELPER_DIR/gh list-pr open)+change-prompt(Open> )'"
             )
 
         [[ -z "$result" ]] && return 0
@@ -61,15 +61,15 @@ if command -v fzf >/dev/null 2>&1; then
     gh-issue() {
         local query="${1:-}"
         local issue
-        issue=$(gh issue list --limit 50 | \
+        issue=$("$FZF_HELPER_DIR/gh" list-issue | \
             fzf --ansi --query="$query" \
                 --delimiter='\t' \
                 --prompt='Open> ' \
                 --preview 'gh issue view {1}' \
                 --header='Enter: Browser | Ctrl+E: Bearbeiten | Ctrl+S: Open/Alle' \
                 --bind 'ctrl-e:execute(gh issue edit {1})' \
-                --bind "ctrl-s:transform:[[ \$FZF_PROMPT == 'Open> ' ]] && echo 'reload(gh issue list --state all --limit 50)+change-prompt(Alle> )' || echo 'reload(gh issue list --state open --limit 50)+change-prompt(Open> )'" | \
-            awk '{print $1}')
+                --bind "ctrl-s:transform:[[ \$FZF_PROMPT == 'Open> ' ]] && echo 'reload($FZF_HELPER_DIR/gh list-issue all)+change-prompt(Alle> )' || echo 'reload($FZF_HELPER_DIR/gh list-issue open)+change-prompt(Open> )'" | \
+            cut -f1)
 
         [[ -n "$issue" ]] && gh issue view "$issue" --web
     }

--- a/terminal/.config/fzf/gh
+++ b/terminal/.config/fzf/gh
@@ -1,0 +1,55 @@
+#!/usr/bin/env zsh
+# ============================================================
+# gh - Helper für gh-pr() und gh-issue() Funktionen
+# ============================================================
+# Zweck       : GitHub CLI Listen für fzf (stabiles Tab-Format)
+# Pfad        : ~/.config/fzf/gh
+# Aufruf      : gh <list-pr|list-issue> [open|all]
+# ============================================================
+# Hinweis     : Nutzt --json + --template für stabiles Format
+#               (unabhängig von gh-Version und Locale)
+# ============================================================
+
+# Gemeinsame Bibliothek laden (Farben, Dispatch)
+source "${0:A:h}/lib.zsh"
+
+# ------------------------------------------------------------
+# Subcommand: list-pr
+# ------------------------------------------------------------
+# Format: Nummer\tTitel\tBranch\tState (OPEN|DRAFT|MERGED|CLOSED)
+_gh_list-pr() {
+    local state="${1:-open}"
+    gh pr list --limit 50 --state "$state" \
+        --json number,title,headRefName,state,isDraft \
+        --template '{{range .}}{{.number}}{{"\t"}}{{.title}}{{"\t"}}{{.headRefName}}{{"\t"}}{{if .isDraft}}DRAFT{{else}}{{.state}}{{end}}{{"\n"}}{{end}}'
+}
+
+# ------------------------------------------------------------
+# Subcommand: list-issue
+# ------------------------------------------------------------
+# Format: Nummer\tTitel\tLabels\tState (OPEN|CLOSED)
+_gh_list-issue() {
+    local state="${1:-open}"
+    gh issue list --limit 50 --state "$state" \
+        --json number,title,labels,state \
+        --template '{{range .}}{{.number}}{{"\t"}}{{.title}}{{"\t"}}{{range $i, $l := .labels}}{{if $i}}, {{end}}{{$l.name}}{{end}}{{"\t"}}{{.state}}{{"\n"}}{{end}}'
+}
+
+# ------------------------------------------------------------
+# Usage
+# ------------------------------------------------------------
+_gh_usage() {
+    cat <<EOF
+Usage: gh <command> [args...]
+
+Commands:
+  list-pr [open|all]      PR-Liste generieren (Default: open)
+  list-issue [open|all]   Issue-Liste generieren (Default: open)
+
+EOF
+}
+
+# ------------------------------------------------------------
+# Main Dispatch
+# ------------------------------------------------------------
+_fzf_dispatch "gh" "$@"

--- a/terminal/.config/tealdeer/pages/fzf.patch.md
+++ b/terminal/.config/tealdeer/pages/fzf.patch.md
@@ -24,6 +24,8 @@
 
 - dotfiles: `config` – Native fzf-Konfiguration (FZF_DEFAULT_OPTS_FILE)
 
+- dotfiles: `gh` – GitHub CLI Listen für fzf (stabiles Tab-Format)
+
 - dotfiles: `help` – Subcommands für man/tldr Browser
 
 - dotfiles: `init.zsh` – fzf Keybindings und fd-Backend aktivieren

--- a/terminal/.config/tealdeer/pages/gh.patch.md
+++ b/terminal/.config/tealdeer/pages/gh.patch.md
@@ -1,4 +1,4 @@
-- dotfiles: Nutzt `fzf (Interactive), bat (Diff-Highlighting)`
+- dotfiles: Nutzt `fzf (Interactive), bat (Diff-Highlighting), fzf-Helper (gh)`
 
 - dotfiles: Repository im Browser öffnen:
 


### PR DESCRIPTION
## Beschreibung

Erweitert `gh-pr` und `gh-issue` um einen **Ctrl+S State-Toggle** (`open ↔ all`), konsistent mit dem bestehenden Pattern in `procs()` und `help()`.

### gh-pr — Toggle + State-abhängiger Enter

| Modus | Prompt | Inhalt |
|-------|--------|--------|
| Default | `Open>` | Nur offene PRs |
| Ctrl+S | `Alle>` | Alle PRs (open + merged + closed) |

**Enter-Aktion ist state-abhängig:**

| PR-State | Enter-Aktion | Begründung |
|----------|-------------|------------|
| OPEN / DRAFT | `gh pr checkout` | Primärer Workflow, Branch existiert |
| MERGED / CLOSED | `gh pr view --web` | Branch meist gelöscht → checkout scheitert nach ~10s |

### gh-issue — Toggle

| Modus | Prompt | Inhalt |
|-------|--------|--------|
| Default | `Open>` | Nur offene Issues |
| Ctrl+S | `Alle>` | Alle Issues (open + closed) |

Enter bleibt `gh issue view --web` (funktioniert für alle States).

### Commit 2: Stabiles Format via fzf-Helper (Copilot-Review)

Neuer fzf-Helper `terminal/.config/fzf/gh` mit `--json` + `--template`:
- `list-pr [open|all]`: Nummer\\tTitel\\tBranch\\tState
- `list-issue [open|all]`: Nummer\\tTitel\\tLabels\\tState

Vorteile gegenüber der Standard-Ausgabe:
- Versionsstabiles Tab-Format (unabhängig von `gh` CLI Version)
- Kein `eval` nötig — kein Quoting-Problem im `reload()` Bind
- Konsistent mit `procs`/`help` Helper-Pattern

### Risikobewertung

| Risiko | Bewertung | Maßnahme |
|--------|-----------|----------|
| Checkout merged/closed PR | **Hoch** → adressiert | State-abhängiger Enter |
| Feld `{1}` Stabilität | **Hoch** → adressiert | `--json` + `--template` via Helper |
| API Rate-Limiting | Niedrig | 1 Request pro Toggle, 5000/h Limit |
| Race Conditions | Niedrig | fzf handhabt concurrent Reloads |

## Art der Änderung

- [x] ✨ Neues Feature

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Pre-Commit-Hooks: 8/8 bestanden

## Zusammenhängende Issues

Closes #283