### PR TITLE
fix(setup): print -r statt print -P in Bootstrap-Logging

### DIFF
--- a/setup/bootstrap.sh
+++ b/setup/bootstrap.sh
@@ -226,10 +226,10 @@ main() {
     fi
 
     # Banner (minimalistisch wie brew-list)
-    print -P ""
-    print -P "${C_MAUVE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${C_RESET}"
-    print -P "${C_MAUVE}  ${C_BOLD}Dotfiles Bootstrap${C_RESET}  ${C_DIM}$os_version${C_RESET}"
-    print -P "${C_MAUVE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${C_RESET}"
+    print -r -- ""
+    print -r -- "${C_MAUVE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${C_RESET}"
+    print -r -- "${C_MAUVE}  ${C_BOLD}Dotfiles Bootstrap${C_RESET}  ${C_DIM}$os_version${C_RESET}"
+    print -r -- "${C_MAUVE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${C_RESET}"
 
     # Module in definierter Reihenfolge laden und ausführen
     for module in "${MODULES[@]}"; do
@@ -250,19 +250,19 @@ main() {
     CURRENT_STEP=""
 
     # Abschluss-Meldung
-    print -P ""
-    print -P "${C_GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${C_RESET}"
-    print -P "${C_GREEN}  ✔ Setup abgeschlossen${C_RESET}"
-    print -P "${C_GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${C_RESET}"
-    print -P ""
+    print -r -- ""
+    print -r -- "${C_GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${C_RESET}"
+    print -r -- "${C_GREEN}  ✔ Setup abgeschlossen${C_RESET}"
+    print -r -- "${C_GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${C_RESET}"
+    print -r -- ""
     section "Nächster Schritt"
 
-    print -P "  ${C_MAUVE}1.${C_RESET} Neue Shell-Sitzung starten: ${C_DIM}exec zsh${C_RESET}"
-    print -P "     ${C_DIM}Oder Terminal schließen und neu öffnen${C_RESET}"
+    print -r -- "  ${C_MAUVE}1.${C_RESET} Neue Shell-Sitzung starten: ${C_DIM}exec zsh${C_RESET}"
+    print -r -- "     ${C_DIM}Oder Terminal schließen und neu öffnen${C_RESET}"
 
-    print -P ""
-    print -P "  ${C_GREEN}💡 Gib '${C_BOLD}dothelp${C_RESET}${C_GREEN}' ein – zeigt alle Aliase, Shortcuts und Wartungsbefehle${C_RESET}"
-    print -P ""
+    print -r -- ""
+    print -r -- "  ${C_GREEN}💡 Gib '${C_BOLD}dothelp${C_RESET}${C_GREEN}' ein – zeigt alle Aliase, Shortcuts und Wartungsbefehle${C_RESET}"
+    print -r -- ""
 }
 
 main "$@"

--- a/setup/modules/_core.sh
+++ b/setup/modules/_core.sh
@@ -87,26 +87,26 @@ unset _THEME_STYLE
 # ------------------------------------------------------------
 # Format: Emoji + Nachricht (für konsistente Ausgabe)
 #
-# HINWEIS: Nutzt print -P (ZSH Prompt-Expansion) statt echo -e.
-# Das ist gewollt für section() (farbige Prompts), aber bedeutet:
-# Ausgaben die % enthalten MÜSSEN escaped werden: ${text//\%/%%}
-# Die Check-Skripte nutzen stattdessen .github/scripts/lib/log.sh (print -r).
-log()  { print -P "${C_BLUE}→${C_RESET} $*"; }
-ok()   { print -P "${C_GREEN}✔${C_RESET} $*"; }
-err()  { print -P "${C_RED}✖${C_RESET} $*" >&2; }
-warn() { print -P "${C_YELLOW}⚠${C_RESET} $*"; }
-skip() { print -P "${C_OVERLAY0}⏭${C_RESET} $*"; }
+# Nutzt print -r (raw output): Keine %-Expansion, keine \-Interpretation.
+# Sicher bei beliebigem Text (Dateinamen, URLs, Prozentwerte).
+# Die Check-Skripte nutzen identisch .github/scripts/lib/log.sh (print -r).
+log()  { print -r -- "${C_BLUE}→${C_RESET} $*"; }
+ok()   { print -r -- "${C_GREEN}✔${C_RESET} $*"; }
+err()  { print -r -- "${C_RED}✖${C_RESET} $*" >&2; }
+warn() { print -r -- "${C_YELLOW}⚠${C_RESET} $*"; }
+skip() { print -r -- "${C_OVERLAY0}⏭${C_RESET} $*"; }
 
 # Sektions-Header (wie brew-list)
 # Verwendung  : section "Titel"
 section() {
-    print -P "\n${C_MAUVE}━━━ ${C_BOLD}$1${C_RESET}${C_MAUVE} ━━━${C_RESET}"
+    print -r -- ""
+    print -r -- "${C_MAUVE}━━━ ${C_BOLD}$1${C_RESET}${C_MAUVE} ━━━${C_RESET}"
 }
 
 # Sektions-Abschluss mit Status
 # Verwendung  : section_end "3 Pakete installiert"
 section_end() {
-    print -P "${C_OVERLAY0}    └─ $*${C_RESET}"
+    print -r -- "${C_OVERLAY0}    └─ $*${C_RESET}"
 }
 
 # ------------------------------------------------------------

--- a/setup/modules/stow.sh
+++ b/setup/modules/stow.sh
@@ -191,11 +191,9 @@ run_stow() {
     else
         warn "Stow hatte Probleme (Exit-Code: $stow_rc):"
         # Jede Zeile einzeln loggen für konsistente Formatierung
-        # warn() nutzt print -P: % vor Ausgabe escapen, um Prompt-Escapes zu vermeiden
-        local line safe_line
+        local line
         while IFS= read -r line; do
-            safe_line=${line//\%/%%}
-            [[ -n "$safe_line" ]] && warn "  $safe_line"
+            [[ -n "$line" ]] && warn "  $line"
         done <<< "$stow_output"
         # Stash trotzdem wiederherstellen bei Fehler
         if ! _restore_stashed_changes "$stash_sha"; then


### PR DESCRIPTION
## Beschreibung

`print -P` in den Bootstrap-Logging-Funktionen interpretiert `%`-Zeichen als ZSH-Prompt-Escapes (z.B. `%f` → end foreground, `%B` → bold). Da `theme-style` echte ANSI-Escape-Sequenzen liefert (`\033[38;2;...m`), war `print -P` nie nötig — `print -r` reicht und ist sicher bei beliebigem Text.

**Änderungen:**

1. **_core.sh**: Alle 7 Logging-Funktionen (`log`, `ok`, `err`, `warn`, `skip`, `section`, `section_end`) von `print -P` auf `print -r --` umgestellt
2. **bootstrap.sh**: 14 direkte `print -P`-Aufrufe durch `print -r --` ersetzt
3. **stow.sh**: Manuelles `%`-Escaping (`${line//\%/%%}`) entfernt — nicht mehr nötig

**Warum Option B (`print -r`) statt Option A (Auto-Escaping):**
- Löst das Problem an der Wurzel statt Symptombehandlung
- Konsistent mit `.github/scripts/lib/log.sh` (identisches Verhalten)
- Kein manuelles `%`-Escaping mehr nötig für Aufrufer

## Art der Änderung

- [x] 🐛 Bugfix

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler

## Zusammenhängende Issues

Closes #378