### PR TITLE
fix(setup): Rückgabewerte in setup-Modulen prüfen

### DIFF
--- a/setup/modules/backup.sh
+++ b/setup/modules/backup.sh
@@ -374,7 +374,10 @@ backup_create_if_needed() {
     log "Analysiere $total_files Dateien..."
 
     # Manifest erstellen (inkl. Backups)
-    _create_manifest
+    _create_manifest || {
+        err "Backup-Manifest fehlgeschlagen – Abbruch"
+        return 1
+    }
 
     _backup_log "END: Backup abgeschlossen"
 
@@ -418,5 +421,5 @@ backup_info() {
 # ------------------------------------------------------------
 setup_backup() {
     CURRENT_STEP="Backup Setup"
-    backup_create_if_needed
+    backup_create_if_needed || return 1
 }

--- a/setup/modules/stow.sh
+++ b/setup/modules/stow.sh
@@ -164,7 +164,9 @@ run_stow() {
             [[ -n "$safe_line" ]] && warn "  $safe_line"
         done <<< "$stow_output"
         # Stash trotzdem wiederherstellen bei Fehler
-        _restore_stashed_changes
+        if ! _restore_stashed_changes; then
+            warn "Bootstrap fortgesetzt – Stash manuell wiederherstellen"
+        fi
         popd >/dev/null
         return 0
     fi
@@ -184,7 +186,9 @@ run_stow() {
     fi
 
     # Gestashte User-Änderungen wiederherstellen
-    _restore_stashed_changes
+    if ! _restore_stashed_changes; then
+        warn "Bootstrap fortgesetzt – Stash manuell wiederherstellen"
+    fi
 
     # CWD wiederherstellen
     popd >/dev/null


### PR DESCRIPTION
## Beschreibung

Rückgabewerte von internen Funktionen in `stow.sh` und `backup.sh` werden jetzt korrekt geprüft, sodass Fehler nicht mehr stillschweigend ignoriert werden.

**stow.sh:** `_restore_stashed_changes` kann bei merge-Konflikten `return 1` liefern – das wurde bisher ignoriert. Jetzt wird eine Warnung ausgegeben und der Bootstrap läuft weiter (Stash kann manuell wiederhergestellt werden).

**backup.sh:** `_create_manifest` und `backup_create_if_needed` konnten fehlschlagen, ohne dass der Fehler an den Aufrufer weitergeleitet wurde. Jetzt propagiert der Fehler korrekt.

## Art der Änderung

- [x] 🐛 Bugfix

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Bei neuen Tools: Guard-Check vorhanden

## Zusammenhängende Issues

Closes #337

## Screenshots / Terminal-Ausgabe

```
stow.sh:  if ! _restore_stashed_changes; then warn \"...\"; fi
backup.sh: _create_manifest || { err \"...\"; return 1; }
backup.sh: backup_create_if_needed || return 1
```