### PR TITLE
fix(stow): Stow-Fehler an Bootstrap propagieren

### DIFF
--- a/setup/modules/stow.sh
+++ b/setup/modules/stow.sh
@@ -200,7 +200,7 @@ run_stow() {
             warn "Bootstrap fortgesetzt – Stash manuell wiederherstellen"
         fi
         popd >/dev/null
-        return 0
+        return 1
     fi
 
     # Adoptierte Dateien auf Repository-Zustand zurücksetzen

--- a/setup/modules/stow.sh
+++ b/setup/modules/stow.sh
@@ -197,7 +197,7 @@ run_stow() {
         done <<< "$stow_output"
         # Stash trotzdem wiederherstellen bei Fehler
         if ! _restore_stashed_changes "$stash_sha"; then
-            warn "Bootstrap fortgesetzt – Stash manuell wiederherstellen"
+            warn "Bootstrap abgebrochen – Stash manuell wiederherstellen"
         fi
         popd >/dev/null
         return 1


### PR DESCRIPTION
## Beschreibung

`run_stow()` gab bei einem Stow-Fehler `return 0` zurück, sodass Bootstrap den Fehler nicht erkannte und alle nachfolgenden Module (git-hooks, bat, tealdeer usw.) trotzdem ausgeführt wurden – obwohl die Symlinks nicht erstellt wurden.

Jetzt wird `return 1` zurückgegeben. Bootstrap erkennt den Fehler korrekt über `case *) exit 1` und bricht ab.

### Analyse

- **Einziger Outlier:** Alle 11 anderen Module propagieren Fehler konsistent mit `return 1`. Nur stow.sh maskierte den Fehler seit dem ersten Commit (PR #179).
- **Kein Datenverlust:** Die Stash-Wiederherstellung und `popd` passieren **vor** dem Return – `return 1` ändert nur die Signalisierung an Bootstrap.
- **Kritisches Modul:** stow.sh ist als "⚠️ Kritisch" markiert. Fehlende Symlinks haben Auswirkungen auf nachfolgende Module.

## Art der Änderung

- [x] 🐛 Bugfix
- [x] 🏗️ Setup/Bootstrap

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [ ] ~~Neue Aliase/Funktionen haben Beschreibungskommentare~~ (nicht zutreffend)
- [ ] ~~Bei neuen Tools: Guard-Check vorhanden~~ (nicht zutreffend)
- [ ] ~~Screenshots in `docs/assets/` noch aktuell~~ (nicht zutreffend)

## Zusammenhängende Issues

Closes #399

## Terminal-Ausgabe

```diff
# setup/modules/stow.sh, Zeile 203
-        return 0
+        return 1
```