### PR TITLE
feat(fzf): Keybinding-Drift durch redundante Quellen verhindern

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,6 +21,7 @@
 | **Variablen quoten** | `"$var"` statt `$var` |
 | **Deutsch schreiben** | Kommentare, Doku, Commits |
 | **Pre-Commit durchlaufen** | Hooks validieren vor Commit |
+| **Projekt-Config nutzen** | Linter/Checks nur mit `--config` oder via Hook |
 | **Bei Unklarheit fragen** | Rückfrage statt Annahme |
 
 ## DON'Ts ✗
@@ -31,6 +32,7 @@
 | **Niemals blind ändern** | Repository-Zustand ist die Wahrheit |
 | **Niemals statische Zahlen** | "X Tools installiert" veraltet sofort |
 | **Niemals Annahmen** | Erst recherchieren, dann handeln |
+| **Niemals nackte Linter** | Immer Projekt-Config verwenden, nie `npx tool datei` ohne `--config` |
 | **Niemals `/Users/<name>`** | Öffentlich sichtbar → `~` oder `$HOME` |
 | **ZSH ist die Ziel-Shell** | POSIX sh nur in `setup/install.sh` und `setup/lib/logging.sh` (weil zsh auf frischen Linux-Systemen fehlen kann) |
 
@@ -158,6 +160,10 @@ func() {
 ## GitHub PRs
 
 ### Merge-Workflow (KRITISCH)
+
+**PRs niemals eigenständig mergen** – immer den User fragen!
+
+**PRs niemals eigenständig erstellen** – immer den User fragen!
 
 **VOR jedem Merge diese Schritte ausführen:**
 

--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -226,6 +226,16 @@ check_header_wrap() {
 }
 
 # ------------------------------------------------------------
+# 10. Keybinding-Sync: Beschreibungskommentar ↔ header-wrap
+# Prüft ob die Keybinding-Texte in beiden Quellen identisch
+# sind (Single Source of Truth = Beschreibungskommentar).
+# Läuft auch in CI (siehe .github/workflows/validate.yml)
+# ------------------------------------------------------------
+check_header_sync() {
+    "$DOTFILES_DIR/.github/scripts/check-header-sync.sh"
+}
+
+# ------------------------------------------------------------
 # Hauptprogramm
 # ------------------------------------------------------------
 print ""
@@ -245,6 +255,7 @@ check_platform_sync || { (( failed++ )) || true; }
 check_markdown || { (( failed++ )) || true; }
 check_health || { (( failed++ )) || true; }
 check_header_wrap || { (( failed++ )) || true; }
+check_header_sync || { (( failed++ )) || true; }
 
 print ""
 print "${C_OVERLAY0}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${C_RESET}"

--- a/.github/scripts/check-header-sync.sh
+++ b/.github/scripts/check-header-sync.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env zsh
+# ============================================================
+# check-header-sync.sh – Keybinding-Sync: Kommentar ↔ header-wrap
+# ============================================================
+# Zweck       : Stellt sicher, dass Keybinding-Texte in
+#             : Beschreibungskommentaren und header-wrap-Argumenten
+#             : identisch sind (Drift-Prävention)
+# Pfad        : .github/scripts/check-header-sync.sh
+# Docs        : CONTRIBUTING.md (Keybinding-Architektur)
+# ============================================================
+
+set -uo pipefail
+setopt TYPESET_SILENT
+
+SCRIPT_DIR="${0:A:h}"
+DOTFILES_DIR="${SCRIPT_DIR:h:h}"
+SHELL_COLORS="$DOTFILES_DIR/terminal/.config/theme-style"
+[[ -f "$SHELL_COLORS" ]] && source "$SHELL_COLORS"
+
+log()  { echo -e "${C_BLUE:-}→${C_RESET:-} $1"; }
+ok()   { echo -e "${C_GREEN:-}✔${C_RESET:-} $1"; }
+warn() { echo -e "${C_YELLOW:-}⚠${C_RESET:-} $1"; }
+err()  { echo -e "${C_RED:-}✖${C_RESET:-} $1" >&2; }
+
+ALIAS_DIR="$DOTFILES_DIR/terminal/.config/alias"
+FZF_INIT="$DOTFILES_DIR/terminal/.config/fzf/init.zsh"
+
+# ── Normalisierung ──────────────────────────────────────────
+
+# Beschreibungskommentar-Keybindings → sortierte "Key\tAktion" Zeilen
+# Input: "Enter=Beenden, Tab=Mehrfach, Ctrl+S=Apps ↔ Alle"
+normalize_comment() {
+    local text="$1"
+    local -a parts=("${(@s:, :)text}")
+    local part
+    for part in "${parts[@]}"; do
+        [[ -z "$part" ]] && continue
+        echo "${part%%=*}	${part#*=}"
+    done | sort
+}
+
+# header-wrap Argumente → sortierte "Key\tAktion" Zeilen
+# Überspringt Legenden ('[X]=Text' Muster, z.B. '[F]=Formula [C]=Cask')
+# Input: vollständige Zeile mit header-wrap 'Arg1' 'Arg2' ...
+normalize_header_wrap() {
+    local line="$1"
+    local args="${line#*header-wrap }"
+
+    # Single-Quoted Gruppen extrahieren
+    local rest="$args"
+    while [[ "$rest" == *"'"*"'"* ]]; do
+        rest="${rest#*\'}"
+        local group="${rest%%\'*}"
+        rest="${rest#*\'}"
+
+        # Legenden überspringen: enthält [X]=Text Muster
+        [[ "$group" == *'['?']='* ]] && continue
+
+        # Bindings innerhalb einer Gruppe durch " | " getrennt
+        local -a bindings=("${(@s: | :)group}")
+        local binding
+        for binding in "${bindings[@]}"; do
+            [[ -z "$binding" ]] && continue
+            echo "${binding%%: *}	${binding#*: }"
+        done
+    done | sort
+}
+
+# ── Hauptprüfung ────────────────────────────────────────────
+
+check_header_sync() {
+    local errors=0
+    local checked=0
+    local -a files=("$ALIAS_DIR"/*.alias(N) "$FZF_INIT")
+
+    local file
+    for file in "${files[@]}"; do
+        local name
+        name=$(basename "$file")
+
+        # Datei in Array einlesen (schneller als wiederholtes sed)
+        local -a flines=("${(@f)$(< "$file")}")
+        local total=${#flines}
+
+        # header-wrap Zeilen finden (keine Kommentare)
+        local -a hw_nums=()
+        local i
+        for (( i = 1; i <= total; i++ )); do
+            [[ "${flines[$i]}" == *"header-wrap "* ]] || continue
+            [[ "${flines[$i]}" =~ '^[[:space:]]*#' ]] && continue
+            hw_nums+=("$i")
+        done
+
+        (( ${#hw_nums} == 0 )) && continue
+
+        # header-wrap Zeilen nach Funktion gruppieren
+        local -A func_of_hw=()
+        local -A comment_of_func=()
+
+        local hw
+        for hw in "${hw_nums[@]}"; do
+            # Aufwärts zur Funktionsdefinition/Export suchen
+            local func_num=""
+            for (( i = hw - 1; i >= 1; i-- )); do
+                if [[ "${flines[$i]}" =~ '^[[:space:]]*[a-zA-Z0-9][a-zA-Z0-9_-]*\(\)' ]] || \
+                   [[ "${flines[$i]}" =~ '^export FZF_' ]]; then
+                    func_num="$i"
+                    break
+                fi
+            done
+            if [[ -z "$func_num" ]]; then
+                warn "$name:$hw: header-wrap ohne zugehörige Funktion"
+                continue
+            fi
+            func_of_hw[$hw]="$func_num"
+
+            # Beschreibungskommentar finden (einmal pro Funktion)
+            [[ -n "${comment_of_func[$func_num]:-}" ]] && continue
+            local comment_num=""
+            for (( i = func_num - 1; i >= 1; i-- )); do
+                local l="${flines[$i]}"
+                # Eingerückte Kommentare berücksichtigen (z.B. in if-Blöcken)
+                if [[ "$l" =~ '^[[:space:]]*#' ]]; then
+                    if [[ "$l" == *" – "* ]] && [[ "$l" == *=* ]]; then
+                        comment_num="$i"
+                        break
+                    fi
+                    continue
+                fi
+                # Nicht-Kommentar → Suche beenden
+                break
+            done
+            comment_of_func[$func_num]="${comment_num:-NONE}"
+        done
+
+        # Pro Funktion: Vereinigte header-wrap Keys mit Kommentar vergleichen
+        local -a done_funcs=()
+        for hw in "${hw_nums[@]}"; do
+            local func_num="${func_of_hw[$hw]:-}"
+            [[ -z "$func_num" ]] && continue
+
+            # Nur einmal pro Funktion
+            if (( ${done_funcs[(Ie)$func_num]} )); then
+                continue
+            fi
+            done_funcs+=("$func_num")
+
+            local comment_num="${comment_of_func[$func_num]:-NONE}"
+            if [[ "$comment_num" == "NONE" ]]; then
+                warn "$name: Funktion (Zeile $func_num) hat header-wrap ohne Beschreibungskommentar"
+                continue
+            fi
+
+            # Kommentar-Keybindings normalisieren
+            local comment_text="${flines[$comment_num]}"
+            local comment_kb="${comment_text#* – }"
+            local comment_sorted
+            comment_sorted=$(normalize_comment "$comment_kb")
+
+            # Alle header-wrap Zeilen dieser Funktion vereinigen
+            local -A merged=()
+            local h
+            for h in "${hw_nums[@]}"; do
+                [[ "${func_of_hw[$h]:-}" == "$func_num" ]] || continue
+                local key action
+                while IFS=$'\t' read -r key action; do
+                    [[ -z "$key" ]] && continue
+                    merged[$key]="$action"
+                done < <(normalize_header_wrap "${flines[$h]}")
+            done
+
+            # Merged-Set → sortierter String zum Vergleich
+            local merged_sorted=""
+            local k
+            for k in "${(@ko)merged}"; do
+                [[ -n "$merged_sorted" ]] && merged_sorted+=$'\n'
+                merged_sorted+="${k}	${merged[$k]}"
+            done
+
+            (( checked++ )) || true
+
+            # Vergleich: Kommentar ↔ vereinigte header-wrap Bindings
+            if [[ "$comment_sorted" != "$merged_sorted" ]]; then
+                local -A comment_map=()
+                local ckey caction
+                while IFS=$'\t' read -r ckey caction; do
+                    [[ -z "$ckey" ]] && continue
+                    comment_map[$ckey]="$caction"
+                done <<< "$comment_sorted"
+
+                # header-wrap Keys die im Kommentar fehlen
+                for k in "${(@ko)merged}"; do
+                    if [[ -z "${comment_map[$k]:-}" ]]; then
+                        err "$name:$comment_num: header-wrap Key '$k' fehlt im Kommentar"
+                        (( errors++ )) || true
+                    fi
+                done
+
+                # Kommentar-Keys die im header-wrap fehlen oder abweichen
+                for k in "${(@ko)comment_map}"; do
+                    if [[ -z "${merged[$k]:-}" ]]; then
+                        err "$name:$comment_num: Kommentar-Key '$k' fehlt in header-wrap"
+                        (( errors++ )) || true
+                    elif [[ "${merged[$k]}" != "${comment_map[$k]}" ]]; then
+                        err "$name:$comment_num: '$k' → Kommentar='${comment_map[$k]}' ≠ header-wrap='${merged[$k]}'"
+                        (( errors++ )) || true
+                    fi
+                done
+            fi
+
+            # Cleanup für nächste Funktion
+            merged=()
+        done
+    done
+
+    if (( errors > 0 )); then
+        err "${errors} Keybinding-Sync-Fehler"
+        return 1
+    fi
+    ok "Keybinding-Sync OK ($checked Funktionen geprüft)"
+    return 0
+}
+
+# ── Hauptprogramm ───────────────────────────────────────────
+
+log "Prüfe Keybinding-Sync..."
+check_header_sync

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -127,6 +127,10 @@ jobs:
         shell: zsh {0}
         run: ./.github/scripts/check-header-alignment.sh
 
+      - name: Keybinding-Sync prüfen
+        shell: zsh {0}
+        run: ./.github/scripts/check-header-sync.sh
+
       - name: Markdown prüfen
         run: |
           echo "Prüfe Markdown-Dateien..."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -400,7 +400,7 @@ Funktionen mit fzf-UI nutzen ein erweitertes Format:
 **Beispiele:**
 
 ```zsh
-# zoxide Browser – Enter=Wechseln, Ctrl+D=Löschen, Ctrl+Y=Kopieren
+# zoxide Browser(suche?) – Enter=Wechseln, Ctrl+D=Eintrag löschen, Ctrl+Y=Pfad kopieren
 zj() { ... }  # in zoxide.alias (Tool-Zuordnung!)
 
 # Verzeichnis wechseln(pfad=.) – Enter=Wechseln, Ctrl+Y=Pfad kopieren
@@ -418,6 +418,48 @@ rg-live() { ... }
 >
 > Der Generator prüft den tealdeer-Cache (`~/Library/Caches/tealdeer/tldr-pages/`)
 > und wählt automatisch das richtige Format.
+
+#### Keybinding-Architektur (Drift-Prävention)
+
+Jede fzf-Funktion hat **zwei synchronisierte Keybinding-Quellen**:
+
+| Quelle | Format | Zweck |
+| -------- | -------- | ------- |
+| **Beschreibungskommentar** | `Key=Aktion, Key=Aktion` | Autorität — wird von Generatoren gelesen |
+| **header-wrap Argumente** | `'Key: Aktion' 'Key: Aktion'` | Dynamische fzf-Header (Zeilenumbruch bei schmalen Terminals) |
+
+> **Warum nur zwei Quellen?**
+>
+> Früher gab es eine dritte Quelle: `--header='...'` als statischer Fallback.
+> Da `transform-header` den `--header`-Text beim `start`-Event sofort ersetzt,
+> war `--header` redundant und wurde entfernt (Issue #305).
+
+**Sync-Regel:** Der Aktions-Text muss **exakt** übereinstimmen:
+
+```text
+# Kommentar:   Enter=Wechseln, Ctrl+D=Eintrag löschen
+# header-wrap: 'Enter: Wechseln' 'Ctrl+D: Eintrag löschen'
+#                       ↑ identischer Text ↑
+```
+
+**Sonderfälle:**
+
+- **Legenden** (`[F]=Formula [C]=Cask`) stehen nur in header-wrap, nicht im Kommentar
+- **Plattform-Branches** (z.B. `procs`): Der Kommentar dokumentiert alle Keys
+  der Primärplattform (macOS). Andere Plattformen können eine Teilmenge verwenden.
+- **`rg-live` `start:+`**: Nutzt additives Binding (`start:+transform-header`)
+  statt überschreibendes (`start,resize:transform-header`), da ein vorheriges
+  `start`-Event den initialen Suchlauf startet.
+
+**Neue fzf-Funktion hinzufügen:**
+
+1. Beschreibungskommentar mit `Key=Aktion` Format schreiben
+2. `--bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Key: Aktion'"` hinzufügen
+3. **Kein `--header=`** — wurde entfernt, header-wrap übernimmt
+4. `.github/scripts/check-header-sync.sh` ausführen → muss grün sein
+
+**Automatisierte Prüfung:** `check-header-sync.sh` (Pre-Commit Check 10)
+vergleicht beide Quellen und meldet Abweichungen.
 
 ### Ausnahmen vom Header-Format
 
@@ -589,8 +631,8 @@ Diese Regeln gelten für alle Shell-Dateien:
 | **Guard-Kommentar** | Mit Tool-Name | `# Guard   : Nur wenn X installiert ist` |
 | **Sektions-Trenner** | `----` (60 Zeichen) | `# --------------------------------------------------------` |
 | **Header-Block** | `====` nur oben | Erste Zeilen der Datei |
-| **fzf-Header** | `Enter:` zuerst | `--header='Enter: Aktion'` |
-| **Header Pipe-Zeichen** | ASCII | Kein Unicode in `--header` |
+| **fzf-Header** | `Enter:` zuerst, via header-wrap | `--bind "...:header-wrap 'Enter: Aktion'"` |
+| **Header Pipe-Zeichen** | ASCII `\|` in header-wrap Gruppen | `'Enter: Aktion \| Tab: Mehrfach'` |
 
 ### Dokumentation
 

--- a/terminal/.config/alias/7z.alias
+++ b/terminal/.config/alias/7z.alias
@@ -46,7 +46,6 @@ alias unrar='7zz x'
 
     archive=$(fd -e zip -e 7z -e rar -e tar -e gz -e xz -e bz2 -e tgz -e tbz2 . "${1:-.}" 2>/dev/null | \
         fzf --preview='zsh -c '\''7zz l -- "$1" 2>/dev/null | head -50'\'' -- {}' \
-            --header='Enter: Entpacken | Ctrl+Y: Pfad kopieren' \
             --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Entpacken' 'Ctrl+Y: Pfad kopieren'" \
             --bind "ctrl-y:execute-silent($FZF_HELPER_DIR/action copy {})+abort")
 

--- a/terminal/.config/alias/bat.alias
+++ b/terminal/.config/alias/bat.alias
@@ -31,7 +31,7 @@ alias catd='bat --diff'
 # Interaktive Funktionen (mit fzf)
 # ------------------------------------------------------------
 if command -v fzf >/dev/null 2>&1; then
-    # Theme Browser(suche?) – Enter=Aktivieren
+    # Theme Browser(suche?) – Enter=Theme aktivieren
     bat-theme() {
         local query="${1:-}"
         local theme
@@ -42,7 +42,6 @@ if command -v fzf >/dev/null 2>&1; then
 
         theme=$(bat --list-themes | fzf --query="$query" \
             --preview='bat --theme={} --color=always ~/.zshrc' \
-            --header='Enter: Theme aktivieren' \
             --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Theme aktivieren'")
 
         [[ -z "$theme" ]] && return 0

--- a/terminal/.config/alias/brew.alias
+++ b/terminal/.config/alias/brew.alias
@@ -245,7 +245,6 @@ if command -v fzf >/dev/null 2>&1; then
             brew casks | sed 's/^/[C] /'
         } | fzf --multi --query="$query" \
             --preview 'case {1} in \[C\]) brew info --cask {2};; *) brew info {2};; esac' \
-            --header='[F]=Formula [C]=Cask | Enter: Installieren | Tab: Mehrfach' \
             --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap '[F]=Formula [C]=Cask' 'Enter: Installieren | Tab: Mehrfach'")
 
         [[ -z "$selection" ]] && return 0
@@ -270,7 +269,6 @@ if command -v fzf >/dev/null 2>&1; then
             brew list --cask 2>/dev/null | sed 's/^/[C] /'
         } | fzf --multi --query="$query" \
             --preview 'case {1} in \[C\]) brew info --cask {2};; *) brew info {2};; esac' \
-            --header='[F]=Formula [C]=Cask | Enter: Entfernen | Tab: Mehrfach' \
             --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap '[F]=Formula [C]=Cask' 'Enter: Entfernen | Tab: Mehrfach'")
 
         [[ -z "$selection" ]] && return 0

--- a/terminal/.config/alias/btop.alias
+++ b/terminal/.config/alias/btop.alias
@@ -6,7 +6,7 @@
 # Docs        : https://github.com/aristocratos/btop
 # Config      : ~/.config/btop/btop.conf (Catppuccin Mocha Theme)
 # Ersetzt     : top (moderner Ressourcen-Monitor)
-# Aliase      : top
+# Aliase      : top, htop
 # ============================================================
 
 # Guard   : Nur wenn btop installiert ist

--- a/terminal/.config/alias/dotfiles.alias
+++ b/terminal/.config/alias/dotfiles.alias
@@ -87,7 +87,6 @@ if command -v fzf >/dev/null 2>&1 && command -v fd >/dev/null 2>&1; then
             | sort \
             | fzf --ansi --query="$query" \
                 --prompt='dotedit> ' \
-                --header='Enter: Editieren | Ctrl+Y: Pfad kopieren' \
                 --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Editieren' 'Ctrl+Y: Pfad kopieren'" \
                 --preview "zsh '$FZF_HELPER_DIR/preview' file '${dotdir}/'{}" \
                 --bind "enter:execute(${EDITOR:-vi} -- '${dotdir}/'{})+refresh-preview" \

--- a/terminal/.config/alias/fd.alias
+++ b/terminal/.config/alias/fd.alias
@@ -61,7 +61,6 @@ if command -v fzf >/dev/null 2>&1; then
 
         dir=$(fd --type d --hidden --follow --exclude .git . "${1:-.}" | \
             fzf --preview "$FZF_HELPER_DIR/preview dir {}" \
-                --header='Enter: Wechseln | Ctrl+Y: Pfad kopieren' \
                 --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Wechseln' 'Ctrl+Y: Pfad kopieren'" \
                 --bind "ctrl-y:execute-silent($FZF_HELPER_DIR/action copy {})+abort")
 
@@ -74,7 +73,6 @@ if command -v fzf >/dev/null 2>&1; then
 
         file=$(fd --type f --hidden --follow --exclude .git . "${1:-.}" | \
             fzf --preview "$FZF_HELPER_DIR/preview file {}" \
-                --header='Enter: Öffnen | Ctrl+Y: Pfad kopieren' \
                 --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Öffnen' 'Ctrl+Y: Pfad kopieren'" \
                 --bind "ctrl-y:execute-silent($FZF_HELPER_DIR/action copy {})+abort")
 

--- a/terminal/.config/alias/fzf.alias
+++ b/terminal/.config/alias/fzf.alias
@@ -49,7 +49,6 @@ procs() {
         local mode="apps"
         fzf_opts+=(
             --prompt='Apps> '
-            --header='Enter: Beenden | Tab: Mehrfach | Ctrl+S: Apps ↔ Alle'
             --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Beenden | Tab: Mehrfach' 'Ctrl+S: Apps ↔ Alle'"
             --bind "ctrl-s:transform:[[ \$FZF_PROMPT == 'Apps> ' ]] && echo 'reload($FZF_HELPER_DIR/procs list all)+change-prompt(Alle> )' || echo 'reload($FZF_HELPER_DIR/procs list apps)+change-prompt(Apps> )'"
         )
@@ -57,7 +56,6 @@ procs() {
         local mode="all"
         fzf_opts+=(
             --prompt='Procs> '
-            --header='Enter: Beenden | Tab: Mehrfach'
             --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Beenden | Tab: Mehrfach'"
         )
     fi
@@ -82,7 +80,6 @@ help() {
     output=$("$FZF_HELPER_DIR/help" list man | \
         fzf --query="$query" --prompt='man> ' \
             --preview="$FZF_HELPER_DIR/help preview man {}" \
-            --header='Enter: öffnen | Ctrl+S: man ↔ tldr' \
             --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: öffnen' 'Ctrl+S: man ↔ tldr'" \
             --bind "ctrl-s:transform:$FZF_HELPER_DIR/help toggle" \
             --bind "enter:transform:[[ \$FZF_PROMPT == 'tldr> ' ]] && echo 'print(tldr)+accept' || echo 'print(man)+accept'")
@@ -137,7 +134,6 @@ cmds() {
         }
     ' | fzf --ansi --query="$query" \
         --prompt='tldr> ' \
-        --header='Enter: Übernehmen | Ctrl+S: tldr ↔ Code | Ctrl+E: Datei editieren' \
         --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Übernehmen' 'Ctrl+S: tldr ↔ Code' 'Ctrl+E: Datei editieren'" \
         --preview "[[ \$FZF_PROMPT == 'code> ' ]] && zsh '$FZF_HELPER_DIR/cmds' preview code {} || zsh '$FZF_HELPER_DIR/cmds' preview tldr {}" \
         --bind "ctrl-s:transform:[[ \$FZF_PROMPT == 'tldr> ' ]] && echo 'change-prompt(code> )+refresh-preview' || echo 'change-prompt(tldr> )+refresh-preview'" \
@@ -187,7 +183,6 @@ vars() {
     }
 
     selection=$(printenv | grep -E '^[a-zA-Z_][a-zA-Z0-9_]*=' | sort | _fenv_colorize | fzf --ansi --query="$query" \
-        --header='Enter: Export → Edit | Ctrl+Y: Wert kopieren' \
         --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Export → Edit' 'Ctrl+Y: Wert kopieren'" \
         --preview='n=$(echo {} | cut -d"│" -f1 | xargs | grep -E "^[a-zA-Z_][a-zA-Z0-9_]*$")
             [[ -z "$n" ]] && exit 0

--- a/terminal/.config/alias/gh.alias
+++ b/terminal/.config/alias/gh.alias
@@ -40,7 +40,6 @@ if command -v fzf >/dev/null 2>&1; then
                 --delimiter='\t' \
                 --prompt='Open> ' \
                 --preview 'gh pr view {1}' \
-                --header='Enter: Checkout/Browser | Ctrl+D: Diff | Ctrl+O: Browser | Ctrl+S: Open ↔ Alle' \
                 --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Checkout/Browser | Ctrl+D: Diff' 'Ctrl+O: Browser | Ctrl+S: Open ↔ Alle'" \
                 --bind 'ctrl-o:execute-silent(gh pr view {1} --web)' \
                 --bind 'ctrl-d:execute(gh pr diff {1} | bat --color=always -l diff)' \
@@ -67,7 +66,6 @@ if command -v fzf >/dev/null 2>&1; then
                 --delimiter='\t' \
                 --prompt='Open> ' \
                 --preview 'gh issue view {1}' \
-                --header='Enter: Browser | Ctrl+E: Bearbeiten | Ctrl+S: Open ↔ Alle' \
                 --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Browser | Ctrl+E: Bearbeiten' 'Ctrl+S: Open ↔ Alle'" \
                 --bind 'ctrl-e:execute(gh issue edit {1})' \
                 --bind "ctrl-s:transform:[[ \$FZF_PROMPT == 'Open> ' ]] && echo 'reload($FZF_HELPER_DIR/gh list-issue all)+change-prompt(Alle> )' || echo 'reload($FZF_HELPER_DIR/gh list-issue open)+change-prompt(Open> )'" | \
@@ -104,7 +102,6 @@ if command -v fzf >/dev/null 2>&1; then
             fzf --ansi --query="$query" \
                 --delimiter='\t' \
                 --preview 'gh run view {1}' \
-                --header='Enter: Logs | Ctrl+R: Rerun | Ctrl+O: Browser' \
                 --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Logs | Ctrl+R: Rerun' 'Ctrl+O: Browser'" \
                 --bind 'ctrl-o:execute-silent(gh run view {1} --web)' \
                 --bind 'ctrl-r:execute(gh run rerun {1})' | \
@@ -120,7 +117,6 @@ if command -v fzf >/dev/null 2>&1; then
         repo=$(gh repo list --limit 30 | \
             fzf --ansi --query="$query" \
                 --preview 'gh repo view {1}' \
-                --header='Enter: Klonen | Ctrl+O: Browser' \
                 --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Klonen' 'Ctrl+O: Browser'" \
                 --bind 'ctrl-o:execute-silent(gh repo view {1} --web)' | \
             awk '{print $1}')
@@ -135,7 +131,6 @@ if command -v fzf >/dev/null 2>&1; then
         gist=$(gh gist list --limit 30 | \
             fzf --ansi --query="$query" \
                 --preview 'gh gist view {1}' \
-                --header='Enter: Anzeigen | Ctrl+E: Bearbeiten | Ctrl+O: Browser' \
                 --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Anzeigen' 'Ctrl+E: Bearbeiten | Ctrl+O: Browser'" \
                 --bind 'ctrl-e:execute(gh gist edit {1})' \
                 --bind 'ctrl-o:execute-silent(gh gist view {1} --web)' | \

--- a/terminal/.config/alias/git.alias
+++ b/terminal/.config/alias/git.alias
@@ -63,7 +63,6 @@ if command -v fzf >/dev/null 2>&1; then
             fzf --ansi --no-sort --reverse --query="$query" \
                 --freeze-left=1 \
                 --preview 'git show --color=always {1} | bat --style=numbers --color=always -l diff 2>/dev/null || git show --color=always {1}' \
-                --header='Enter: Anzeigen | Ctrl+Y: SHA kopieren' \
                 --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Anzeigen' 'Ctrl+Y: SHA kopieren'" \
                 --bind "ctrl-y:execute-silent($FZF_HELPER_DIR/action copy {1})+abort" | \
             awk '{print $1}')
@@ -85,7 +84,6 @@ if command -v fzf >/dev/null 2>&1; then
             grep -v HEAD | \
             fzf --ansi --query="$query" \
                 --preview 'git log --oneline --color=always {1} | head -20' \
-                --header='Enter: Checkout | Ctrl+D: Löschen' \
                 --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Checkout' 'Ctrl+D: Löschen'" \
                 --bind 'ctrl-d:execute(read -q "REPLY?Branch {1} löschen? [y/N] " && git branch -d {1}; echo)+reload(git branch --all --color=always | grep -v HEAD)' | \
             sed 's/^[* ]*//' | sed 's|remotes/[^/]*/||')
@@ -103,7 +101,6 @@ if command -v fzf >/dev/null 2>&1; then
         files=$(git -c color.status=always -c core.quotepath=off status --short | sed 's/ "\(.*\)"$/ \1/' | \
             fzf --ansi --multi --query="$query" \
                 --preview "$FZF_HELPER_DIR/action git-diff {2..}" \
-                --header='Enter: Add | Tab: Mehrfach | Ctrl+R: Reset' \
                 --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Add | Tab: Mehrfach' 'Ctrl+R: Reset'" \
                 --bind "ctrl-r:execute($FZF_HELPER_DIR/action git-restore {+2..})+reload(git -c color.status=always -c core.quotepath=off status --short | sed 's/ \"\\(.*\\)\"\$/ \\1/')" | \
             awk '{$1=""; print substr($0,2)}')
@@ -124,7 +121,6 @@ if command -v fzf >/dev/null 2>&1; then
         stash=$(git stash list | \
             fzf --ansi --query="$query" \
                 --preview 'echo {} | cut -d: -f1 | xargs git stash show -p | { bat --style=numbers --color=always -l diff 2>/dev/null || cat; }' \
-                --header='Enter: Apply | Ctrl+P: Pop | Ctrl+D: Drop' \
                 --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Apply' 'Ctrl+P: Pop | Ctrl+D: Drop'" \
                 --bind 'ctrl-d:execute(echo {} | cut -d: -f1 | xargs git stash drop)+reload(git stash list)' \
                 --bind 'ctrl-p:execute(echo {} | cut -d: -f1 | xargs git stash pop)+abort' | \

--- a/terminal/.config/alias/rg.alias
+++ b/terminal/.config/alias/rg.alias
@@ -77,7 +77,6 @@ if command -v fzf >/dev/null 2>&1; then
             --freeze-left=1 \
             --preview "$FZF_HELPER_DIR/preview file {1} {2}" \
             --preview-window 'up,60%,border-bottom,+{2}+3/3,~3' \
-            --header='Enter: Datei öffnen | Ctrl+Y: Pfad kopieren' \
             --bind "start:+transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Datei öffnen' 'Ctrl+Y: Pfad kopieren'" \
             --bind "resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Datei öffnen' 'Ctrl+Y: Pfad kopieren'" \
             --bind "ctrl-y:execute-silent($FZF_HELPER_DIR/action copy {1})+abort" \

--- a/terminal/.config/alias/zoxide.alias
+++ b/terminal/.config/alias/zoxide.alias
@@ -34,7 +34,7 @@ fi
 # Interaktive Funktionen (mit fzf)
 # ------------------------------------------------------------
 if command -v fzf >/dev/null 2>&1; then
-    # zoxide Browser(suche?) – Enter=Wechseln, Ctrl+D=Löschen, Ctrl+Y=Kopieren
+    # zoxide Browser(suche?) – Enter=Wechseln, Ctrl+D=Eintrag löschen, Ctrl+Y=Pfad kopieren
     zj() {
         local query="${1:-}"
         local selection dir
@@ -46,7 +46,6 @@ if command -v fzf >/dev/null 2>&1; then
                 --preview "$FZF_HELPER_DIR/preview dir {2..} 2" \
                 --bind "ctrl-d:execute-silent($FZF_HELPER_DIR/action zoxide-remove {2..})+reload(zoxide query -l -s)" \
                 --bind "ctrl-y:execute-silent($FZF_HELPER_DIR/action copy {2..})" \
-                --header='Enter: Wechseln | Ctrl+D: Eintrag löschen | Ctrl+Y: Pfad kopieren' \
                 --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Wechseln' 'Ctrl+D: Eintrag löschen' 'Ctrl+Y: Pfad kopieren'")
 
         # Pfad extrahieren: Score entfernen (awk ist sicherer bei Leerzeichen)

--- a/terminal/.config/fzf/init.zsh
+++ b/terminal/.config/fzf/init.zsh
@@ -29,11 +29,10 @@ if command -v fd >/dev/null 2>&1; then
     export FZF_ALT_C_COMMAND='fd --type d --strip-cwd-prefix --hidden --follow --exclude .git'
 fi
 
-# Ctrl+X 1: History-Suche mit Kopier-Funktion
+# Ctrl+X 1: History-Suche – Ctrl+Y=Kopieren
 # Nutzt fzf/action für plattformübergreifendes Clipboard
 export FZF_CTRL_R_OPTS="
     --bind 'ctrl-y:execute-silent(${FZF_HELPER_DIR}/action copy {2..})+abort'
-    --header 'Ctrl+Y: Kopieren'
     --bind \"start,resize:transform-header:${FZF_HELPER_DIR}/header-wrap 'Ctrl+Y: Kopieren'\""
 
 # Ctrl+X 2: Dateisuche mit Syntax-Highlighting Vorschau

--- a/terminal/.config/tealdeer/pages/bat.patch.md
+++ b/terminal/.config/tealdeer/pages/bat.patch.md
@@ -14,6 +14,6 @@
 
 `catd`
 
-- dotfiles: Theme Browser (`<Enter>` Aktivieren):
+- dotfiles: Theme Browser (`<Enter>` Theme aktivieren):
 
 `bat-theme {{suche}}`

--- a/terminal/.config/tealdeer/pages/dotfiles.page.md
+++ b/terminal/.config/tealdeer/pages/dotfiles.page.md
@@ -53,7 +53,7 @@
 
 - top → btop (moderner Ressourcen-Monitor):
 
-`top`
+`top, htop`
 
 - ls → eza (mit Icons und Git-Status):
 

--- a/terminal/.config/tealdeer/pages/zoxide.patch.md
+++ b/terminal/.config/tealdeer/pages/zoxide.patch.md
@@ -1,5 +1,5 @@
 - dotfiles: Nutzt `fzf (Interactive), eza (Preview)`
 
-- dotfiles: zoxide Browser (`<Enter>` Wechseln, `<Ctrl d>` Löschen, `<Ctrl y>` Kopieren):
+- dotfiles: zoxide Browser (`<Enter>` Wechseln, `<Ctrl d>` Eintrag löschen, `<Ctrl y>` Pfad kopieren):
 
 `zj {{suche}}`


### PR DESCRIPTION
# Beschreibung

Entfernt die redundante `--header`-Quelle aus allen 23 fzf-Funktionen und führt einen automatisierten Sync-Check zwischen den verbleibenden zwei Quellen ein: **Beschreibungskommentar** (Autorität) und **header-wrap** (dynamische UI).

Closes #305

## Art der Änderung

- [x] Neues Feature / Erweiterung
- [x] Dokumentations-Update
- [x] CI/CD / Tooling

## Änderungen

### --header entfernt (24 Aufrufe in 11 Dateien)
`transform-header` ersetzt `--header` beim `start`-Event sofort → `--header` war redundant als Fallback. Entfernt aus:
- `7z.alias`, `bat.alias`, `brew.alias` (×2), `dotfiles.alias`
- `fd.alias` (×2), `fzf.alias` (×5), `gh.alias` (×5)
- `git.alias` (×4), `rg.alias`, `zoxide.alias`, `init.zsh`

### 3 Keybinding-Drifts korrigiert
- **zj**: `Ctrl+D=Löschen` → `Ctrl+D=Eintrag löschen`, `Ctrl+Y=Kopieren` → `Ctrl+Y=Pfad kopieren`
- **bat-theme**: `Enter=Aktivieren` → `Enter=Theme aktivieren`
- **btop**: `# Aliase : top` → `# Aliase : top, htop`

### check-header-sync.sh (neuer Pre-Commit Check 10)
- Vergleicht Keybindings zwischen Beschreibungskommentar und header-wrap-Argumenten
- Normalisiert beide Formate (`Key=Aktion` vs. `Key: Aktion`) und vergleicht Sets
- Überspringt Legenden (`[F]=Formula [C]=Cask`)
- Unterstützt Plattform-Branches (procs: macOS/Linux Vereinigung)
- Erkennt Funktionen mit Ziffern-Anfang (7zf)
- Behandelt eingerückte Kommentare (in `if`-Blöcken)

### Dokumentation
- **CONTRIBUTING.md**: Neue Sektion „Keybinding-Architektur (Drift-Prävention)" mit Zwei-Quellen-Modell, Sync-Regel, Sonderfällen, Checkliste für neue Funktionen
- **init.zsh**: Beschreibungskommentar im `Key=Aktion`-Format
- **Generierte Docs**: bat.patch.md, zoxide.patch.md, dotfiles.page.md aktualisiert

## Checkliste

- [x] `.github/scripts/generate-docs.sh --generate` ausgeführt
- [x] `.github/scripts/health-check.sh` bestanden
- [x] Alle 10 Pre-Commit Checks bestanden
- [x] header-wrap Selbsttests: 33/33
- [x] check-header-sync.sh: 23/23 Funktionen synchron
- [x] Keine neuen Markdown-Lint-Fehler

## Labels

enhancement