### PR TITLE
fix(fzf): doppelte Quotierung von {} in execute() entfernen

### DIFF
--- a/terminal/.config/alias/dotfiles.alias
+++ b/terminal/.config/alias/dotfiles.alias
@@ -89,8 +89,8 @@ if command -v fzf >/dev/null 2>&1 && command -v fd >/dev/null 2>&1; then
                 --prompt='dotedit> ' \
                 --header='Enter: Editieren | Ctrl+Y: Pfad kopieren' \
                 --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Editieren' 'Ctrl+Y: Pfad kopieren'" \
-                --preview "zsh '$FZF_HELPER_DIR/preview' file '${dotdir}/{}'" \
-                --bind "enter:execute(${EDITOR:-vi} -- '${dotdir}/{}')+refresh-preview" \
-                --bind "ctrl-y:execute-silent('$FZF_HELPER_DIR/action' copy '${dotdir}/{}')+abort"
+                --preview "zsh '$FZF_HELPER_DIR/preview' file '${dotdir}/'{}" \
+                --bind "enter:execute(${EDITOR:-vi} -- '${dotdir}/'{})+refresh-preview" \
+                --bind "ctrl-y:execute-silent('$FZF_HELPER_DIR/action' copy '${dotdir}/'{})+abort"
     }
 fi

--- a/terminal/.config/alias/fzf.alias
+++ b/terminal/.config/alias/fzf.alias
@@ -141,7 +141,7 @@ cmds() {
         --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Übernehmen' 'Ctrl+S: tldr ↔ Code' 'Ctrl+E: Datei editieren'" \
         --preview "[[ \$FZF_PROMPT == 'code> ' ]] && zsh '$FZF_HELPER_DIR/cmds' preview code {} || zsh '$FZF_HELPER_DIR/cmds' preview tldr {}" \
         --bind "ctrl-s:transform:[[ \$FZF_PROMPT == 'tldr> ' ]] && echo 'change-prompt(code> )+refresh-preview' || echo 'change-prompt(tldr> )+refresh-preview'" \
-        --bind "ctrl-e:execute(zsh '$FZF_HELPER_DIR/cmds' edit '{}')+refresh-preview")
+        --bind "ctrl-e:execute(zsh '$FZF_HELPER_DIR/cmds' edit {})+refresh-preview")
 
     # Bei Enter: Befehl ins Edit-Buffer (kann editiert/ausgeführt werden)
     if [[ -n "$selection" ]]; then


### PR DESCRIPTION
## Beschreibung

Behebt lautloses Fehlschlagen von `execute()`/`execute-silent()` Aktionen in fzf, wenn der ausgewählte Eintrag Klammern `()` im Text enthält.

**Root Cause:** fzf's internes `quoteEntry()` umschließt `{}` automatisch mit Single Quotes (`'TEXT'`). Die zusätzlichen `'...'` um `{}` im Code erzeugten `''TEXT''` – in der Shell wird das zu:
- `''` (leer) + `TEXT` (UNQUOTED!) + `''` (leer)

Einträge mit Klammern wie `(plain style)` im Beschreibungstext wurden dadurch als Subshell interpretiert → Shell-Fehler → Aktion brach lautlos ab.

**Beispiel:** `cat` → Beschreibung `Ersetzt cat mit Syntax-Highlighting (plain style)` → Ctrl+E in `cmds()` öffnete keinen Editor.

## Art der Änderung

- [x] 🐛 Bugfix

## Checkliste

- [x] [CONTRIBUTING.md](../CONTRIBUTING.md) gelesen
- [x] `generate-docs.sh --check` → bestanden
- [x] `health-check.sh` → bestanden (124/124)
- [x] Beschreibungskommentare aktualisiert (nicht zutreffend – keine neuen Funktionen)
- [x] Guard-Checks vorhanden (bestehend)

## Geänderte Dateien

| Datei | Änderung |
|-------|----------|
| `terminal/.config/alias/fzf.alias` | `'{}'` → `{}` in cmds() Ctrl+E |
| `terminal/.config/alias/dotfiles.alias` | `'${dotdir}/{}'` → `'${dotdir}/'{}` in dotedit() (Preview, Enter, Ctrl+Y) |

## Repo-weiter Audit

Alle 12+ `execute()`/`execute-silent()` Aufrufe repo-weit geprüft – nur die 4 geänderten Stellen hatten das Problem. Andere nutzen bereits `{}` ohne zusätzliche Quotes oder `{1}` (Feld-Index, nicht betroffen).

## Verwandte Issues / PRs

- Entstanden durch PR #301 (cmds Ctrl+E), entdeckt nach PR #304 (header-wrap)