### PR TITLE
chore: Profil-Name dynamisch, Kommentar-Pfad + CI-Version korrigiert

### DIFF
--- a/.github/scripts/generators/common/config.sh
+++ b/.github/scripts/generators/common/config.sh
@@ -13,7 +13,7 @@
 # daher DOTFILES_DIR als Referenzpunkt nutzen
 if [[ -z "${DOTFILES_DIR:-}" ]]; then
     # Fallback: Aus Skriptpfad ableiten
-    DOTFILES_DIR="${0:A:h:h:h:h:h}"  # lib/config.sh → generators → scripts → .github → dotfiles
+    DOTFILES_DIR="${0:A:h:h:h:h:h}"  # common/config.sh → generators → scripts → .github → dotfiles
 fi
 
 ALIAS_DIR="$DOTFILES_DIR/terminal/.config/alias"

--- a/.github/scripts/health-check.sh
+++ b/.github/scripts/health-check.sh
@@ -463,7 +463,11 @@ fi
 if [[ "$_hc_os" == "macos" ]]; then
 section "Terminal.app Profil"
 
-profile_name="catppuccin-mocha"
+# Profilname dynamisch aus .terminal-Datei ableiten
+typeset terminal_file profile_name default_profile startup_profile
+terminal_file=$(find "$DOTFILES_DIR/setup" -maxdepth 1 -name "*.terminal" | sort | head -1)
+profile_name="${${terminal_file:t}%.terminal}"
+[[ -z "$profile_name" ]] && profile_name="catppuccin-mocha"
 default_profile=$(defaults read com.apple.Terminal "Default Window Settings" 2>/dev/null || echo "")
 startup_profile=$(defaults read com.apple.Terminal "Startup Window Settings" 2>/dev/null || echo "")
 
@@ -546,8 +550,8 @@ check_theme_registry() {
     case "$file" in
       */bat/themes/*|*/bat/config)     tool="bat" ;;
       */zsh/*syntax*)                  tool="zsh-syntax" ;;
-      *catppuccin-mocha.terminal)      tool="Terminal.app" ;;
-      *Catppuccin\ Mocha.xccolortheme) tool="Xcode" ;;
+      *.terminal)                      tool="Terminal.app" ;;
+      *.xccolortheme)                  tool="Xcode" ;;
       */theme-style)                  tool="theme-style" ;;
       */docs/*|*/tests/*|*.page.md|*.sh|*.alias) continue ;;
       */.config/*/*)

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -157,5 +157,5 @@ jobs:
           echo "Prüfe Markdown-Dateien..."
           # Config aus terminal/.config/ (wird lokal via Stow verlinkt)
           # markdownlint-cli2 via npx – Node.js auf ubuntu-latest vorinstalliert
-          npx --yes markdownlint-cli2@0.21.0 --config terminal/.config/markdownlint-cli2/.markdownlint-cli2.jsonc '**/*.md' '#node_modules'
+          npx --yes markdownlint-cli2@0.22.0 --config terminal/.config/markdownlint-cli2/.markdownlint-cli2.jsonc '**/*.md' '#node_modules'
           echo "✔ Markdown OK"


### PR DESCRIPTION
## Beschreibung

Behebt kleinere Inkonsistenzen in Health-Check, Generator-Kommentar und CI:

1. **health-check.sh**: `profile_name` dynamisch aus `.terminal`-Datei ableiten statt hardcoded `"catppuccin-mocha"` (mit Fallback)
2. **health-check.sh**: Case-Patterns `*.terminal` / `*.xccolortheme` verallgemeinert (statt namentlich hardcoded)
3. **health-check.sh**: `typeset`-Deklaration für `terminal_file`, `profile_name`, `default_profile`, `startup_profile` ergänzt (Konsistenz mit restlichen Top-Level-Variablen)
4. **config.sh**: Kommentar `lib/config.sh` → `common/config.sh` korrigiert (veralteter Pfad)
5. **validate.yml**: markdownlint-cli2 `0.21.0` → `0.22.0` (gleicht CI an lokale Version an)

## Art der Änderung

- [x] 🔧 Konfiguration/Maintenance

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Bei neuen Tools: Guard-Check vorhanden

## Zusammenhängende Issues

Closes #381