### PR TITLE
feat(ux): Konsistenz bei Keybindings und Multi-Select

### DIFF
--- a/terminal/.config/alias/dotfiles.alias
+++ b/terminal/.config/alias/dotfiles.alias
@@ -90,6 +90,6 @@ if command -v fzf >/dev/null 2>&1 && command -v fd >/dev/null 2>&1; then
                 --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Editieren' 'Ctrl+Y: Pfad kopieren'" \
                 --preview "zsh '$FZF_HELPER_DIR/preview' file '${dotdir}/'{}" \
                 --bind "enter:execute(${EDITOR:-vi} -- '${dotdir}/'{})+refresh-preview" \
-                --bind "ctrl-y:execute-silent('$FZF_HELPER_DIR/action' copy '${dotdir}/'{})+abort"
+                --bind "ctrl-y:execute-silent('$FZF_HELPER_DIR/action' copy '${dotdir}/'{})"
     }
 fi

--- a/terminal/.config/alias/fd.alias
+++ b/terminal/.config/alias/fd.alias
@@ -67,16 +67,17 @@ if command -v fzf >/dev/null 2>&1; then
         [[ -n "$dir" ]] && cd "$dir"
     }
 
-    # Datei öffnen(pfad=.) – Enter=Öffnen, Ctrl+Y=Pfad kopieren
+    # Dateien öffnen(pfad=.) – Enter=Öffnen, Tab=Mehrfach, Ctrl+Y=Pfad kopieren
     pick() {
-        local file
+        local files
 
-        file=$(fd --type f --hidden --follow --exclude .git . "${1:-.}" | \
-            fzf --preview "$FZF_HELPER_DIR/preview file {}" \
-                --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Öffnen' 'Ctrl+Y: Pfad kopieren'" \
-                --bind "ctrl-y:execute-silent($FZF_HELPER_DIR/action copy {})+abort")
+        files=$(fd --type f --hidden --follow --exclude .git . "${1:-.}" | \
+            fzf --multi \
+                --preview "$FZF_HELPER_DIR/preview file {}" \
+                --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Öffnen | Tab: Mehrfach' 'Ctrl+Y: Pfad kopieren'" \
+                --bind "ctrl-y:execute-silent($FZF_HELPER_DIR/action copy {})")
 
         # xopen aus platform.zsh (wird vor Aliase geladen)
-        [[ -n "$file" ]] && xopen "$file"
+        [[ -n "$files" ]] && while IFS= read -r f; do xopen "$f"; done <<< "$files"
     }
 fi

--- a/terminal/.config/alias/gh.alias
+++ b/terminal/.config/alias/gh.alias
@@ -31,7 +31,7 @@ alias gh-status='gh status'
 # Interaktive Funktionen (mit fzf)
 # ------------------------------------------------------------
 if command -v fzf >/dev/null 2>&1; then
-    # PRs durchsuchen(suche?) – Enter=Checkout/Browser, Ctrl+D=Diff, Ctrl+O=Browser, Ctrl+S=Open ↔ Alle
+    # PRs durchsuchen(suche?) – Enter=Checkout/Browser, Ctrl+D=Diff, Ctrl+O=Browser, Ctrl+S=Open ↔ Alle, Ctrl+Y=Nr. kopieren
     gh-pr() {
         local query="${1:-}"
         local result pr_num pr_state
@@ -40,10 +40,11 @@ if command -v fzf >/dev/null 2>&1; then
                 --delimiter='\t' \
                 --prompt='Open> ' \
                 --preview 'gh pr view {1}' \
-                --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Checkout/Browser | Ctrl+D: Diff' 'Ctrl+O: Browser | Ctrl+S: Open ↔ Alle'" \
+                --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Checkout/Browser | Ctrl+D: Diff' 'Ctrl+O: Browser | Ctrl+S: Open ↔ Alle' 'Ctrl+Y: Nr. kopieren'" \
                 --bind 'ctrl-o:execute-silent(gh pr view {1} --web)' \
                 --bind 'ctrl-d:execute(gh pr diff {1} | bat --color=always -l diff)' \
-                --bind "ctrl-s:transform:[[ \$FZF_PROMPT == 'Open> ' ]] && echo 'reload($FZF_HELPER_DIR/gh list-pr all)+change-prompt(Alle> )' || echo 'reload($FZF_HELPER_DIR/gh list-pr open)+change-prompt(Open> )'"
+                --bind "ctrl-s:transform:[[ \$FZF_PROMPT == 'Open> ' ]] && echo 'reload($FZF_HELPER_DIR/gh list-pr all)+change-prompt(Alle> )' || echo 'reload($FZF_HELPER_DIR/gh list-pr open)+change-prompt(Open> )'" \
+                --bind "ctrl-y:execute-silent($FZF_HELPER_DIR/action copy {1})"
             )
 
         [[ -z "$result" ]] && return 0
@@ -57,7 +58,7 @@ if command -v fzf >/dev/null 2>&1; then
         fi
     }
 
-    # Issues durchsuchen(suche?) – Enter=Browser, Ctrl+E=Bearbeiten, Ctrl+S=Open ↔ Alle
+    # Issues durchsuchen(suche?) – Enter=Anzeigen, Ctrl+E=Bearbeiten, Ctrl+O=Browser, Ctrl+S=Open ↔ Alle, Ctrl+Y=Nr. kopieren
     gh-issue() {
         local query="${1:-}"
         local issue
@@ -66,15 +67,17 @@ if command -v fzf >/dev/null 2>&1; then
                 --delimiter='\t' \
                 --prompt='Open> ' \
                 --preview 'gh issue view {1}' \
-                --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Browser | Ctrl+E: Bearbeiten' 'Ctrl+S: Open ↔ Alle'" \
+                --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Anzeigen | Ctrl+E: Bearbeiten' 'Ctrl+O: Browser | Ctrl+S: Open ↔ Alle' 'Ctrl+Y: Nr. kopieren'" \
                 --bind 'ctrl-e:execute(gh issue edit {1})' \
-                --bind "ctrl-s:transform:[[ \$FZF_PROMPT == 'Open> ' ]] && echo 'reload($FZF_HELPER_DIR/gh list-issue all)+change-prompt(Alle> )' || echo 'reload($FZF_HELPER_DIR/gh list-issue open)+change-prompt(Open> )'" | \
+                --bind 'ctrl-o:execute-silent(gh issue view {1} --web)' \
+                --bind "ctrl-s:transform:[[ \$FZF_PROMPT == 'Open> ' ]] && echo 'reload($FZF_HELPER_DIR/gh list-issue all)+change-prompt(Alle> )' || echo 'reload($FZF_HELPER_DIR/gh list-issue open)+change-prompt(Open> )'" \
+                --bind "ctrl-y:execute-silent($FZF_HELPER_DIR/action copy {1})" | \
             cut -f1)
 
-        [[ -n "$issue" ]] && gh issue view "$issue" --web
+        [[ -n "$issue" ]] && gh issue view "$issue" | bat --color=always -l md
     }
 
-    # Actions Runs(suche?) – Enter=Logs, Ctrl+R=Rerun, Ctrl+O=Browser
+    # Actions Runs(suche?) – Enter=Logs, Ctrl+R=Rerun, Ctrl+O=Browser, Ctrl+Y=ID kopieren
     gh-run() {
         local query="${1:-}"
         local run_id
@@ -102,23 +105,25 @@ if command -v fzf >/dev/null 2>&1; then
             fzf --ansi --query="$query" \
                 --delimiter='\t' \
                 --preview 'gh run view {1}' \
-                --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Logs | Ctrl+R: Rerun' 'Ctrl+O: Browser'" \
+                --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Logs | Ctrl+R: Rerun' 'Ctrl+O: Browser' 'Ctrl+Y: ID kopieren'" \
                 --bind 'ctrl-o:execute-silent(gh run view {1} --web)' \
-                --bind 'ctrl-r:execute(gh run rerun {1})' | \
+                --bind 'ctrl-r:execute(gh run rerun {1})' \
+                --bind "ctrl-y:execute-silent($FZF_HELPER_DIR/action copy {1})" | \
             cut -f1)
 
         [[ -n "$run_id" ]] && gh run view "$run_id" --log | bat --color=always
     }
 
-    # Repo Browser(suche?) – Enter=Klonen, Ctrl+O=Browser
+    # Repo Browser(suche?) – Enter=Klonen, Ctrl+O=Browser, Ctrl+Y=Repo kopieren
     gh-repo() {
         local query="${1:-}"
         local repo
         repo=$(gh repo list --limit 30 | \
             fzf --ansi --query="$query" \
                 --preview 'gh repo view {1}' \
-                --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Klonen' 'Ctrl+O: Browser'" \
-                --bind 'ctrl-o:execute-silent(gh repo view {1} --web)' | \
+                --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Klonen' 'Ctrl+O: Browser' 'Ctrl+Y: Repo kopieren'" \
+                --bind 'ctrl-o:execute-silent(gh repo view {1} --web)' \
+                --bind "ctrl-y:execute-silent($FZF_HELPER_DIR/action copy {1})" | \
             awk '{print $1}')
 
         [[ -n "$repo" ]] && gh repo clone "$repo"

--- a/terminal/.config/alias/git.alias
+++ b/terminal/.config/alias/git.alias
@@ -76,7 +76,7 @@ if command -v fzf >/dev/null 2>&1; then
         fi
     }
 
-    # Branch wechseln(suche?) mit Log-Vorschau – Enter=Checkout, Ctrl+D=Löschen
+    # Branch wechseln(suche?) mit Log-Vorschau – Enter=Checkout, Ctrl+D=Löschen, Ctrl+Y=Branch kopieren
     git-branch() {
         local query="${1:-}"
         local branch
@@ -84,14 +84,15 @@ if command -v fzf >/dev/null 2>&1; then
             grep -v HEAD | \
             fzf --ansi --query="$query" \
                 --preview 'git log --oneline --color=always {1} | head -20' \
-                --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Checkout' 'Ctrl+D: Löschen'" \
-                --bind 'ctrl-d:execute(read -q "REPLY?Branch {1} löschen? [y/N] " && git branch -d {1}; echo)+reload(git branch --all --color=always | grep -v HEAD)' | \
+                --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Checkout' 'Ctrl+D: Löschen' 'Ctrl+Y: Branch kopieren'" \
+                --bind 'ctrl-d:execute(read -q "REPLY?Branch {1} löschen? [y/N] " && git branch -d {1}; echo)+reload(git branch --all --color=always | grep -v HEAD)' \
+                --bind "ctrl-y:execute-silent($FZF_HELPER_DIR/action copy-branch {})" | \
             sed 's/^[* ]*//' | sed 's|remotes/[^/]*/||')
 
         [[ -n "$branch" ]] && git checkout "$branch"
     }
 
-    # Status(suche?) mit Diff-Vorschau (bat) – Enter=Add, Tab=Mehrfach, Ctrl+R=Reset
+    # Status(suche?) mit Diff-Vorschau (bat) – Enter=Add, Tab=Mehrfach, Ctrl+R=Reset, Ctrl+Y=Pfad kopieren
     git-stage() {
         local query="${1:-}"
         local files
@@ -101,8 +102,9 @@ if command -v fzf >/dev/null 2>&1; then
         files=$(git -c color.status=always -c core.quotepath=off status --short | sed 's/ "\(.*\)"$/ \1/' | \
             fzf --ansi --multi --query="$query" \
                 --preview "$FZF_HELPER_DIR/action git-diff {2..}" \
-                --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Add | Tab: Mehrfach' 'Ctrl+R: Reset'" \
-                --bind "ctrl-r:execute($FZF_HELPER_DIR/action git-restore {+2..})+reload(git -c color.status=always -c core.quotepath=off status --short | sed 's/ \"\\(.*\\)\"\$/ \\1/')" | \
+                --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Add | Tab: Mehrfach' 'Ctrl+R: Reset' 'Ctrl+Y: Pfad kopieren'" \
+                --bind "ctrl-r:execute($FZF_HELPER_DIR/action git-restore {+2..})+reload(git -c color.status=always -c core.quotepath=off status --short | sed 's/ \"\\(.*\\)\"\$/ \\1/')" \
+                --bind "ctrl-y:execute-silent($FZF_HELPER_DIR/action copy {2..})" | \
             awk '{$1=""; print substr($0,2)}')
 
         if [[ -n "$files" ]]; then
@@ -114,7 +116,7 @@ if command -v fzf >/dev/null 2>&1; then
         fi
     }
 
-    # Stash-Browser(suche?) – Enter=Apply, Ctrl+P=Pop, Ctrl+D=Drop
+    # Stash-Browser(suche?) – Enter=Apply, Ctrl+P=Pop, Ctrl+D=Drop, Ctrl+Y=Ref kopieren
     git-stash() {
         local query="${1:-}"
         local stash
@@ -122,9 +124,10 @@ if command -v fzf >/dev/null 2>&1; then
             fzf --ansi --query="$query" \
                 --delimiter ':' \
                 --preview 'git stash show -p {1} | { bat --style=numbers --color=always -l diff 2>/dev/null || cat; }' \
-                --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Apply' 'Ctrl+P: Pop | Ctrl+D: Drop'" \
+                --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Apply' 'Ctrl+P: Pop | Ctrl+D: Drop' 'Ctrl+Y: Ref kopieren'" \
                 --bind 'ctrl-d:execute(git stash drop {1})+reload(git stash list)' \
-                --bind 'ctrl-p:execute(git stash pop {1})+abort' | \
+                --bind 'ctrl-p:execute(git stash pop {1})+abort' \
+                --bind "ctrl-y:execute-silent($FZF_HELPER_DIR/action copy {1})" | \
             cut -d: -f1)
 
         [[ -n "$stash" ]] && git stash apply "$stash"

--- a/terminal/.config/fzf/action
+++ b/terminal/.config/fzf/action
@@ -7,8 +7,8 @@
 # Aufruf      : ~/.config/fzf/action <command> "argument" [...]
 # Nutzt       : platform.zsh (clip)
 # ============================================================
-# Commands: copy, copy-env, edit, git-diff, git-restore, git-add,
-#           zoxide-remove
+# Commands: copy, copy-branch, copy-env, edit, git-diff, git-restore,
+#           git-add, zoxide-remove
 # ============================================================
 
 # Plattform-Abstraktionen laden (clip)
@@ -27,6 +27,16 @@ case "${1:-}" in
         # Pfad ins Clipboard kopieren
         shift
         printf '%s' "$1" | clip
+        ;;
+    copy-branch)
+        # Branch-Name aus fzf-Zeile bereinigen und kopieren
+        # Input per {}: "* main", "  feature-branch", "  remotes/origin/feat/x"
+        # fzf --ansi strippt ANSI-Codes; sed entfernt ANSI als Defense-in-Depth
+        shift
+        printf '%s' "$*" \
+            | sed 's/\x1b\[[0-9;]*m//g; s/^[* ]*//' \
+            | sed 's|^remotes/[^/]*/||' \
+            | clip
         ;;
     copy-env)
         # Umgebungsvariable aus farbkodierter fzf-Zeile ins Clipboard kopieren
@@ -80,6 +90,7 @@ Usage: ~/.config/fzf/action <command> [args...]
 
 Commands:
   copy <path>            Pfad ins Clipboard kopieren
+  copy-branch <line>     Branch aus git-branch-Zeile bereinigen + kopieren
   copy-env <fzf-line>    Umgebungsvariable aus vars()-Zeile kopieren
   edit <file> [line]     Datei im Editor öffnen
   git-diff <file>        Git diff für Datei anzeigen

--- a/terminal/.config/tealdeer/pages/fd.patch.md
+++ b/terminal/.config/tealdeer/pages/fd.patch.md
@@ -46,6 +46,6 @@
 
 `jump {{pfad}}`
 
-- dotfiles: Datei öffnen (`<Enter>` Öffnen, `<Ctrl y>` Pfad kopieren):
+- dotfiles: Dateien öffnen (`<Enter>` Öffnen, `<Tab>` Mehrfach, `<Ctrl y>` Pfad kopieren):
 
 `pick {{pfad}}`

--- a/terminal/.config/tealdeer/pages/gh.patch.md
+++ b/terminal/.config/tealdeer/pages/gh.patch.md
@@ -8,19 +8,19 @@
 
 `gh-status`
 
-- dotfiles: PRs durchsuchen (`<Enter>` Checkout/Browser, `<Ctrl d>` Diff, `<Ctrl o>` Browser, `<Ctrl s>` Open ↔ Alle):
+- dotfiles: PRs durchsuchen (`<Enter>` Checkout/Browser, `<Ctrl d>` Diff, `<Ctrl o>` Browser, `<Ctrl s>` Open ↔ Alle, `<Ctrl y>` Nr. kopieren):
 
 `gh-pr {{suche}}`
 
-- dotfiles: Issues durchsuchen (`<Enter>` Browser, `<Ctrl e>` Bearbeiten, `<Ctrl s>` Open ↔ Alle):
+- dotfiles: Issues durchsuchen (`<Enter>` Anzeigen, `<Ctrl e>` Bearbeiten, `<Ctrl o>` Browser, `<Ctrl s>` Open ↔ Alle, `<Ctrl y>` Nr. kopieren):
 
 `gh-issue {{suche}}`
 
-- dotfiles: Actions Runs (`<Enter>` Logs, `<Ctrl r>` Rerun, `<Ctrl o>` Browser):
+- dotfiles: Actions Runs (`<Enter>` Logs, `<Ctrl r>` Rerun, `<Ctrl o>` Browser, `<Ctrl y>` ID kopieren):
 
 `gh-run {{suche}}`
 
-- dotfiles: Repo Browser (`<Enter>` Klonen, `<Ctrl o>` Browser):
+- dotfiles: Repo Browser (`<Enter>` Klonen, `<Ctrl o>` Browser, `<Ctrl y>` Repo kopieren):
 
 `gh-repo {{suche}}`
 

--- a/terminal/.config/tealdeer/pages/git.patch.md
+++ b/terminal/.config/tealdeer/pages/git.patch.md
@@ -44,14 +44,14 @@
 
 `git-log {{suche}}`
 
-- dotfiles: Branch wechseln (`<Enter>` Checkout, `<Ctrl d>` Löschen):
+- dotfiles: Branch wechseln (`<Enter>` Checkout, `<Ctrl d>` Löschen, `<Ctrl y>` Branch kopieren):
 
 `git-branch {{suche}}`
 
-- dotfiles: Status (`<Enter>` Add, `<Tab>` Mehrfach, `<Ctrl r>` Reset):
+- dotfiles: Status (`<Enter>` Add, `<Tab>` Mehrfach, `<Ctrl r>` Reset, `<Ctrl y>` Pfad kopieren):
 
 `git-stage {{suche}}`
 
-- dotfiles: Stash-Browser (`<Enter>` Apply, `<Ctrl p>` Pop, `<Ctrl d>` Drop):
+- dotfiles: Stash-Browser (`<Enter>` Apply, `<Ctrl p>` Pop, `<Ctrl d>` Drop, `<Ctrl y>` Ref kopieren):
 
 `git-stash {{suche}}`


### PR DESCRIPTION
## Beschreibung

Einheitliches Keybinding-Schema für alle fzf-Funktionen:

**Phase 1 – Ctrl+Y nachrüsten (7 Funktionen + 1 Fix):**
- `gh-pr`, `gh-issue`, `gh-run`, `gh-repo`: Ctrl+Y kopiert ID/Nr/Name
- `git-branch`, `git-stage`, `git-stash`: Ctrl+Y kopiert Ref/Pfad
- `dotedit`: +abort entfernt (Browser-Muster, kein One-Shot)

**Phase 2 – gh-issue Enter → Terminal-View:**
- Enter zeigt Issue im Terminal (via bat) statt Browser
- Ctrl+O öffnet im Browser (konsistent mit gh-pr)
- `--comments` Flag entfernt (Bug: 0 Bytes Output bei Issues ohne Kommentare)

**Phase 3 – pick --multi:**
- `--multi` Flag hinzugefügt, Loop öffnet alle gewählten Dateien
- +abort bei Ctrl+Y entfernt (Browser-Muster)

**Zusätzlicher Fix (beim Testen gefunden):**
- `gh-repo`: +abort bei Ctrl+Y entfernt (hat Ctrl+O → ist Browser, kein One-Shot)

## Art der Änderung

- [ ] 🐛 Bugfix
- [x] ✨ Neues Feature
- [ ] 📝 Dokumentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Konfiguration/Maintenance

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Bei neuen Tools: Guard-Check vorhanden

## Zusammenhängende Issues

Schließt #284