### PR TITLE
refactor(bat): Defensiverer sed-Delimiter in bat-theme()

### DIFF
--- a/terminal/.config/alias/bat.alias
+++ b/terminal/.config/alias/bat.alias
@@ -47,8 +47,12 @@ if command -v fzf >/dev/null 2>&1; then
         [[ -z "$theme" ]] && return 0
 
         if [[ -f "$config_file" ]] && grep -q '^--theme=' "$config_file"; then
+            # sed-Sonderzeichen im Theme-Namen escapen (Delimiter: |)
+            local safe_theme="${theme//\\/\\\\}"
+            safe_theme="${safe_theme//|/\\|}"
+            safe_theme="${safe_theme//&/\\&}"
             # sedi aus platform.zsh (BSD/GNU kompatibel, wird vor Aliase geladen)
-            sedi "s/^--theme=.*$/--theme=\"$theme\"/" "$config_file"
+            sedi "s|^--theme=.*$|--theme=\"$safe_theme\"|" "$config_file"
             echo "✓ Theme aktiviert: $theme"
         else
             echo "✗ Konnte Config nicht aktualisieren"


### PR DESCRIPTION
## Beschreibung

Ändert den sed-Delimiter in `bat-theme()` von `/` auf `|` und escaped sed-Sonderzeichen (`\`, `|`, `&`) im Theme-Namen vor der Substitution.

**Vorher:** Theme-Namen mit sed-Sonderzeichen hätten die Substitution gebrochen.
**Nachher:** Beliebige Zeichen in Theme-Namen werden korrekt verarbeitet.

## Art der Änderung

- [ ] 🐛 Bugfix
- [ ] ✨ Neues Feature
- [ ] 📝 Dokumentation
- [x] ♻️ Refactoring
- [ ] 🔧 Konfiguration/Maintenance

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler (124/124)
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Bei neuen Tools: Guard-Check vorhanden

## Zusammenhängende Issues

Closes #336

## Terminal-Ausgabe

End-to-End-Tests mit echtem BSD sed auf macOS 26.3.1:

```
=== sed-Escape End-to-End-Tests ===
  ✔ Leerzeichen: --theme="Catppuccin Mocha"
  ✔ Klammern: --theme="Solarized (dark)"
  ✔ Nur Zahlen: --theme="1337"
  ✔ Pipe im Namen: --theme="Some|Theme"
  ✔ Ampersand im Namen: --theme="Dark&Light"
  ✔ Backslash im Namen: --theme="Back\slash"
  ✔ Alle Sonderzeichen: --theme="A|B&C\D/E"
  ✔ Einfacher Name: --theme="Normal"
```