### PR TITLE
docs(readme): dothealth in Dokumentations-Tabelle ergänzen

### DIFF
--- a/.github/scripts/generators/readme.sh
+++ b/.github/scripts/generators/readme.sh
@@ -353,6 +353,7 @@ Details: [Setup-Doku → Deinstallation](docs/setup.md#deinstallation--wiederher
 | Befehl | Was es zeigt |
 | ------ | ------------ |
 | \`dothelp\` | Schnellreferenz: Aliase, Shortcuts, Tool-Ersetzungen, Wartung |
+| \`dothealth\` | Installations-Check: fehlende Tools, defekte Symlinks, Config-Probleme |
 | \`cmds\` | Alle Aliase und Funktionen interaktiv durchsuchen |
 | \`tldr <tool>\` | Vollständige Tool-Doku mit dotfiles-Erweiterungen |
 

--- a/.github/scripts/tests/test-generate-docs-integration.sh
+++ b/.github/scripts/tests/test-generate-docs-integration.sh
@@ -29,10 +29,10 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-# Guard: Keine lokalen Änderungen in Test-Pfaden überschreiben
-if ! git -C "$DOTFILES_DIR" diff --quiet -- "${_MUTATED_PATHS[@]}" \
-  || ! git -C "$DOTFILES_DIR" diff --cached --quiet -- "${_MUTATED_PATHS[@]}"; then
-    echo "Abbruch: Lokale Änderungen in generierten Dateien. Bitte erst committen oder verwerfen." >&2
+# Guard: Keine UNSTAGED Änderungen in Test-Pfaden überschreiben
+# Staged Changes (--cached) sind OK: cleanup nutzt git checkout (stellt aus Index wieder her)
+if ! git -C "$DOTFILES_DIR" diff --quiet -- "${_MUTATED_PATHS[@]}"; then
+    echo "Abbruch: Unstaged Änderungen in generierten Dateien. Bitte erst stagen oder verwerfen." >&2
     exit 1
 fi
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Details: [Setup-Doku → Deinstallation](docs/setup.md#deinstallation--wiederher
 | Befehl | Was es zeigt |
 | ------ | ------------ |
 | `dothelp` | Schnellreferenz: Aliase, Shortcuts, Tool-Ersetzungen, Wartung |
+| `dothealth` | Installations-Check: fehlende Tools, defekte Symlinks, Config-Probleme |
 | `cmds` | Alle Aliase und Funktionen interaktiv durchsuchen |
 | `tldr <tool>` | Vollständige Tool-Doku mit dotfiles-Erweiterungen |
 


### PR DESCRIPTION
## Beschreibung

`dothealth` fehlte in der 📖 Dokumentations-Tabelle der README.md, obwohl es bereits im Hinweis-Block erwähnt wird. Dieser PR ergänzt den Eintrag im Generator.

Zusätzlich wurde ein Bug im Integrationstest aus #394 behoben: der Guard blockierte **alle** Generator-Commits, weil `git diff --cached` staged Changes in generierten Dateien als "lokale Änderungen" wertete. Da `git checkout --` (Cleanup) aus dem Index wiederherstellt, sind staged Changes sicher.

### Analyse der 3 Issue-Punkte

| Punkt | Entscheidung | Begründung |
|---|---|---|
| **1. `dothealth` in Tabelle** | ✅ Umgesetzt | Funktion existiert in `dotfiles.alias`, fehlte in Doku-Tabelle |
| **2. `brew-up`/`brew-list` Sichtbarkeit** | ❌ Kein Handlungsbedarf | Beide sind Utility-Funktionen ohne fzf, bereits im Features-Abschnitt (Zeile 300-302) dokumentiert. Die Tabelle "Interaktive Workflows (fzf)" darf keine Nicht-fzf-Befehle enthalten. |
| **3. `tar --strip-components`** | ❌ Nicht umgesetzt (unsicher) | Überschreibt bestehende Dateien **lautlos** → Datenverlust-Risiko. Aktueller `tar + mv` Ansatz scheitert sichtbar — das ist die sicherere Variante. |

## Art der Änderung

- [x] 📝 Dokumentation
- [x] 🧪 Testing

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [ ] ~~Neue Aliase/Funktionen haben Beschreibungskommentare~~ (nicht zutreffend)
- [ ] ~~Bei neuen Tools: Guard-Check vorhanden~~ (nicht zutreffend)
- [ ] ~~Screenshots in `docs/assets/` noch aktuell~~ (nicht zutreffend)

## Zusammenhängende Issues

Closes #395

## Details: tar-Sicherheitstest

Getestet auf macOS 26.4 (bsdtar 3.5.3):

```
# --strip-components ÜBERSCHREIBT bestehende Dateien lautlos:
VOR:  dotfiles/setup/Brewfile → "LOCAL-CHANGES"
NACH: dotfiles/setup/Brewfile → "archive-brewfile"  ← DATEN VERLOREN

# Aktueller mv-Ansatz: Scheitert sichtbar wenn ~/dotfiles existiert
# → mv verschiebt nested → install.sh findet falschen Pfad → Fehler
```

## Details: Integrationstest-Guard (#394)

Der Guard in `test-generate-docs-integration.sh` prüfte sowohl `git diff` (unstaged) als auch `git diff --cached` (staged). Im Pre-Commit-Hook sind generierte Dateien **immer** staged → der Guard blockierte jeden Generator-Commit.

**Fix:** Nur unstaged Changes prüfen. Staged Changes sind sicher, weil der Cleanup (`git checkout --`) aus dem Index (= staged Stand) wiederherstellt.

**Getestete Edge Cases:**
| Szenario | Erwartung | Ergebnis |
|----------|-----------|----------|
| Nur unstaged | Guard blockiert | ✅ |
| Nur staged | Guard erlaubt | ✅ |
| Staged + unstaged | Guard blockiert | ✅ |