### PR TITLE
docs(contributing): Klarheit bei Logging, install vs bootstrap, Stow und Labels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,10 @@ stow --adopt -R terminal editor && git reset --hard HEAD
 
 Nach Schritt 3 wird bei jedem Commit automatisch geprüft, ob Dokumentation und Code synchron sind.
 
+> **`install.sh` vs. `bootstrap.sh`:** `install.sh` ist der Einstiegspunkt für Erstinstallation
+> (stellt zsh sicher, setzt auf Linux ggf. die Default-Shell, startet dann `bootstrap.sh`).
+> Für Entwickler mit bestehender zsh-Installation reicht `bootstrap.sh` direkt.
+>
 > **Hinweis:** Bei erneuter Ausführung von `bootstrap.sh` werden uncommitted Changes
 > automatisch gestasht und nach Abschluss wiederhergestellt. Du verlierst keine Arbeit.
 
@@ -62,6 +66,7 @@ Nach Schritt 3 wird bei jedem Commit automatisch geprüft, ob Dokumentation und 
 | ------- | --------- |
 | **Isolation** | Jedes Tool hat eigene Config in `~/.config/tool/` |
 | **Unabhängigkeit** | Guard-System erlaubt Teilinstallation |
+| **Symlinks** | Stow mit `--no-folding` (via `.stowrc`) — nur Datei-Symlinks, `~/.config/` bleibt ein echtes Verzeichnis |
 | **Erweiterbarkeit** | Neue Tools durch Hinzufügen einer `.alias`-Datei |
 | **Austauschbarkeit** | Aliase abstrahieren Tool-spezifische Syntax |
 
@@ -567,15 +572,24 @@ manual          = Manuell basierend auf catppuccin.com/palette
 
 ### Shell-Scripts
 
+Das Repository nutzt drei separate Logging-Systeme — je nach Shell und Kontext:
+
+#### `.github/scripts/` (ZSH)
+
 ```zsh
 #!/usr/bin/env zsh
 set -euo pipefail
 
-# Logging-Helper verwenden (geteilte Library)
 source "${0:A:h}/lib/log.sh"
 # Stellt bereit: log(), ok(), warn(), err()
 # Siehe .github/scripts/lib/log.sh
 ```
+
+#### `setup/` Skripte
+
+- **`install.sh`:** POSIX sh → `. "$SCRIPT_DIR/lib/logging.sh"`
+- **`restore.sh`:** ZSH → `source "${SCRIPT_DIR}/lib/logging.sh"`
+- **`setup/modules/*.sh`:** Werden von `bootstrap.sh` (ZSH) geladen — Logging via `_core.sh` bereitgestellt
 
 ### Alias-Dateien
 
@@ -756,8 +770,8 @@ Nach PR-Erstellung das passende Label hinzufügen:
 
 | Label | Verwendung |
 | ------- | ------------ |
-| `bug` | Fehler, etwas funktioniert nicht |
-| `enhancement` | Neues Feature oder Verbesserung |
+| `bug` | Fehler, etwas funktioniert nicht (bei Issues via Template automatisch gesetzt) |
+| `enhancement` | Neues Feature oder Verbesserung (bei Issues via Template automatisch gesetzt) |
 | `documentation` | Nur Doku-Änderungen |
 | `refactoring` | Code-Verbesserung ohne Funktionsänderung |
 | `chore` | Routineaufgaben, Wartung |


### PR DESCRIPTION
## Beschreibung

Vier Stellen in CONTRIBUTING.md setzen implizites Wissen voraus, das Contributors nicht haben können. Dieser PR macht die Zusammenhänge explizit.

### Änderungen

**Logging aufgeteilt** — Die Shell-Scripts-Sektion zeigte nur `log.sh`. Das Repository hat aber drei verschiedene Logging-Systeme: `.github/scripts/` nutzt `log.sh` (ZSH), `install.sh` nutzt `logging.sh` (POSIX sh), `restore.sh` nutzt `logging.sh` (ZSH), und `setup/modules/` bekommen Logging über `_core.sh`. Ein Contributor, der ein Setup-Modul schreibt, hätte das falsche Pattern verwendet.

**install.sh vs. bootstrap.sh** — Der Quick-Setup nutzt `bootstrap.sh`, die README verweist auf `install.sh`. Ohne Erklärung ist unklar, wann welcher Einstiegspunkt gilt. Blockquote ergänzt: `install.sh` stellt zsh sicher und setzt auf Linux ggf. die Default-Shell, `bootstrap.sh` ist für Entwickler mit bestehender zsh-Installation.

**Stow `--no-folding`** — Die `.stowrc` sorgt dafür, dass Stow nur Datei-Symlinks erstellt (kein Tree-Folding). Das steht in `docs/setup.md` und `copilot-instructions.md`, fehlte aber in der CONTRIBUTING.md-Architektur. Neue Zeile in der Modularität-Tabelle ergänzt.

**Label-Klarheit** — `bug` und `enhancement` standen sowohl unter „Typ-Labels" als auch „Automatisch gesetzte Labels" ohne Cross-Referenz. Hinweis ergänzt, dass Issue-Templates diese Labels automatisch setzen.

## Art der Änderung

- [x] 📝 Dokumentation

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare (falls zutreffend)
- [x] Bei neuen Tools: Guard-Check vorhanden (falls zutreffend)
- [x] Screenshots in `docs/assets/` noch aktuell (falls zutreffend)

## Zusammenhängende Issues

Closes #396