### PR TITLE
docs: Hero-Bild nach Intro-Text verschieben

### DIFF
--- a/.github/scripts/generators/readme.sh
+++ b/.github/scripts/generators/readme.sh
@@ -208,11 +208,11 @@ generate_readme_md() {
 [![macOS](https://img.shields.io/badge/macOS-${macos_min}%2B-black?logo=apple)](https://www.apple.com/macos/)
 [![Linux](https://img.shields.io/badge/Linux-vorbereitet-yellow?logo=linux)](https://kernel.org/)
 [![Shell: zsh](https://img.shields.io/badge/Shell-zsh-green?logo=gnubash)](https://www.zsh.org/)
-${hero_image}
+
 **Dotfiles mit modernen CLI-Tools, einheitlichem Theme und integrierter Hilfe.**
 
 > ⚠️ **Plattform-Status:** Auf **macOS** produktiv getestet. Linux-Bootstrap (Fedora, Debian, Arch) in Docker/Headless validiert – Desktop (Wayland) und echte Hardware noch ausstehend.
-
+${hero_image}
 ## ✨ Was du bekommst
 
 ${tool_replacements}

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 [![Linux](https://img.shields.io/badge/Linux-vorbereitet-yellow?logo=linux)](https://kernel.org/)
 [![Shell: zsh](https://img.shields.io/badge/Shell-zsh-green?logo=gnubash)](https://www.zsh.org/)
 
+**Dotfiles mit modernen CLI-Tools, einheitlichem Theme und integrierter Hilfe.**
+
+> ⚠️ **Plattform-Status:** Auf **macOS** produktiv getestet. Linux-Bootstrap (Fedora, Debian, Arch) in Docker/Headless validiert – Desktop (Wayland) und echte Hardware noch ausstehend.
+
 <p align="center">
   <img src="docs/assets/hero.png" alt="dotfiles – cmds Workflow mit fzf und bat-Preview" width="800">
   <br>
   <em>cmds – alle Aliase und Funktionen durchsuchen (einer von 20+ fzf-Workflows)</em>
 </p>
-
-**Dotfiles mit modernen CLI-Tools, einheitlichem Theme und integrierter Hilfe.**
-
-> ⚠️ **Plattform-Status:** Auf **macOS** produktiv getestet. Linux-Bootstrap (Fedora, Debian, Arch) in Docker/Headless validiert – Desktop (Wayland) und echte Hardware noch ausstehend.
 
 ## ✨ Was du bekommst
 


### PR DESCRIPTION
## Beschreibung

Hero-Screenshot wurde im README vor dem Intro-Text angezeigt – Besucher sahen ein Bild, bevor sie wussten was das Repo ist.

Recherche populärer dotfiles-Repos (mathiasbynens 31k⭐, holman 7.7k⭐, skwp 7k⭐) zeigt: Standard ist **Titel → Beschreibung → Screenshot**.

Änderung im Generator (`readme.sh`), nicht manuell in README.md.

**Vorher:** Badges → Hero-Bild → Intro-Text → Plattform-Status
**Nachher:** Badges → Intro-Text → Plattform-Status → Hero-Bild

## Art der Änderung

- [x] 📝 Dokumentation

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Screenshots in `docs/assets/` noch aktuell

## Zusammenhängende Issues

Keine