### PR TITLE
fix(dotfiles): PWD-Leak in dotstow() beheben

### DIFF
--- a/terminal/.config/alias/dotfiles.alias
+++ b/terminal/.config/alias/dotfiles.alias
@@ -63,7 +63,7 @@ dotstow() {
         return 1
     fi
 
-    cd "$dotdir" && stow -R "${pkgs[@]}"
+    (cd "$dotdir" && stow -R "${pkgs[@]}")
 }
 
 # Guard: fzf+fd für interaktive Funktionen


### PR DESCRIPTION
## Beschreibung

`dotstow()` änderte mit `cd "$dotdir"` das Arbeitsverzeichnis der aufrufenden Shell dauerhaft. Nach dem Aufruf befand sich der User im dotfiles-Verzeichnis statt in seinem vorherigen Pfad.

**Fix:** Subshell `(cd ... && stow ...)` isoliert den Verzeichniswechsel. Der Exit-Code von `stow` wird automatisch propagiert, `.stowrc` wird weiterhin korrekt gelesen (da CWD in der Subshell auf das dotfiles-Verzeichnis gesetzt wird).

**Bewertete Alternativen:**
- `pushd`/`popd`: Mehr Boilerplate, besser bei mehreren Operationen (wie in `stow.sh`), hier Overkill
- `stow -d "$dotdir"`: Scheidet aus – `.stowrc` liegt nur in `~/dotfiles/`, nicht in `~/.stowrc`. Ohne `cd` ins dotfiles-Verzeichnis würde Stow die Resource-File nicht finden → `--no-folding` und Ignore-Patterns greifen nicht

## Art der Änderung

- [x] 🐛 Bugfix

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Bei neuen Tools: Guard-Check vorhanden

## Zusammenhängende Issues

Schließt #314

## Terminal-Ausgabe

```
cd /tmp && source dotfiles.alias && pwd && dotstow && pwd
/tmp
/tmp   ← PWD bleibt erhalten
```