### PR TITLE
docs: Credits-Verweis auf setup.md statt Brewfile

### DIFF
--- a/.github/scripts/generators/readme.sh
+++ b/.github/scripts/generators/readme.sh
@@ -298,7 +298,7 @@ ${shell_keybindings}
 
 Dazu: **[Catppuccin Mocha](https://catppuccin.com/) Theme** überall, **Hilfe im Terminal** via \`dothelp\`, **fzf-Integration** für alles.
 ${theme_image}
-Alle installierten Pakete: [\`setup/Brewfile\`](setup/Brewfile)
+Alle installierten Pakete: [Vollständige Paketliste](docs/setup.md#installierte-pakete)
 
 ## 🚀 Installation
 
@@ -354,7 +354,7 @@ Mehr: [Setup](docs/setup.md) · [Anpassung](docs/customization.md) · [Contribut
 
 Dieses Projekt nutzt [Catppuccin Mocha](https://catppuccin.com/) als einheitliches Theme.
 
-Alle installierten Tools und Abhängigkeiten: [\`setup/Brewfile\`](setup/Brewfile)
+Alle Tools und deren Projekt-Homepages: [Installierte Pakete](docs/setup.md#installierte-pakete)
 
 ## Lizenz
 

--- a/.github/scripts/tests/test-generator-readme.sh
+++ b/.github/scripts/tests/test-generator-readme.sh
@@ -438,7 +438,7 @@ echo "=== Credits-Sektion (Integration) ==="
 result=$(generate_readme_md)
 assert_contains "Credits: Sektion vorhanden" "## 🙏 Credits" "$result"
 assert_contains "Credits: Catppuccin" "Catppuccin Mocha" "$result"
-assert_contains "Credits: Brewfile-Link" "setup/Brewfile" "$result"
+assert_contains "Credits: Paketliste-Link" "docs/setup.md#installierte-pakete" "$result"
 
 # Credits steht zwischen Dokumentation und Lizenz
 local credits_pos doku_pos lizenz_pos

--- a/.github/scripts/tests/test-generator-readme.sh
+++ b/.github/scripts/tests/test-generator-readme.sh
@@ -441,6 +441,10 @@ assert_contains "Credits: Catppuccin" "Catppuccin Mocha" "$result"
 assert_contains "Credits: Paketliste-Link" "[Installierte Pakete](docs/setup.md#installierte-pakete)" "$result"
 assert_contains "Shell-Erlebnis: Paketliste-Link" "[Vollständige Paketliste](docs/setup.md#installierte-pakete)" "$result"
 
+# Link-Target-Validierung: Anker muss in docs/setup.md existieren
+grep -q '^## Installierte Pakete' "$DOCS_DIR/setup.md"
+assert_equals "Link-Target: Anker #installierte-pakete existiert in setup.md" "0" "$?"
+
 # Credits steht zwischen Dokumentation und Lizenz
 local credits_pos doku_pos lizenz_pos
 credits_pos=$(echo "$result" | grep -n '## 🙏 Credits' | head -1 | cut -d: -f1)

--- a/.github/scripts/tests/test-generator-readme.sh
+++ b/.github/scripts/tests/test-generator-readme.sh
@@ -438,7 +438,8 @@ echo "=== Credits-Sektion (Integration) ==="
 result=$(generate_readme_md)
 assert_contains "Credits: Sektion vorhanden" "## 🙏 Credits" "$result"
 assert_contains "Credits: Catppuccin" "Catppuccin Mocha" "$result"
-assert_contains "Credits: Paketliste-Link" "docs/setup.md#installierte-pakete" "$result"
+assert_contains "Credits: Paketliste-Link" "[Installierte Pakete](docs/setup.md#installierte-pakete)" "$result"
+assert_contains "Shell-Erlebnis: Paketliste-Link" "[Vollständige Paketliste](docs/setup.md#installierte-pakete)" "$result"
 
 # Credits steht zwischen Dokumentation und Lizenz
 local credits_pos doku_pos lizenz_pos

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Dazu: **[Catppuccin Mocha](https://catppuccin.com/) Theme** überall, **Hilfe im
   <em>lt – eza Tree-View mit Nerd Font Icons und Catppuccin Mocha Farben</em>
 </p>
 
-Alle installierten Pakete: [`setup/Brewfile`](setup/Brewfile)
+Alle installierten Pakete: [Vollständige Paketliste](docs/setup.md#installierte-pakete)
 
 ## 🚀 Installation
 
@@ -157,7 +157,7 @@ Mehr: [Setup](docs/setup.md) · [Anpassung](docs/customization.md) · [Contribut
 
 Dieses Projekt nutzt [Catppuccin Mocha](https://catppuccin.com/) als einheitliches Theme.
 
-Alle installierten Tools und Abhängigkeiten: [`setup/Brewfile`](setup/Brewfile)
+Alle Tools und deren Projekt-Homepages: [Installierte Pakete](docs/setup.md#installierte-pakete)
 
 ## Lizenz
 


### PR DESCRIPTION
## Beschreibung

Beide Brewfile-Links in der README.md auf `docs/setup.md#installierte-pakete` umgestellt. Die gerenderte Tabelle mit klickbaren Homepage-Links und deutschen Beschreibungen ist für Credits und Paketübersicht deutlich besser geeignet als das rohe Brewfile.

**Änderungen:**
- **Shell-Erlebnis:** `setup/Brewfile` → [Vollständige Paketliste](docs/setup.md#installierte-pakete)
- **Credits:** `setup/Brewfile` → [Installierte Pakete](docs/setup.md#installierte-pakete)
- Texte differenziert (Entdeckung vs. Anerkennung)
- Tests verschärft: beide Links unabhängig prüfbar (voller Markdown-Linktext statt nur Substring)
- Link-Target-Validierung: prüft, dass `## Installierte Pakete` in `docs/setup.md` existiert

## Art der Änderung

- [x] 📝 Dokumentation
- [x] 🧪 Testing

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [ ] Neue Aliase/Funktionen haben Beschreibungskommentare (falls zutreffend)
- [ ] Bei neuen Tools: Guard-Check vorhanden (falls zutreffend)
- [ ] Screenshots in `docs/assets/` noch aktuell (falls zutreffend)

## Zusammenhängende Issues

Closes #407

## Screenshots / Terminal-Ausgabe

```
✔ 75 bestanden, 0 fehlgeschlagen
```