### PR TITLE
ci: Workflow auf ubuntu-latest migrieren

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -113,6 +113,8 @@ jobs:
           echo "Installiere tealdeer v1.8.1..."
           curl -fsSL "https://github.com/tealdeer-rs/tealdeer/releases/download/v1.8.1/tealdeer-linux-x86_64-musl" \
             -o /tmp/tldr
+          # SHA256-Verifizierung (offizielle Checksum von GitHub Releases)
+          echo "6f2fad4435e0110484d3f25cdc4bf20129dae03238f32d06ebdd00bdc50ae2ed  /tmp/tldr" | sha256sum -c
           sudo install -m 755 /tmp/tldr /usr/local/bin/tldr
           tldr --version
           echo "✔ tealdeer installiert"


### PR DESCRIPTION
## Beschreibung

Migriert den `validate`-Workflow von `macos-latest` (10× teurer) auf `ubuntu-latest`. Alle 11 CI-Checks sind Linux-kompatibel – der Workflow validiert nur Syntax, Docs und Format, keine macOS-spezifischen APIs.

**Abweichung vom Issue-Vorschlag:** Statt zwei Jobs (lint auf Linux + docs auf macOS) reicht ein einzelner Linux-Job, da alle Skripte bereits plattformunabhängig sind:
- `stat` BSD/GNU: korrekt verzweigt via `$OSTYPE` in `generators/tldr/core.sh`
- tealdeer Cache-Pfade: Linux-Pfade bereits implementiert in `generators/tldr/parsers.sh`
- Alle Generatoren/Skripte: reines ZSH + grep/sed, kein `brew`/`defaults`/`pbcopy`

### Änderungen
- **Runner:** `macos-latest` → `ubuntu-latest`
- **Neuer Step:** ZSH-Installation via `apt-get`
- **tealdeer:** Homebrew → statisches musl-Binary v1.8.1 von GitHub Releases
- **markdownlint-cli2:** Homebrew → `npx` mit gepinnter Version (0.21.0)
- **Entfernt:** Homebrew Cache (nicht mehr nötig)

### Hinweis
- tealdeer v1.8.1 und markdownlint-cli2@0.21.0 werden nicht von Dependabot erfasst → manuelles Update bei Versionssprüngen nötig

## Art der Änderung

- [ ] 🐛 Bugfix
- [x] ✨ Neues Feature
- [ ] 📝 Dokumentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Konfiguration/Maintenance

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Bei neuen Tools: Guard-Check vorhanden

## Zusammenhängende Issues

Closes #329

Verknüpft mit #239 (Plattform-aware Stow) – Linux-CI validiert, dass ZSH-Skripte auf Ubuntu korrekt parsen