### PR TITLE
docs: dothelp/dothealth-Hinweise nach Installation verschieben

### DIFF
--- a/.github/scripts/generators/readme.sh
+++ b/.github/scripts/generators/readme.sh
@@ -319,6 +319,10 @@ Bestehende Konfigurationen werden automatisch gesichert.
 
 Danach **Terminal neu starten**. Fertig!
 
+> 💡 **Tipp:** Gib \`dothelp\` ein – zeigt alle Aliase, Shortcuts und Wartungsbefehle.
+>
+> ⚠️ **Probleme?** \`dothealth\` prüft die Installation.
+
 ### Deinstallation
 
 \`\`\`bash
@@ -328,10 +332,6 @@ Danach **Terminal neu starten**. Fertig!
 Entfernt alle Symlinks, stellt Original-Dateien wieder her und setzt das Terminal-Profil (macOS) zurück. Über Homebrew installierte Pakete bleiben bestehen.
 
 Details: [Setup-Doku → Deinstallation](docs/setup.md#deinstallation--wiederherstellung)
-
-> 💡 **Tipp:** Gib \`dothelp\` ein – zeigt alle Aliase, Shortcuts und Wartungsbefehle.
->
-> ⚠️ **Probleme?** \`dothealth\` prüft die Installation.
 
 ### Voraussetzungen
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Bestehende Konfigurationen werden automatisch gesichert.
 
 Danach **Terminal neu starten**. Fertig!
 
+> 💡 **Tipp:** Gib `dothelp` ein – zeigt alle Aliase, Shortcuts und Wartungsbefehle.
+>
+> ⚠️ **Probleme?** `dothealth` prüft die Installation.
+
 ### Deinstallation
 
 ```bash
@@ -108,10 +112,6 @@ Danach **Terminal neu starten**. Fertig!
 Entfernt alle Symlinks, stellt Original-Dateien wieder her und setzt das Terminal-Profil (macOS) zurück. Über Homebrew installierte Pakete bleiben bestehen.
 
 Details: [Setup-Doku → Deinstallation](docs/setup.md#deinstallation--wiederherstellung)
-
-> 💡 **Tipp:** Gib `dothelp` ein – zeigt alle Aliase, Shortcuts und Wartungsbefehle.
->
-> ⚠️ **Probleme?** `dothealth` prüft die Installation.
 
 ### Voraussetzungen
 


### PR DESCRIPTION
## Beschreibung

Verschiebt die Blockquotes mit `dothelp`- und `dothealth`-Tipps im README-Generator von nach der Deinstallations-Sektion direkt unter „Terminal neu starten. Fertig!" – dem Moment, in dem der Nutzer zum ersten Mal mit den dotfiles arbeitet.

**Vorher:** Tipps standen nach Deinstallation und vor Voraussetzungen – inhaltlich falsch verortet.
**Nachher:** Tipps stehen direkt nach der Installations-Bestätigung – kontextuell relevant.

## Art der Änderung

- [x] 📝 Dokumentation

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [ ] ~~Neue Aliase/Funktionen haben Beschreibungskommentare~~
- [ ] ~~Bei neuen Tools: Guard-Check vorhanden~~
- [ ] ~~Screenshots in `docs/assets/` noch aktuell~~

## Zusammenhängende Issues

Closes #372

## Änderungen

| Datei | Änderung |
| ----- | -------- |
| `.github/scripts/generators/readme.sh` | Blockquotes im Heredoc von Zeile 331–334 nach Zeile 319–322 verschoben |
| `README.md` | Automatisch neu generiert via `generate-docs.sh --generate` |

## Validierung

- `generate-docs.sh --check` ✅
- `markdownlint-cli2` ✅ (0 Errors)
- `test-generator-readme.sh` ✅ (12/12 Tests)
- Pre-Commit-Hooks ✅ (alle Checks bestanden)