### PR TITLE
feat(fzf): eindeutige Aufruf-Referenzen in Helper Usage + Header

### DIFF
--- a/terminal/.config/fzf/action
+++ b/terminal/.config/fzf/action
@@ -4,7 +4,7 @@
 # ============================================================
 # Zweck       : Führt Aktionen Shell-Injection-sicher aus
 # Pfad        : ~/.config/fzf/action
-# Aufruf      : action <command> "argument" [...]
+# Aufruf      : ~/.config/fzf/action <command> "argument" [...]
 # Nutzt       : platform.zsh (clip)
 # ============================================================
 # Commands: copy, copy-env, edit, git-diff, git-restore, git-add,
@@ -17,6 +17,10 @@ source "${XDG_CONFIG_HOME:-$HOME/.config}/platform.zsh" 2>/dev/null || {
     echo "action: platform.zsh nicht gefunden" >&2
     exit 1
 }
+
+# Shell-Farben laden (für Fehlermeldungen)
+source "${XDG_CONFIG_HOME:-$HOME/.config}/theme-style" 2>/dev/null
+: "${C_RED:=}" "${C_RESET:=}"
 
 case "${1:-}" in
     copy)
@@ -72,7 +76,7 @@ case "${1:-}" in
         ;;
     -h|--help)
         cat <<EOF
-Usage: action <command> [args...]
+Usage: ~/.config/fzf/action <command> [args...]
 
 Commands:
   copy <path>            Pfad ins Clipboard kopieren
@@ -86,12 +90,12 @@ Commands:
 EOF
         ;;
     "")
-        echo "Usage: action <command> [args...]" >&2
-        echo "Try 'action --help' for more information." >&2
+        echo "Usage: ~/.config/fzf/action <command> [args...]" >&2
+        echo "Siehe '~/.config/fzf/action --help' für Details." >&2
         exit 1
         ;;
     *)
-        echo "Unknown action: $1" >&2
+        echo "${C_RED}Unbekannte Aktion:${C_RESET} $1" >&2
         exit 1
         ;;
 esac

--- a/terminal/.config/fzf/cmds
+++ b/terminal/.config/fzf/cmds
@@ -4,7 +4,7 @@
 # ============================================================
 # Zweck       : Liste und Preview für cmds (Alias-Browser) in fzf
 # Pfad        : ~/.config/fzf/cmds
-# Aufruf      : cmds <list|preview> [args...]
+# Aufruf      : ~/.config/fzf/cmds <list|preview|edit> [args...]
 # ============================================================
 # Commands:
 #   list                   – Listet alle Aliase und Funktionen
@@ -208,7 +208,7 @@ _cmds_edit() {
 # ------------------------------------------------------------
 _cmds_usage() {
     cat <<EOF
-Usage: cmds <command> [args...]
+Usage: ~/.config/fzf/cmds <command> [args...]
 
 Commands:
   list                        Liste aller Aliase und Funktionen

--- a/terminal/.config/fzf/gh
+++ b/terminal/.config/fzf/gh
@@ -4,7 +4,7 @@
 # ============================================================
 # Zweck       : GitHub CLI Listen für fzf (stabiles Tab-Format)
 # Pfad        : ~/.config/fzf/gh
-# Aufruf      : gh <list-pr|list-issue> [open|all]
+# Aufruf      : ~/.config/fzf/gh <list-pr|list-issue> [open|all]
 # ============================================================
 # Hinweis     : Nutzt --json + --template für stabiles Format
 #               (unabhängig von gh-Version und Locale)
@@ -40,7 +40,7 @@ _gh_list-issue() {
 # ------------------------------------------------------------
 _gh_usage() {
     cat <<EOF
-Usage: gh <command> [args...]
+Usage: ~/.config/fzf/gh <command> [args...]
 
 Commands:
   list-pr [open|all]      PR-Liste generieren (Default: open)

--- a/terminal/.config/fzf/header-wrap
+++ b/terminal/.config/fzf/header-wrap
@@ -4,7 +4,7 @@
 # ============================================================
 # Zweck       : Dynamischer fzf-Header-Umbruch nach verfügbarer Breite
 # Pfad        : ~/.config/fzf/header-wrap
-# Aufruf      : header-wrap [--test|-h|--help] GROUP [GROUP ...]
+# Aufruf      : ~/.config/fzf/header-wrap [--test|-h|--help] GROUP [GROUP ...]
 # Docs        : https://github.com/tshofmann/dotfiles/issues/302
 # ============================================================
 # Semantische Gruppen:
@@ -292,14 +292,14 @@ case "${1:-}" in
         _header_test
         ;;
     -h|--help)
-        printf 'Verwendung: header-wrap [--test|-h] GROUP [GROUP ...]\n'
+        printf 'Verwendung: ~/.config/fzf/header-wrap [--test|-h] GROUP [GROUP ...]\n'
         printf 'Bricht fzf-Header an semantischen Gruppen um.\n\n'
         printf 'Argumente:\n'
         printf '  GROUP    Zusammengehörige Keybindings (ein Argument pro Gruppe)\n'
         printf '  --test   Selbsttest ausführen\n'
         printf '  -h       Diese Hilfe anzeigen\n\n'
         printf 'Nutzt FZF_COLUMNS und FZF_PREVIEW_COLUMNS automatisch.\n'
-        printf 'Aufruf via fzf: --bind "start,resize:transform-header:header-wrap G1 G2"\n'
+        printf 'Aufruf via fzf: --bind "start,resize:transform-header:~/.config/fzf/header-wrap G1 G2"\n'
         ;;
     *)
         _header_wrap "$(_header_available_width)" "$@"

--- a/terminal/.config/fzf/help
+++ b/terminal/.config/fzf/help
@@ -4,7 +4,7 @@
 # ============================================================
 # Zweck       : Subcommands für man/tldr Browser
 # Pfad        : ~/.config/fzf/help
-# Aufruf      : help <list|preview|toggle> [args...]
+# Aufruf      : ~/.config/fzf/help <list|preview|toggle> [args...]
 # ============================================================
 # Commands:
 #   list [man|tldr]        – Listet Einträge
@@ -74,7 +74,7 @@ _help_toggle() {
 # ------------------------------------------------------------
 _help_usage() {
     cat <<EOF
-Usage: help <command> [args...]
+Usage: ~/.config/fzf/help <command> [args...]
 
 Commands:
   list [man|tldr]        Liste Einträge (Default: man)

--- a/terminal/.config/fzf/lib.zsh
+++ b/terminal/.config/fzf/lib.zsh
@@ -56,7 +56,7 @@ _fzf_dispatch() {
                 shift
                 "_${name}_${cmd}" "$@"
             else
-                echo "${C_RED}Unknown command:${C_RESET} $cmd" >&2
+                echo "${C_RED}Unbekannter Befehl:${C_RESET} $cmd (Helper: ~/.config/fzf/$name)" >&2
                 "_${name}_usage" >&2
                 return 1
             fi

--- a/terminal/.config/fzf/preview
+++ b/terminal/.config/fzf/preview
@@ -4,12 +4,16 @@
 # ============================================================
 # Zweck       : Zeigt Vorschau für Dateien und Verzeichnisse
 # Pfad        : ~/.config/fzf/preview
-# Aufruf      : preview <file|dir> <path> [args...]
+# Aufruf      : ~/.config/fzf/preview <file|dir> <path> [args...]
 # Nutzt       : bat (Code), eza (Dir), pdftotext (PDF), jq (JSON),
 #               7zz (Archive), identify (Bilder), ffprobe (Video/Audio)
 # ============================================================
 # Hinweis     : Pfad wird als Argument übergeben, nicht interpoliert
 # ============================================================
+
+# Shell-Farben laden (für Fehlermeldungen)
+source "${XDG_CONFIG_HOME:-$HOME/.config}/theme-style" 2>/dev/null
+: "${C_RED:=}" "${C_RESET:=}"
 
 # ------------------------------------------------------------
 # Subcommand: file
@@ -150,7 +154,7 @@ _preview_dir() {
 # ------------------------------------------------------------
 _preview_usage() {
     cat <<EOF
-Usage: preview <command> [args...]
+Usage: ~/.config/fzf/preview <command> [args...]
 
 Commands:
   file <path> [line]   Datei-Vorschau (optional mit Zeile hervorheben)
@@ -168,7 +172,7 @@ case "${1:-}" in
     -h|--help) _preview_usage ;;
     "")   _preview_usage ;;
     *)
-        echo "Unknown command: $1" >&2
+        echo "${C_RED}Unbekannter Befehl:${C_RESET} $1" >&2
         _preview_usage >&2
         exit 1
         ;;

--- a/terminal/.config/fzf/procs
+++ b/terminal/.config/fzf/procs
@@ -4,7 +4,7 @@
 # ============================================================
 # Zweck       : Prozessliste für fzf
 # Pfad        : ~/.config/fzf/procs
-# Aufruf      : procs list [apps|all]
+# Aufruf      : ~/.config/fzf/procs list [apps|all]
 # ============================================================
 # Hinweis     : macOS-spezifisch! Das Pattern \.app\/ filtert nach
 #               macOS App-Bundles. Für Linux-Portabilität müsste
@@ -52,7 +52,7 @@ _procs_list() {
 # ------------------------------------------------------------
 _procs_usage() {
     cat <<EOF
-Usage: procs <command> [args...]
+Usage: ~/.config/fzf/procs <command> [args...]
 
 Commands:
   list [apps|all]  Prozessliste generieren (Default: apps)


### PR DESCRIPTION
## Beschreibung

Alle fzf-Helper verwenden nun `~/.config/fzf/` als Pfad-Präfix in Kommentaren, Usage-Ausgaben und Fehlermeldungen. Verhindert Verwechslung mit gleichnamigen System-Tools (`gh` → GitHub CLI, `procs` → Rust-Tool) und macht die Helper-Herkunft sofort erkennbar.

### Änderungen

- **7× `# Aufruf`-Header** mit `~/.config/fzf/` Prefix (gh, procs, help, cmds, action, preview, header-wrap)
- **6× `Usage:`-Zeilen** mit Prefix
- **5× Fehlermeldungen** auf Deutsch vereinheitlicht (`Unknown` → `Unbekannter Befehl/Aktion/Modus`)
- **2× `source theme-style`** in action/preview für funktionierende Farbausgabe bei Fehlern
- **Bonus:** cmds-Header um fehlenden `edit`-Subcommand ergänzt

## Art der Änderung

- [ ] 🐛 Bugfix
- [x] ✨ Neues Feature
- [ ] 📝 Dokumentation
- [x] ♻️ Refactoring
- [ ] 🔧 Konfiguration/Maintenance

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler (124/124)
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Bei neuen Tools: Guard-Check vorhanden

### Bei Theme-/Config-Änderungen (`.config/*`)

- [x] Theme-Quellen-Tabelle in `theme-style` geprüft (Zeile 13-42)
- [x] Status aktualisiert falls Upstream-Abweichung (`upstream+X`)
- [x] Semantische Farben eingehalten (siehe CONTRIBUTING.md → Theming)

## Zusammenhängende Issues

Closes #295

## Validierung

| Prüfung | Ergebnis |
|---------|----------|
| `zsh -n` Syntax | 8/8 ✅ |
| `--help` aller 7 Helper | 7/7 ✅ |
| Fehlermeldungen (ungültiger Input) | 4/4 ✅ |
| Funktionstests (procs, cmds, preview) | 4/4 ✅ |
| header-wrap Selbsttest | 33/33 ✅ |
| health-check | 124/124 ✅ |
| generate-docs --check | 4/4 ✅ |
| Pre-commit Hooks | Alle bestanden ✅ |
| Farb-Konsistenz | Alle Helper mit Farbvariablen haben Quelle ✅ |