### PR TITLE
fix(docs): Tippfehler und Semantik-Tabelle korrigieren

### DIFF
--- a/.github/scripts/generators/setup.sh
+++ b/.github/scripts/generators/setup.sh
@@ -62,7 +62,7 @@ Falls du die dotfiles-Installation rückgängig machen möchtest:
 | Aktion | Beschreibung |
 | ------ | ------------ |
 | Symlinks entfernen | Alle dotfiles-Symlinks aus `~` werden gelöscht |
-| Backup wiederstellen | Originale Konfigurationsdateien werden aus `.backup/` zurückkopiert |
+| Backup wiederherstellen | Originale Konfigurationsdateien werden aus `.backup/` zurückkopiert |
 | Terminal-Profil | Wird auf "Basic" zurückgesetzt (macOS) |
 
 ### Optionen

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -276,7 +276,7 @@ Falls du die dotfiles-Installation rückgängig machen möchtest:
 | Aktion | Beschreibung |
 | ------ | ------------ |
 | Symlinks entfernen | Alle dotfiles-Symlinks aus `~` werden gelöscht |
-| Backup wiederstellen | Originale Konfigurationsdateien werden aus `.backup/` zurückkopiert |
+| Backup wiederherstellen | Originale Konfigurationsdateien werden aus `.backup/` zurückkopiert |
 | Terminal-Profil | Wird auf "Basic" zurückgesetzt (macOS) |
 
 ### Optionen

--- a/terminal/.config/theme-style
+++ b/terminal/.config/theme-style
@@ -136,7 +136,7 @@ typeset -gx RGB_SURFACE1="69;71;90"
 #   Error/Invalid       │ Red      │ #F38BA8 │ Fehler, Git Deleted
 #   Warning/Modified    │ Yellow   │ #F9E2AF │ Git Modified, Warnungen
 #   Info/Link           │ Blue     │ #89B4FA │ Symlinks, URLs, Referenzen
-#   Special/Executable  │ Teal     │ #94E2D5 │ Ausführbare Dateien
+#   Special/Executable  │ Green    │ #A6E3A1 │ Ausführbare Dateien
 #   Directory           │ Mauve    │ #CBA6F7 │ Verzeichnisse
 #   String              │ Yellow   │ #F9E2AF │ Strings in Code/Shell
 #   Variable/Parameter  │ Mauve    │ #CBA6F7 │ Variablen in Beispielen


### PR DESCRIPTION
## Beschreibung

Zwei Dokumentations-Inkonsistenzen behoben:

1. **Tippfehler:** „wiederstellen" → „wiederherstellen" im Generator `setup.sh` und der generierten `docs/setup.md`
2. **Semantik-Tabelle:** Executable-Farbe von Teal/#94E2D5 auf Green/#A6E3A1 korrigiert – entspricht der tatsächlichen Implementierung in eza, LS_COLORS und zsh-syntax-highlighting

## Art der Änderung

- [x] 🐛 Bugfix
- [x] 📝 Dokumentation

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Bei neuen Tools: Guard-Check vorhanden

## Zusammenhängende Issues

Schließt #317