### PR TITLE
feat(zsh): INTERACTIVE_COMMENTS aktivieren

### DIFF
--- a/terminal/.zshrc
+++ b/terminal/.zshrc
@@ -38,6 +38,10 @@ setopt HIST_VERIFY           # History-Expansion (!!) erst in Buffer laden
 # Benötigt für (#q...) Glob-Qualifier-Syntax (z.B. bei compinit)
 setopt EXTENDED_GLOB
 
+# Kommentare (#) in interaktiven Shells erlauben
+# Ohne diese Option interpretiert ZSH # als Extended-Glob-Operator
+setopt INTERACTIVE_COMMENTS
+
 # ------------------------------------------------------------
 # Completion-System initialisieren
 # ------------------------------------------------------------


### PR DESCRIPTION
## Beschreibung

Aktiviert `setopt INTERACTIVE_COMMENTS` in der Globbing-Sektion der `.zshrc`.

Ohne diese Option interpretiert ZSH bei aktivem `EXTENDED_GLOB` das `#`-Zeichen als Glob-Quantifier in der interaktiven Kommandozeile. Das führt zu `zsh: bad pattern: #`-Fehlern wenn Inline-Kommentare verwendet werden (z.B. durch Copilot oder manuelle Eingabe).

Die Option ist bei oh-my-zsh, prezto und grml standardmäßig aktiviert und hat keine negativen Seiteneffekte — sie wirkt ausschließlich auf die interaktive Kommandozeile, nicht auf gesourcte Dateien oder Skripte.

## Art der Änderung

- [ ] 🐛 Bugfix
- [x] ✨ Neues Feature
- [ ] 📝 Dokumentation
- [ ] ♻️ Refactoring
- [x] 🔧 Konfiguration/Maintenance

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Bei neuen Tools: Guard-Check vorhanden

## Zusammenhängende Issues

Kein Issue — Verbesserung der interaktiven Shell-Nutzung.

## Terminal-Ausgabe

```
# Vorher (INTERACTIVE_COMMENTS aus):
$ echo "test" # Kommentar
zsh: bad pattern: #

# Nachher (INTERACTIVE_COMMENTS an):
$ echo "test" # Kommentar
test
```