### PR TITLE
fix(setup): Cargo-Env-Variablen via Subshell isolieren

### DIFF
--- a/setup/modules/apt-packages.sh
+++ b/setup/modules/apt-packages.sh
@@ -245,7 +245,7 @@ _install_cargo_tools() {
     # nötig, Env-Variablen können auch bei Abbruch (Ctrl+C) nicht leaken
     (
         [[ -n "$cargo_jobs" ]] && export CARGO_BUILD_JOBS="$cargo_jobs"
-        [[ -n "$cargo_rustflags" ]] && export RUSTFLAGS="${cargo_rustflags} ${RUSTFLAGS:-}"
+        [[ -n "$cargo_rustflags" ]] && export RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }${cargo_rustflags}"
 
         for crate in "${missing_crates[@]}"; do
             log "Installiere $crate via cargo..."


### PR DESCRIPTION
## Beschreibung

`CARGO_BUILD_JOBS` und `RUSTFLAGS` werden in `_install_cargo_tools()` temporär für schwache Hardware (≤1 GB RAM) gesetzt. Bisher wurden die Werte manuell gesichert und nach der Schleife wiederhergestellt – bei Abbruch (Ctrl+C) blieben sie in der Shell-Umgebung.

Statt `trap RETURN` (feuert nicht bei `set -e` + SIGINT) wird die `cargo install`-Schleife in eine Subshell `( ... )` verlagert. Env-Variablen können so physisch nicht in die Parent-Shell leaken – unabhängig vom Exit-Grund.

### Warum Subshell statt `trap RETURN` (Issue-Vorschlag)

- `bootstrap.sh` setzt `set -euo pipefail` – bei SIGINT exitiert das Skript, nicht die Funktion → `RETURN`-Trap feuert nicht
- ZSH `RETURN`-Trap Verhalten variiert zwischen 5.8/5.9
- Subshell-Isolation ist fundamentale Unix-Semantik – kein Edge-Case möglich
- Bereits genutztes Muster im Repo (`backup.sh`, `dotfiles.alias`)
- Entfernt 15 Zeilen Backup/Restore-Logik ersatzlos

## Art der Änderung

- [x] 🐛 Bugfix
- [ ] ✨ Neues Feature
- [ ] 📝 Dokumentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Konfiguration/Maintenance

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Bei neuen Tools: Guard-Check vorhanden

## Zusammenhängende Issues

Closes #338

## Verifizierte Edge-Cases

| Szenario | Verhalten |
|---|---|
| Normaler Durchlauf | Subshell exit 0 → `return 0` |
| Crate fehlgeschlagen | `if/else` fängt → `warn` → loop weiter → exit 0 |
| `cargo_jobs=\"\"` (>1 GB RAM) | `[[ -n \"\" ]] && ...` → kein errexit (AND-OR-Liste) |
| SIGINT (Ctrl+C) | Subshell exit 130 → Parent `set -e` → EXIT-Trap mit `CURRENT_STEP=\"Cargo-Tools\"` |
| `source bootstrap.sh` | Env-Vars in Subshell isoliert → Parent-Shell sauber |