### PR TITLE
fix: Farbvariablen-Defaults für Aliase unter set -u

### DIFF
--- a/terminal/.zshrc
+++ b/terminal/.zshrc
@@ -84,9 +84,12 @@ zstyle ':completion:*:approximate:*' max-errors 1 numeric
 [[ -f "$HOME/.config/theme-style" ]] && source "$HOME/.config/theme-style"
 
 # Fallback: leere Defaults wenn theme-style fehlt (schützt Aliase unter set -u)
-: "${C_RESET:=}" "${C_BOLD:=}" "${C_DIM:=}" \
-  "${C_RED:=}" "${C_GREEN:=}" "${C_YELLOW:=}" "${C_BLUE:=}" "${C_MAUVE:=}" \
-  "${C_TEXT:=}"
+# typeset -gx statt ${:=} damit Variablen auch in Child-Prozessen
+# verfügbar sind (z.B. fzf --preview). Matcht theme-style Semantik.
+typeset -gx \
+  C_RESET="${C_RESET-}" C_BOLD="${C_BOLD-}" C_DIM="${C_DIM-}" \
+  C_RED="${C_RED-}" C_GREEN="${C_GREEN-}" C_YELLOW="${C_YELLOW-}" \
+  C_BLUE="${C_BLUE-}" C_MAUVE="${C_MAUVE-}" C_TEXT="${C_TEXT-}"
 
 # LS_COLORS für Completion und Directory-Listings (True-Color 24-bit)
 # Verwendet von: zsh list-colors, eza, ls (GNU/Linux), grep


### PR DESCRIPTION
## Beschreibung

Setzt leere Fallback-Werte für alle `C_`-Farbvariablen direkt nach dem `theme-style`-Source in `.zshrc`. Schützt Alias-Dateien vor `\"parameter not set\"`-Fehlern wenn `theme-style` fehlt und `setopt nounset` aktiv ist.

### Warum `typeset -gx` statt `: \"${:=}\"`?

`: \"${C_X:=}\"` setzt Variablen nur als lokale Shell-Parameter (nicht exportiert). In Child-Prozessen wie fzf `--preview` wären sie dann `UNSET`. `typeset -gx` exportiert die Variablen – matcht die Semantik von `theme-style` und stellt graceful degradation in Subprozessen sicher.

**Konkreter Impact:** `vars()` in `fzf.alias` (Zeile 191) nutzt `$C_MAUVE`/`$C_RESET` in einer Single-Quoted `--preview`, die im fzf-Subprozess expandiert wird.

### Betroffene Dateien

| Datei | Genutzte C_-Variablen | Stellen |
|---|---|---|
| `brew.alias` | `C_YELLOW`, `C_RED`, `C_GREEN`, `C_BLUE`, `C_MAUVE`, `C_BOLD`, `C_DIM`, `C_TEXT`, `C_RESET` | ~20+ |
| `fzf.alias` | `C_MAUVE`, `C_GREEN`, `C_BLUE`, `C_TEXT`, `C_RESET` | 6 (davon 1× in fzf-Preview/Child-Prozess) |

### pdfmerge UX-Teil

Bewusst übersprungen: pdfunite gibt klare Fehlermeldungen aus, Exit-Code 255 propagiert korrekt durch ZSH, keine korrupten Output-Dateien bei Fehler. Wrapper-Message wäre redundant (Issue markiert dies als \"optional\").

## Art der Änderung

- [x] 🐛 Bugfix

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare (falls zutreffend)
- [x] Bei neuen Tools: Guard-Check vorhanden (falls zutreffend)
- [x] Screenshots in `docs/assets/` noch aktuell (falls zutreffend)

## Zusammenhängende Issues

Closes #390

## Copilot-Review

- [x] `typeset -gx` statt `: \"${:=}\"` für Export in Child-Prozesse (b0fe952)