### PR TITLE
feat(config): PROJECT_REPO dynamisch aus Git-Remote ermitteln

### DIFF
--- a/.github/scripts/generators/common/config.sh
+++ b/.github/scripts/generators/common/config.sh
@@ -36,7 +36,8 @@ SHELL_COLORS="$DOTFILES_DIR/terminal/.config/theme-style"
 # Projekt-Metadaten (Single Source of Truth)
 # ------------------------------------------------------------
 # Repository-Identifikation (für Badge-URLs, Install-Befehle, tldr-Links)
-readonly PROJECT_REPO="tshofmann/dotfiles"
+# Git-Remote bevorzugen (funktioniert auch in Forks/CI), Fallback auf Standardwert
+readonly PROJECT_REPO="${$(git -C "$DOTFILES_DIR" remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||'):-tshofmann/dotfiles}"
 # Kurzbeschreibung für README, tldr, GitHub Repo Description
 readonly PROJECT_TAGLINE="Dotfiles mit Catppuccin-Theme und modernen CLI-Tools."
 # Erweiterte Beschreibung für README


### PR DESCRIPTION
## Beschreibung

`PROJECT_REPO` in `config.sh` war hardcoded als `"tshofmann/dotfiles"`. Jetzt wird der Wert dynamisch aus `git remote get-url origin` ermittelt, mit Fallback auf den bisherigen Wert.

```zsh
# Vorher
readonly PROJECT_REPO="tshofmann/dotfiles"

# Nachher
readonly PROJECT_REPO="${$(git -C "$DOTFILES_DIR" remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||'):-tshofmann/dotfiles}"
```

### Warum?

- `PROJECT_REPO` wird in Badge-URLs, Install-Befehlen und tldr-Links verwendet
- Bei Forks zeigt der Wert jetzt automatisch auf das richtige Repository
- In CI (GitHub Actions) ist `origin` verfügbar → korrekte Ausgabe
- Fallback auf `tshofmann/dotfiles` wenn kein Remote vorhanden

### Getestet gegen

- SSH-URLs: `git@github.com:owner/repo.git` ✅
- HTTPS-URLs: `https://github.com/owner/repo.git` ✅
- HTTPS ohne `.git`: `https://github.com/owner/repo` ✅
- Kein Remote / kein Git: Fallback greift ✅

### Bewusst NICHT gelöst: `_is_dotfiles_symlink()` Duplizierung

Issue #400 beschreibt zwei Themen. Die Duplizierung der Funktion zwischen `backup.sh` und `restore.sh` (~15 Zeilen) wird bewusst nicht adressiert:
- `setup/lib/` enthält nur POSIX-Code (`logging.sh`) – eine ZSH-Datei dort wäre ein Architekturbruch
- `restore.sh` kann `backup.sh` nicht sourcen (Bootstrap-Guard `_BOOTSTRAP_CORE_LOADED`)
- Aufwand (neue Lib-Datei, Source-Guards, Header, Doku) >> Nutzen für 15 Zeilen stabilen Code
- Das Issue selbst nennt den Trade-off als akzeptabel

## Art der Änderung

- [x] ✨ Neues Feature
- [x] 🔧 Konfiguration

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [ ] ~~Neue Aliase/Funktionen haben Beschreibungskommentare~~ (nicht zutreffend)
- [ ] ~~Bei neuen Tools: Guard-Check vorhanden~~ (nicht zutreffend)
- [ ] ~~Screenshots in `docs/assets/` noch aktuell~~ (nicht zutreffend)

## Zusammenhängende Issues

Closes #400

## Validierung

- 116 Unit Tests bestanden (inkl. `assert_contains "dotfiles: Repo-URL" "$PROJECT_REPO"`)
- 128 Health-Checks bestanden
- Generator-Ausgabe identisch (`--check` erfolgreich)