### PR TITLE
fix(ci): Supply-Chain-Hardening für Workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,13 +17,23 @@ on:
     branches: [main]
   workflow_dispatch:  # Manuelles Triggern ermöglichen
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
+    # macos-latest: Bewusst nicht gepinnt – Workflow validiert nur Syntax, Docs
+    # und Format. Keine macOS-spezifischen Features nötig. Dependabot kann
+    # Runner-Labels nicht aktualisieren, Pinning erfordert manuelle Wartung.
     runs-on: macos-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: ZSH-Syntax prüfen
         shell: zsh {0}
@@ -80,13 +90,15 @@ jobs:
           echo "✔ POSIX-Syntax OK"
 
       - name: Execute-Berechtigungen prüfen
+        shell: zsh {0}
         run: ./.github/scripts/check-executable-permissions.sh
 
       - name: Plattform-Sync prüfen
+        shell: zsh {0}
         run: ./.github/scripts/check-platform-sync.sh
 
       - name: Homebrew Cache
-        uses: actions/cache@v5
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ~/Library/Caches/Homebrew
           key: ${{ runner.os }}-homebrew-${{ hashFiles('setup/Brewfile') }}


### PR DESCRIPTION
## Beschreibung

Supply-Chain-Hardening für den GitHub Actions Workflow gemäß aktuellen Best Practices. Alle vier Findings aus Issue #313 werden adressiert, plus ein zusätzlicher Shell-Konsistenz-Fix.

**Änderungen:**
- **Permissions:** `contents: read` als Top-Level-Deklaration (Least Privilege)
- **Concurrency:** Workflow+Branch scoped mit `cancel-in-progress: true`
- **SHA-Pinning:** `actions/checkout` v6.0.2, `actions/cache` v5.0.3 – SHAs via GitHub API verifiziert, Dependabot-kompatibel durch `# vX.Y.Z` Kommentare
- **Runner:** `macos-latest` bewusst beibehalten (dokumentiert) – Workflow validiert nur Syntax/Docs/Format, keine macOS-spezifischen Features nötig; Dependabot kann Runner-Labels nicht aktualisieren
- **Shell-Konsistenz:** `shell: zsh {0}` für alle Steps die ZSH-Skripte aufrufen (2 fehlten)

## Art der Änderung

- [x] 🐛 Bugfix

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Bei neuen Tools: Guard-Check vorhanden

## Zusammenhängende Issues

Schließt #313