### PR TITLE
chore(starship): Entfernte Optionen aus cmd_duration bereinigen

### DIFF
--- a/terminal/.config/starship/starship.toml
+++ b/terminal/.config/starship/starship.toml
@@ -172,8 +172,6 @@ show_milliseconds = true
 format = " in [$duration]($style) "
 style = "fg:lavender"
 disabled = false
-show_notifications = true
-min_time_to_notify = 45000
 
 [palettes.catppuccin_mocha]
 rosewater = "#f5e0dc"


### PR DESCRIPTION
## Beschreibung

Entfernt zwei veraltete Optionen aus dem `[cmd_duration]`-Block der Starship-Konfiguration:

- `show_notifications = true` – Desktop-Benachrichtigungen bei langen Befehlen
- `min_time_to_notify = 45000` – Mindestzeit vor Benachrichtigung

Beide Optionen wurden seit Starship ~1.0 entfernt (wegen Portabilitätsproblemen mit `notify-rust`) und werden stillschweigend ignoriert. Installierte Version: Starship 1.24.2.

## Art der Änderung

- [x] 🔧 Konfiguration/Maintenance

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Bei neuen Tools: Guard-Check vorhanden

## Zusammenhängende Issues

Schließt #316