### PR TITLE
feat: README.md um Inhaltsverzeichnis und Credits erweitern

### DIFF
--- a/.github/scripts/generators/readme.sh
+++ b/.github/scripts/generators/readme.sh
@@ -224,32 +224,48 @@ generate_utility_tools_table() {
 # 1. Kleinschreibung
 # 2. Nicht-erlaubte Zeichen entfernen (behält Buchstaben, Ziffern, Leerzeichen, Bindestriche)
 # 3. Leerzeichen → Bindestriche
+# LC_ALL=C.UTF-8 stellt sicher, dass tr/sed Unicode-Buchstaben (ä, ü, ö)
+# korrekt als [:alnum:] erkennen – unabhängig von der System-Locale (CI: Ubuntu).
+# LC_ALL hat Vorrang vor LC_CTYPE, daher muss LC_ALL gesetzt werden.
 heading_to_anchor() {
     local heading="$1"
     printf '%s' "$heading" \
-        | tr '[:upper:]' '[:lower:]' \
-        | sed 's/[^[:lower:][:digit:] -]//g; s/ /-/g'
+        | LC_ALL=C.UTF-8 tr '[:upper:]' '[:lower:]' \
+        | LC_ALL=C.UTF-8 sed 's/[^[:alnum:] -]//g; s/ /-/g'
 }
 
 # ------------------------------------------------------------
 # Helper: Inhaltsverzeichnis aus generiertem Inhalt ableiten
 # ------------------------------------------------------------
-# Parst ## und ### Überschriften, generiert Markdown-Links mit Ankern
+# Parst ## und ### Überschriften, generiert Markdown-Links mit Ankern.
+# Dedupliziert Anker bei mehrfach vorkommenden Überschriften
+# (GitHub hängt -1, -2, … an) mittels Slug-Usage-Map.
 generate_toc() {
     local content="$1"
     local toc=""
-    local title anchor
+    local title anchor base_anchor prefix
+    typeset -A slug_count
 
     while IFS= read -r line; do
         if [[ "$line" == '## '* ]]; then
             title="${line#\#\# }"
-            anchor=$(heading_to_anchor "$title")
-            toc+="- [${title}](#${anchor})"$'\n'
+            prefix="- "
         elif [[ "$line" == '### '* ]]; then
             title="${line#\#\#\# }"
-            anchor=$(heading_to_anchor "$title")
-            toc+="  - [${title}](#${anchor})"$'\n'
+            prefix="  - "
+        else
+            continue
         fi
+
+        base_anchor=$(heading_to_anchor "$title")
+        if (( ${slug_count[$base_anchor]:-0} > 0 )); then
+            anchor="${base_anchor}-${slug_count[$base_anchor]}"
+        else
+            anchor="$base_anchor"
+        fi
+        (( slug_count[$base_anchor]++ )) || true
+
+        toc+="${prefix}[${title}](#${anchor})"$'\n'
     done <<< "$content"
 
     # Abschließenden Zeilenumbruch entfernen

--- a/.github/scripts/generators/readme.sh
+++ b/.github/scripts/generators/readme.sh
@@ -224,14 +224,14 @@ generate_utility_tools_table() {
 # 1. Kleinschreibung
 # 2. Nicht-erlaubte Zeichen entfernen (behält Buchstaben, Ziffern, Leerzeichen, Bindestriche)
 # 3. Leerzeichen → Bindestriche
-# LC_ALL=C.UTF-8 stellt sicher, dass tr/sed Unicode-Buchstaben (ä, ü, ö)
-# korrekt als [:alnum:] erkennen – unabhängig von der System-Locale (CI: Ubuntu).
-# LC_ALL hat Vorrang vor LC_CTYPE, daher muss LC_ALL gesetzt werden.
+# Subshell mit LC_ALL=C.UTF-8: GNU tr (Ubuntu) konvertiert Unicode-Case nicht,
+# daher ZSH-eigene ${(L)} Expansion für Lowercase + sed für Zeichenfilterung.
 heading_to_anchor() {
-    local heading="$1"
-    printf '%s' "$heading" \
-        | LC_ALL=C.UTF-8 tr '[:upper:]' '[:lower:]' \
-        | LC_ALL=C.UTF-8 sed 's/[^[:alnum:] -]//g; s/ /-/g'
+    (
+        LC_ALL=C.UTF-8
+        local heading="$1"
+        printf '%s' "${(L)heading}" | sed 's/[^[:alnum:] -]//g; s/ /-/g'
+    )
 }
 
 # ------------------------------------------------------------

--- a/.github/scripts/generators/readme.sh
+++ b/.github/scripts/generators/readme.sh
@@ -4,7 +4,7 @@
 # ============================================================
 # Zweck       : Generiert Haupt-README aus Template + dynamischen Daten
 # Pfad        : .github/scripts/generators/readme.sh
-# Quelle  : setup/modules/*.sh, setup/Brewfile
+# Quelle      : setup/modules/*.sh, setup/Brewfile
 # ============================================================
 
 source "${0:A:h}/common.sh"
@@ -217,6 +217,46 @@ generate_utility_tools_table() {
 }
 
 # ------------------------------------------------------------
+# Helper: GitHub-Anker aus Überschrift generieren
+# ------------------------------------------------------------
+# Konvertiert eine Markdown-Überschrift in einen GitHub-kompatiblen Anker.
+# Bildet das Verhalten von github-slugger (v2) nach:
+# 1. Kleinschreibung
+# 2. Nicht-erlaubte Zeichen entfernen (behält Buchstaben, Ziffern, Leerzeichen, Bindestriche)
+# 3. Leerzeichen → Bindestriche
+heading_to_anchor() {
+    local heading="$1"
+    printf '%s' "$heading" \
+        | tr '[:upper:]' '[:lower:]' \
+        | sed 's/[^[:lower:][:digit:] -]//g; s/ /-/g'
+}
+
+# ------------------------------------------------------------
+# Helper: Inhaltsverzeichnis aus generiertem Inhalt ableiten
+# ------------------------------------------------------------
+# Parst ## und ### Überschriften, generiert Markdown-Links mit Ankern
+generate_toc() {
+    local content="$1"
+    local toc=""
+    local title anchor
+
+    while IFS= read -r line; do
+        if [[ "$line" == '## '* ]]; then
+            title="${line#\#\# }"
+            anchor=$(heading_to_anchor "$title")
+            toc+="- [${title}](#${anchor})"$'\n'
+        elif [[ "$line" == '### '* ]]; then
+            title="${line#\#\#\# }"
+            anchor=$(heading_to_anchor "$title")
+            toc+="  - [${title}](#${anchor})"$'\n'
+        fi
+    done <<< "$content"
+
+    # Abschließenden Zeilenumbruch entfernen
+    printf '%s' "${toc%$'\n'}"
+}
+
+# ------------------------------------------------------------
 # Haupt-Generator für README.md
 # ------------------------------------------------------------
 generate_readme_md() {
@@ -263,19 +303,9 @@ generate_readme_md() {
         workflow_image=$'\n<p align="center">\n  <img src="docs/assets/workflow.png" alt="git-log Workflow – fzf mit bat-Preview zeigt Commit-Diffs" width="800">\n  <br>\n  <em>git-log – Commit-Historie mit Diff-Preview (bat + Catppuccin Syntax-Highlighting)</em>\n</p>\n'
     fi
 
-    cat << EOF
-# 🍎 dotfiles
-
-[![CI](https://github.com/${PROJECT_REPO}/actions/workflows/validate.yml/badge.svg)](https://github.com/${PROJECT_REPO}/actions/workflows/validate.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![macOS](https://img.shields.io/badge/macOS-${macos_min_name_url}%20%28${macos_min}%2B%29-black?logo=apple)](https://www.apple.com/macos/)
-[![Linux](https://img.shields.io/badge/Linux-vorbereitet-yellow?logo=linux)](https://kernel.org/)
-[![Shell: zsh](https://img.shields.io/badge/Shell-zsh-green?logo=gnubash)](https://www.zsh.org/)
-
-**Dotfiles mit modernen CLI-Tools, einheitlichem Theme und integrierter Hilfe.**
-
-> ⚠️ **Plattform-Status:** Auf **macOS** produktiv getestet. Linux-Bootstrap (Fedora, Debian, Arch) in Docker/Headless validiert – Desktop (Wayland) und echte Hardware noch ausstehend.
-${hero_image}
+    # 1. Body generieren (alles ab "## ✨ Was du bekommst")
+    local body
+    body=$(cat << EOF
 ## ✨ Was du bekommst
 
 ${tool_replacements}
@@ -359,9 +389,41 @@ Details: [Setup-Doku → Deinstallation](docs/setup.md#deinstallation--wiederher
 
 Mehr: [Setup](docs/setup.md) · [Anpassung](docs/customization.md) · [Contributing](CONTRIBUTING.md)
 
+## 🙏 Credits
+
+Dieses Projekt nutzt [Catppuccin Mocha](https://catppuccin.com/) als einheitliches Theme.
+
+Alle installierten Tools und Abhängigkeiten: [\`setup/Brewfile\`](setup/Brewfile)
+
 ## Lizenz
 
 [MIT](LICENSE)
+EOF
+)
+
+    # 2. ToC dynamisch aus Body ableiten
+    local toc
+    toc=$(generate_toc "$body")
+
+    # 3. Alles zusammensetzen: Header + ToC + Body
+    cat << EOF
+# 🍎 dotfiles
+
+[![CI](https://github.com/${PROJECT_REPO}/actions/workflows/validate.yml/badge.svg)](https://github.com/${PROJECT_REPO}/actions/workflows/validate.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![macOS](https://img.shields.io/badge/macOS-${macos_min_name_url}%20%28${macos_min}%2B%29-black?logo=apple)](https://www.apple.com/macos/)
+[![Linux](https://img.shields.io/badge/Linux-vorbereitet-yellow?logo=linux)](https://kernel.org/)
+[![Shell: zsh](https://img.shields.io/badge/Shell-zsh-green?logo=gnubash)](https://www.zsh.org/)
+
+**Dotfiles mit modernen CLI-Tools, einheitlichem Theme und integrierter Hilfe.**
+
+> ⚠️ **Plattform-Status:** Auf **macOS** produktiv getestet. Linux-Bootstrap (Fedora, Debian, Arch) in Docker/Headless validiert – Desktop (Wayland) und echte Hardware noch ausstehend.
+${hero_image}
+## Inhalt
+
+${toc}
+
+${body}
 EOF
 }
 

--- a/.github/scripts/tests/test-generator-readme.sh
+++ b/.github/scripts/tests/test-generator-readme.sh
@@ -364,8 +364,9 @@ assert_equals "Klammern entfernt" "interaktive-workflows-fzf" "$(heading_to_anch
 assert_equals "Bindestrich erhalten" "media-toolkit" "$(heading_to_anchor 'Media-Toolkit')"
 
 # Umlaute bleiben erhalten (GitHub behält Unicode-Buchstaben)
-assert_equals "Umlaute erhalten" "weitere-werkzeuge" "$(heading_to_anchor 'Weitere Werkzeuge')"
-assert_equals "Voraussetzungen" "voraussetzungen" "$(heading_to_anchor 'Voraussetzungen')"
+assert_equals "Umlaute erhalten (ü)" "überblick" "$(heading_to_anchor 'Überblick')"
+assert_equals "Umlaute erhalten (ä)" "änderungen" "$(heading_to_anchor 'Änderungen')"
+assert_equals "Umlaute erhalten (ö)" "größe" "$(heading_to_anchor 'Größe')"
 
 # ============================================================
 # generate_toc() – Unit Tests
@@ -442,17 +443,28 @@ result=$(generate_readme_md)
 # ToC-Sektion ist vorhanden
 assert_contains "ToC: Inhalt-Überschrift" "## Inhalt" "$result"
 
-# Jede ## und ### Überschrift (außer Inhalt) muss im ToC vorkommen
+# Überschriften aus Body extrahieren (ohne ToC-Block selbst)
+# Robuster Ansatz: nur die Sektionen nach "## Inhalt" und den
+# ToC-Einträgen zählen, nicht über den gesamten Output scannen
 local heading_count=0 toc_count=0
+local in_toc=0 past_toc=0
 while IFS= read -r line; do
-    if [[ "$line" == '## '* || "$line" == '### '* ]]; then
-        # "Inhalt" selbst überspringen
-        [[ "$line" == '## Inhalt' ]] && continue
-        (( heading_count++ )) || true
+    # ToC-Block erkennen (zwischen "## Inhalt" und nächster H2)
+    if [[ "$line" == '## Inhalt' ]]; then
+        in_toc=1
+        continue
     fi
-    # ToC-Einträge zählen (beginnen mit "- [" oder "  - [")
-    if [[ "$line" == '- ['* || "$line" == '  - ['* ]]; then
-        (( toc_count++ )) || true
+    if (( in_toc )); then
+        if [[ "$line" == '## '* ]]; then
+            in_toc=0
+            past_toc=1
+        elif [[ "$line" == '- ['* || "$line" == '  - ['* ]]; then
+            (( toc_count++ )) || true
+        fi
+    fi
+    # Überschriften nach dem ToC zählen
+    if (( past_toc )) && [[ "$line" == '## '* || "$line" == '### '* ]]; then
+        (( heading_count++ )) || true
     fi
 done <<< "$result"
 

--- a/.github/scripts/tests/test-generator-readme.sh
+++ b/.github/scripts/tests/test-generator-readme.sh
@@ -413,6 +413,22 @@ local toc_lines
 toc_lines=$(echo "$result" | wc -l)
 assert_equals "ToC: 2 Einträge (H2+H3, kein H4)" "2" "${toc_lines##* }"
 
+# Doppelte Überschriften werden dedupliziert (GitHub-kompatibel: -1, -2, …)
+_toc_dup_input="## Titel
+
+### Untertitel
+
+## Titel
+
+### Untertitel"
+
+result=$(generate_toc "$_toc_dup_input")
+
+assert_contains "ToC: Erstes H2" "- [Titel](#titel)" "$result"
+assert_contains "ToC: Zweites H2 dedupliziert" "- [Titel](#titel-1)" "$result"
+assert_contains "ToC: Erstes H3" "  - [Untertitel](#untertitel)" "$result"
+assert_contains "ToC: Zweites H3 dedupliziert" "  - [Untertitel](#untertitel-1)" "$result"
+
 # ============================================================
 # Credits-Sektion – Integrations-Test
 # ============================================================

--- a/.github/scripts/tests/test-generator-readme.sh
+++ b/.github/scripts/tests/test-generator-readme.sh
@@ -6,7 +6,8 @@
 #               extract_fzf_functions(), generate_fzf_workflows_table(),
 #               generate_media_toolkit_table(),
 #               generate_shell_keybindings_table(),
-#               generate_utility_tools_table()
+#               generate_utility_tools_table(),
+#               heading_to_anchor(), generate_toc()
 # Pfad        : .github/scripts/tests/test-generator-readme.sh
 # Aufruf      : ./.github/scripts/tests/test-generator-readme.sh
 # ============================================================
@@ -339,6 +340,123 @@ line_count=$(echo "$result" | wc -l)
 assert_equals "Utility: nur Header (2 Zeilen)" "2" "${line_count##* }"
 
 ALIAS_DIR="$_ORIG_ALIAS_DIR4"
+
+# ============================================================
+# heading_to_anchor() – Unit Tests
+# ============================================================
+echo ""
+echo "=== heading_to_anchor (Unit) ==="
+
+# Emoji-Entfernung + Kleinschreibung + Leerzeichen → Bindestrich
+assert_equals "Emoji-Anker (✨)" "-was-du-bekommst" "$(heading_to_anchor '✨ Was du bekommst')"
+assert_equals "Emoji-Anker (🚀)" "-installation" "$(heading_to_anchor '🚀 Installation')"
+assert_equals "Emoji-Anker (📖)" "-dokumentation" "$(heading_to_anchor '📖 Dokumentation')"
+assert_equals "Emoji-Anker (🙏)" "-credits" "$(heading_to_anchor '🙏 Credits')"
+
+# Ohne Emoji
+assert_equals "Ohne Emoji" "deinstallation" "$(heading_to_anchor 'Deinstallation')"
+assert_equals "Ohne Emoji (Lizenz)" "lizenz" "$(heading_to_anchor 'Lizenz')"
+
+# Klammern und Sonderzeichen werden entfernt
+assert_equals "Klammern entfernt" "interaktive-workflows-fzf" "$(heading_to_anchor 'Interaktive Workflows (fzf)')"
+
+# Bindestrich bleibt erhalten
+assert_equals "Bindestrich erhalten" "media-toolkit" "$(heading_to_anchor 'Media-Toolkit')"
+
+# Umlaute bleiben erhalten (GitHub behält Unicode-Buchstaben)
+assert_equals "Umlaute erhalten" "weitere-werkzeuge" "$(heading_to_anchor 'Weitere Werkzeuge')"
+assert_equals "Voraussetzungen" "voraussetzungen" "$(heading_to_anchor 'Voraussetzungen')"
+
+# ============================================================
+# generate_toc() – Unit Tests
+# ============================================================
+echo ""
+echo "=== generate_toc (Unit) ==="
+
+# Einfacher Test mit bekannten Überschriften
+_toc_input="## ✨ Erster Abschnitt
+
+Normaler Text hier.
+
+### Unter-Abschnitt
+
+Mehr Text.
+
+## 🚀 Zweiter Abschnitt
+
+### Noch ein Unter-Abschnitt
+
+## Dritter"
+
+result=$(generate_toc "$_toc_input")
+
+assert_contains "ToC: H2 mit Emoji" "- [✨ Erster Abschnitt](#-erster-abschnitt)" "$result"
+assert_contains "ToC: H3 eingerückt" "  - [Unter-Abschnitt](#unter-abschnitt)" "$result"
+assert_contains "ToC: Zweiter H2" "- [🚀 Zweiter Abschnitt](#-zweiter-abschnitt)" "$result"
+assert_contains "ToC: Zweiter H3" "  - [Noch ein Unter-Abschnitt](#noch-ein-unter-abschnitt)" "$result"
+assert_contains "ToC: H2 ohne Emoji" "- [Dritter](#dritter)" "$result"
+
+# H4 wird ignoriert
+_toc_h4_input="## Hauptabschnitt
+
+### Unter
+
+#### Detail-Ebene"
+
+result=$(generate_toc "$_toc_h4_input")
+[[ "$result" != *"Detail-Ebene"* ]]
+assert_equals "ToC: H4 ignoriert" "0" "$?"
+
+# Anzahl der Einträge prüfen
+local toc_lines
+toc_lines=$(echo "$result" | wc -l)
+assert_equals "ToC: 2 Einträge (H2+H3, kein H4)" "2" "${toc_lines##* }"
+
+# ============================================================
+# Credits-Sektion – Integrations-Test
+# ============================================================
+echo ""
+echo "=== Credits-Sektion (Integration) ==="
+
+result=$(generate_readme_md)
+assert_contains "Credits: Sektion vorhanden" "## 🙏 Credits" "$result"
+assert_contains "Credits: Catppuccin" "Catppuccin Mocha" "$result"
+assert_contains "Credits: Brewfile-Link" "setup/Brewfile" "$result"
+
+# Credits steht zwischen Dokumentation und Lizenz
+local credits_pos doku_pos lizenz_pos
+credits_pos=$(echo "$result" | grep -n '## 🙏 Credits' | head -1 | cut -d: -f1)
+doku_pos=$(echo "$result" | grep -n '## 📖 Dokumentation' | head -1 | cut -d: -f1)
+lizenz_pos=$(echo "$result" | grep -n '## Lizenz' | head -1 | cut -d: -f1)
+[[ "$doku_pos" -lt "$credits_pos" && "$credits_pos" -lt "$lizenz_pos" ]]
+assert_equals "Credits: nach Doku, vor Lizenz" "0" "$?"
+
+# ============================================================
+# ToC-Konsistenz – Integrations-Test
+# ============================================================
+echo ""
+echo "=== ToC-Konsistenz (Integration) ==="
+
+result=$(generate_readme_md)
+
+# ToC-Sektion ist vorhanden
+assert_contains "ToC: Inhalt-Überschrift" "## Inhalt" "$result"
+
+# Jede ## und ### Überschrift (außer Inhalt) muss im ToC vorkommen
+local heading_count=0 toc_count=0
+while IFS= read -r line; do
+    if [[ "$line" == '## '* || "$line" == '### '* ]]; then
+        # "Inhalt" selbst überspringen
+        [[ "$line" == '## Inhalt' ]] && continue
+        (( heading_count++ )) || true
+    fi
+    # ToC-Einträge zählen (beginnen mit "- [" oder "  - [")
+    if [[ "$line" == '- ['* || "$line" == '  - ['* ]]; then
+        (( toc_count++ )) || true
+    fi
+done <<< "$result"
+
+assert_equals "ToC-Vollständigkeit: Einträge == Überschriften" "$heading_count" "$toc_count"
 
 # ============================================================
 # Zusammenfassung

--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@
   <em>cmds – alle Aliase und Funktionen durchsuchen (einer von 20+ fzf-Workflows)</em>
 </p>
 
+## Inhalt
+
+- [✨ Was du bekommst](#-was-du-bekommst)
+  - [Interaktive Workflows (fzf)](#interaktive-workflows-fzf)
+  - [Media-Toolkit](#media-toolkit)
+  - [Weitere Werkzeuge](#weitere-werkzeuge)
+  - [Shell-Erlebnis](#shell-erlebnis)
+- [🚀 Installation](#-installation)
+  - [Deinstallation](#deinstallation)
+  - [Voraussetzungen](#voraussetzungen)
+- [📖 Dokumentation](#-dokumentation)
+- [🙏 Credits](#-credits)
+- [Lizenz](#lizenz)
+
 ## ✨ Was du bekommst
 
 | Vorher | Nachher | Vorteil |
@@ -138,6 +152,12 @@ Details: [Setup-Doku → Deinstallation](docs/setup.md#deinstallation--wiederher
 | `tldr <tool>` | Vollständige Tool-Doku mit dotfiles-Erweiterungen |
 
 Mehr: [Setup](docs/setup.md) · [Anpassung](docs/customization.md) · [Contributing](CONTRIBUTING.md)
+
+## 🙏 Credits
+
+Dieses Projekt nutzt [Catppuccin Mocha](https://catppuccin.com/) als einheitliches Theme.
+
+Alle installierten Tools und Abhängigkeiten: [`setup/Brewfile`](setup/Brewfile)
 
 ## Lizenz
 


### PR DESCRIPTION
## Beschreibung

Erweitert die README.md um zwei neue Sektionen:

1. **Inhaltsverzeichnis (ToC)** – dynamisch aus dem generierten Body abgeleitet, direkt nach dem Hero-Screenshot
2. **Credits-Sektion** – vor der Lizenz, mit Verweis auf Catppuccin Mocha und Brewfile

Die Umsetzung folgt konsequent dem SSOT-Prinzip: Beide Sektionen werden im Generator generiert, nicht manuell gepflegt. Neue Sektionen erscheinen automatisch im ToC.

### Technische Details

- `heading_to_anchor()` bildet das Verhalten von [github-slugger v2](https://github.com/Flet/github-slugger) nach (Quellcode verifiziert)
- `LC_ALL=C.UTF-8` für `tr`/`sed` – stellt sicher, dass Unicode-Buchstaben (ä, ü, ö) unabhängig von der System-Locale korrekt als `[:alnum:]` erkannt werden (CI: Ubuntu C-Locale)
- `generate_toc()` parst `##` und `###` Überschriften aus dem generierten Body, mit Slug-Usage-Map für GitHub-kompatible Deduplizierung doppelter Überschriften (`-1`, `-2`, …)
- `generate_readme_md()` auf Zwei-Phasen-Architektur umgestellt (Body → ToC → Zusammensetzen)
- ZSH-Bug mit `local`-Redeklaration in Schleifen erkannt und vermieden

## Art der Änderung

- [x] 🐛 Bugfix (Locale-Bug in `heading_to_anchor`)
- [x] ✨ Neues Feature
- [x] 📝 Dokumentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Konfiguration
- [ ] 🛠️ Maintenance/Chore
- [ ] 🏗️ Setup/Bootstrap
- [ ] 🎨 Theming
- [x] 🧪 Testing
- [ ] 🔒 Security
- [ ] 🚀 Performance

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare (falls zutreffend)
- [ ] Bei neuen Tools: Guard-Check vorhanden (falls zutreffend)
- [x] Screenshots in `docs/assets/` noch aktuell (falls zutreffend)

## Zusammenhängende Issues

Closes #403

## Screenshots / Terminal-Ausgabe

```
✔ 73 bestanden, 0 fehlgeschlagen      (Unit Tests readme.sh)
✔ 23 bestanden, 0 fehlgeschlagen      (Integrationstests)
✔ Alle 14 Test-Dateien bestanden       (Gesamt-Suite inkl. LC_ALL=C)
✔ Alle Dokumentation ist aktuell       (generate-docs --check)
✔ Health Check erfolgreich             (128 bestanden, 0 Fehler)
```