### PR TITLE
refactor(ffmpeg): Deprecated Optionen durch moderne Syntax ersetzen

### DIFF
--- a/terminal/.config/alias/ffmpeg.alias
+++ b/terminal/.config/alias/ffmpeg.alias
@@ -26,7 +26,7 @@ v2mp3() {
     fi
     local input="$1"
     local output="${2:-${input%.*}.mp3}"
-    ffmpeg -i "$input" -vn -acodec libmp3lame -q:a 2 "$output"
+    ffmpeg -i "$input" -vn -c:a libmp3lame -q:a 2 "$output"
 }
 
 # ------------------------------------------------------------
@@ -41,7 +41,7 @@ vthumb() {
     local input="$1"
     local time="${2:-00:00:01}"
     local output="${3:-${input%.*}_thumb.jpg}"
-    ffmpeg -i "$input" -ss "$time" -vframes 1 -q:v 2 "$output"
+    ffmpeg -i "$input" -ss "$time" -frames:v 1 -q:v 2 "$output"
 }
 
 # ------------------------------------------------------------


### PR DESCRIPTION
## Beschreibung

Deprecated ffmpeg-Optionen durch moderne Stream-Specifier-Syntax ersetzen.

### Änderungen

| Funktion | Alt | Neu | Begründung |
|----------|-----|-----|------------|
| `v2mp3()` | `-acodec libmp3lame` | `-c:a libmp3lame` | ffmpeg 8.0.1 dokumentiert `-acodec` als "alias for -c:a" |
| `vthumb()` | `-vframes 1` | `-frames:v 1` | `-vframes` ist Legacy-Alias für `-frames[:<stream_spec>]` |

### Zusätzlicher Fund

Issue #318 adressiert nur `-acodec`, aber `-vframes` in `vthumb()` ist exakt dieselbe Kategorie deprecated Legacy-Alias. Beide wurden zusammen modernisiert.

### Konsistenz

Nach dem Fix verwenden alle 7 ffmpeg-Aufrufe in der Datei konsistent moderne Syntax:
- `-c:a` (Audio-Codec)
- `-c:v` (Video-Codec)
- `-c copy` (Stream Copy)
- `-frames:v` (Video-Frames)

Closes #318

## Art der Änderung

- [x] Refactoring (keine funktionale Änderung)

## Checkliste

- [x] `generate-docs --check` erfolgreich
- [x] `health-check.sh` erfolgreich (123/0/0)
- [x] Keine Legacy-Optionen mehr vorhanden (grep-Validierung)
- [x] ZSH-Syntax-Check bestanden
- [x] Pre-Commit Hooks bestanden (10/10)