### PR TITLE
fix: Bestätigung für destruktive fzf-Aktionen

### DIFF
--- a/terminal/.config/alias/git.alias
+++ b/terminal/.config/alias/git.alias
@@ -122,7 +122,7 @@ if command -v fzf >/dev/null 2>&1; then
                 --delimiter ':' \
                 --preview 'git stash show -p {1} | { bat --style=numbers --color=always -l diff 2>/dev/null || cat; }' \
                 --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Apply' 'Ctrl+P: Pop | Ctrl+D: Drop' 'Ctrl+Y: Ref kopieren'" \
-                --bind 'ctrl-d:execute(git stash drop {1})+reload(git stash list)' \
+                --bind 'ctrl-d:execute(read -q "REPLY?Stash {1} verwerfen? [y/N] " && git stash drop {1}; echo)+reload(git stash list)' \
                 --bind 'ctrl-p:execute(git stash pop {1})+abort' \
                 --bind "ctrl-y:execute-silent($FZF_HELPER_DIR/action copy {1})" | \
             cut -d: -f1)

--- a/terminal/.config/fzf/action
+++ b/terminal/.config/fzf/action
@@ -66,8 +66,11 @@ case "${1:-}" in
         git diff --color=always -- "$1" | bat --style=numbers --color=always -l diff 2>/dev/null || git diff --color=always -- "$1"
         ;;
     git-restore)
-        # Git restore für Datei(en)
+        # Git restore für Datei(en) – Bestätigung weil destruktiv
         shift
+        printf 'Änderungen verwerfen für %d Datei(en)? [y/N] ' "$#"
+        read -q || { echo; exit 0; }
+        echo
         for file in "$@"; do
             git restore -- "$file"
         done
@@ -94,7 +97,7 @@ Commands:
   copy-env <fzf-line>    Umgebungsvariable aus vars()-Zeile kopieren
   edit <file> [line]     Datei im Editor öffnen
   git-diff <file>        Git diff für Datei anzeigen
-  git-restore <files...> Git restore für Datei(en)
+  git-restore <files...> Git restore für Datei(en) (mit Bestätigung)
   git-add <files...>     Git add für Datei(en)
   zoxide-remove <path>   Zoxide Eintrag entfernen
 


### PR DESCRIPTION
## Beschreibung

Fügt Bestätigungsabfragen für zwei destruktive fzf-Aktionen hinzu, die bisher ohne Rückfrage ausgeführt wurden:

| Aktion | Keybinding | Vorher | Nachher |
|--------|-----------|--------|---------|
| `git restore` (git-stage) | Ctrl+R | ❌ Sofort | ✅ `read -q` im action-Script |
| `git stash drop` (git-stash) | Ctrl+D | ❌ Sofort | ✅ `read -q` inline |

### Warum?

Ein versehentlicher Tastendruck auf Ctrl+R statt z.B. Ctrl+Y verwirft nicht-committete Änderungen **unwiderruflich**. Das ist inkonsistent mit `git-branch()` Ctrl+D, das bereits eine `read -q` Bestätigung hat.

### Implementierung

- **git-restore:** Bestätigung im `action`-Script mit Dateizahl (`printf '%d Datei(en)?'` + `read -q`)
- **git-stash drop:** Inline `read -q` — exakt dasselbe Pattern wie git-branch Ctrl+D

### Bewusst nicht im Scope

- `git stash pop` — intentionale Aktion, Git schützt bei Merge-Konflikten
- `zoxide-remove` — trivial wiederherstellbar (einfach `cd` dorthin)
- `brew-rm` — bewusster Funktionsaufruf, kein versehentlicher Tastendruck

## Art der Änderung

- [x] 🐛 Bugfix

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare (falls zutreffend)
- [x] Bei neuen Tools: Guard-Check vorhanden (falls zutreffend)
- [x] Screenshots in `docs/assets/` noch aktuell (falls zutreffend)

## Zusammenhängende Issues

Closes #389