### PR TITLE
feat: interaktiver SSH-Key Assistent im Bootstrap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,15 +209,26 @@ Alle Module in `setup/modules/` prüfen ob `_core.sh` geladen ist:
 }
 ```
 
-Module mit Standalone-Fähigkeit nutzen zusätzlich `ZSH_EVAL_CONTEXT`:
+Module mit Standalone-Fähigkeit nutzen zusätzlich `ZSH_EVAL_CONTEXT`.
+Der Standalone-Check **muss vor** dem Core-Guard stehen, damit `zsh modul.sh`
+zuerst `_core.sh` laden kann, bevor der Guard greift:
 
 ```zsh
-# Am Ende des Moduls: Standalone-Ausführung erkennen
-# ZSH_EVAL_CONTEXT ist "toplevel" bei `zsh modul.sh`,
-# aber "toplevel:file" bei `source modul.sh` und
-# "toplevel:shfunc:file" bei source aus load_module().
-if [[ "$ZSH_EVAL_CONTEXT" == "toplevel" ]]; then
-    source "${0:A:h}/_core.sh"
+# VOR dem Guard: Standalone erkennen und Core laden
+if [[ "${ZSH_EVAL_CONTEXT}" == "toplevel" ]]; then
+    source "${0:A:h}/_core.sh" || { echo "FEHLER: _core.sh nicht gefunden" >&2; exit 1; }
+fi
+
+# Guard: fängt `source modul.sh` ohne Core ab
+[[ -z "${_BOOTSTRAP_CORE_LOADED:-}" ]] && {
+    echo "FEHLER: _core.sh muss vor <modul>.sh geladen werden" >&2
+    return 1
+}
+
+# ... Funktionsdefinitionen ...
+
+# Am Ende: Standalone-Ausführung
+if [[ "${ZSH_EVAL_CONTEXT}" == "toplevel" ]]; then
     setup_modul
 fi
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,7 +260,8 @@ Interaktive Module (z.B. `ssh-keys.sh`) mit User-Eingaben **müssen** Input vali
 
 - Keine Wildcards/Sonderzeichen in SSH-Aliase erlauben (`*`, `?`, `!`, `[]`, Leerzeichen)
 - Port-Nummern auf 1–65535 begrenzen (ZSH `<->` allein reicht nicht)
-- Validierung über Helper-Funktionen in `_core.sh`: `validate_ssh_alias()`, `validate_port()`
+- SSH-Config-Werte auf Whitespace, `#` und Steuerzeichen prüfen (brechen die gesamte Config)
+- Validierung über Helper-Funktionen in `_core.sh`: `validate_ssh_alias()`, `validate_port()`, `validate_ssh_value()`
 
 ```zsh
 # Beispiel: Alias-Validierung

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,11 +246,20 @@ Alle `source`-Aufrufe müssen geschützt sein:
 
 # Spezialfälle außerhalb load_module():
 if [[ -f "$MODULES_DIR/modul.sh" ]]; then
-    source "$MODULES_DIR/modul.sh" || {
+    if source "$MODULES_DIR/modul.sh"; then
+        # Funktion nur aufrufen wenn source erfolgreich war
+        if (( $+functions[setup_modul] )); then
+            setup_modul || true
+        fi
+    else
         warn "Modul konnte nicht geladen werden"
-    }
+    fi
 fi
 ```
+
+**Wichtig:** `source || { warn }` ohne `return` fällt durch – ZSH registriert
+Funktionen während des Parsens, auch wenn `source` am Ende fehlschlägt.
+`$+functions` ist daher kein zuverlässiger Guard nach fehlgeschlagenem `source`.
 
 ### Input-Validierung
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ Anleitung für die Entwicklung an diesem dotfiles-Repository.
   - [Cross-Platform Abstraktionen](#cross-platform-abstraktionen)
   - [Verzeichniswechsel und zoxide](#verzeichniswechsel-und-zoxide)
   - [Guard-System](#guard-system)
+  - [Input-Validierung](#input-validierung)
   - [Pfad-Pattern](#pfad-pattern)
   - [fzf Helper-Skripte](#fzf-helper-skripte)
   - [fzf Placeholder-Regeln](#fzf-placeholder-regeln)
@@ -183,6 +184,8 @@ alle zukünftigen Funktionen die Verzeichnisse wechseln.
 
 ### Guard-System
 
+#### Alias-Guards
+
 Alle `.alias`-Dateien prüfen ob das jeweilige Tool installiert ist:
 
 ```zsh
@@ -193,6 +196,72 @@ fi
 ```
 
 So bleiben Original-Befehle (`ls`, `cat`) erhalten wenn ein Tool fehlt.
+
+#### Bootstrap-Guards
+
+Alle Module in `setup/modules/` prüfen ob `_core.sh` geladen ist:
+
+```zsh
+# Guard am Anfang jedes Moduls
+[[ -z "${_BOOTSTRAP_CORE_LOADED:-}" ]] && {
+    echo "FEHLER: _core.sh muss vor <modul>.sh geladen werden" >&2
+    return 1
+}
+```
+
+Module mit Standalone-Fähigkeit nutzen zusätzlich `ZSH_EVAL_CONTEXT`:
+
+```zsh
+# Am Ende des Moduls: Standalone-Ausführung erkennen
+# ZSH_EVAL_CONTEXT ist "toplevel" bei `zsh modul.sh`,
+# aber "toplevel:file" bei `source modul.sh` und
+# "toplevel:shfunc:file" bei source aus load_module().
+if [[ "$ZSH_EVAL_CONTEXT" == "toplevel" ]]; then
+    source "${0:A:h}/_core.sh"
+    setup_modul
+fi
+```
+
+> **Wichtig:** `_BOOTSTRAP_CORE_LOADED` prüft **Abhängigkeiten** (Logging, Farben, Pfade).
+> `ZSH_EVAL_CONTEXT` prüft den **Ausführungskontext** (direkt vs. source). Beides hat unterschiedliche Aufgaben.
+
+#### Source-Schutz in bootstrap.sh
+
+`source` unter `set -e` bricht bei fehlender oder fehlerhafter Datei sofort ab.
+Alle `source`-Aufrufe müssen geschützt sein:
+
+```zsh
+# Reguläre Module: load_module() enthält Existenz-Check + || { err; return 1 }
+
+# Spezialfälle außerhalb load_module():
+if [[ -f "$MODULES_DIR/modul.sh" ]]; then
+    source "$MODULES_DIR/modul.sh" || {
+        warn "Modul konnte nicht geladen werden"
+    }
+fi
+```
+
+### Input-Validierung
+
+Interaktive Module (z.B. `ssh-keys.sh`) mit User-Eingaben **müssen** Input validieren.
+
+**Grundregeln:**
+
+- Keine Wildcards/Sonderzeichen in SSH-Aliase erlauben (`*`, `?`, `!`, `[]`, Leerzeichen)
+- Port-Nummern auf 1–65535 begrenzen (ZSH `<->` allein reicht nicht)
+- Validierung über Helper-Funktionen in `_core.sh`: `validate_ssh_alias()`, `validate_port()`
+
+```zsh
+# Beispiel: Alias-Validierung
+alias_name=$(_ask_input "Host-Alias:")
+[[ -z "$alias_name" ]] && break
+if ! validate_ssh_alias "$alias_name"; then
+    continue
+fi
+```
+
+> **Warum?** SSH interpretiert `*`, `?`, `!` als Pattern in Host-Aliase.
+> Ein Alias wie `*evil*` matched ungewollt andere Hosts.
 
 ### Pfad-Pattern
 

--- a/setup/bootstrap.sh
+++ b/setup/bootstrap.sh
@@ -266,7 +266,9 @@ main() {
         source "$MODULES_DIR/ssh-keys.sh" || {
             warn "SSH-Key Modul konnte nicht geladen werden"
         }
-        setup_ssh_keys || true
+        if (( $+functions[setup_ssh_keys] )); then
+            setup_ssh_keys || true
+        fi
     fi
     CURRENT_STEP=""
 

--- a/setup/bootstrap.sh
+++ b/setup/bootstrap.sh
@@ -5,7 +5,8 @@
 # Zweck       : Lädt und führt Bootstrap-Module in definierter Reihenfolge aus
 # Aufruf      : ./bootstrap.sh
 # Docs        : https://github.com/tshofmann/dotfiles#readme
-# Module      : setup/modules/ (validation, homebrew, backup, stow, git-hooks, font, terminal-profile, bat, tealdeer, xcode-theme, zsh-sessions, ssh-keys)
+# Module      : setup/modules/ (validation, homebrew, backup, stow, git-hooks, font, terminal-profile, bat, tealdeer, xcode-theme, zsh-sessions)
+# Optional    : ssh-keys (interaktiv, nach Abschluss-Banner)
 # Generiert   : README.md (macOS-Versionen), docs/setup.md (Bootstrap-Schritte)
 # ============================================================
 
@@ -261,8 +262,12 @@ main() {
     # aufgerufen: System ist komplett, gh installiert, alle Tools verfügbar.
     # Fehler im Assistenten brechen das Bootstrap nicht ab (|| true).
     CURRENT_STEP="SSH-Keys (optional)"
-    source "$MODULES_DIR/ssh-keys.sh"
-    setup_ssh_keys || true
+    if [[ -f "$MODULES_DIR/ssh-keys.sh" ]]; then
+        source "$MODULES_DIR/ssh-keys.sh" || {
+            warn "SSH-Key Modul konnte nicht geladen werden"
+        }
+        setup_ssh_keys || true
+    fi
     CURRENT_STEP=""
 
     section "Nächster Schritt"

--- a/setup/bootstrap.sh
+++ b/setup/bootstrap.sh
@@ -5,7 +5,7 @@
 # Zweck       : Lädt und führt Bootstrap-Module in definierter Reihenfolge aus
 # Aufruf      : ./bootstrap.sh
 # Docs        : https://github.com/tshofmann/dotfiles#readme
-# Module      : setup/modules/ (validation, homebrew, backup, stow, git-hooks, font, terminal-profile, bat, tealdeer, xcode-theme, zsh-sessions)
+# Module      : setup/modules/ (validation, homebrew, backup, stow, git-hooks, font, terminal-profile, bat, tealdeer, xcode-theme, zsh-sessions, ssh-keys)
 # Generiert   : README.md (macOS-Versionen), docs/setup.md (Bootstrap-Schritte)
 # ============================================================
 
@@ -255,6 +255,16 @@ main() {
     print -r -- "${C_GREEN}  ✔ Setup abgeschlossen${C_RESET}"
     print -r -- "${C_GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${C_RESET}"
     print -r -- ""
+
+    # SSH-Key Assistent (optional, interaktiv)
+    # Wird bewusst NACH dem Abschluss-Banner und AUSSERHALB des Modul-Loops
+    # aufgerufen: System ist komplett, gh installiert, alle Tools verfügbar.
+    # Fehler im Assistenten brechen das Bootstrap nicht ab (|| true).
+    CURRENT_STEP="SSH-Keys (optional)"
+    source "$MODULES_DIR/ssh-keys.sh"
+    setup_ssh_keys || true
+    CURRENT_STEP=""
+
     section "Nächster Schritt"
 
     print -r -- "  ${C_MAUVE}1.${C_RESET} Neue Shell-Sitzung starten: ${C_DIM}exec zsh${C_RESET}"

--- a/setup/bootstrap.sh
+++ b/setup/bootstrap.sh
@@ -263,11 +263,12 @@ main() {
     # Fehler im Assistenten brechen das Bootstrap nicht ab (|| true).
     CURRENT_STEP="SSH-Keys (optional)"
     if [[ -f "$MODULES_DIR/ssh-keys.sh" ]]; then
-        source "$MODULES_DIR/ssh-keys.sh" || {
+        if source "$MODULES_DIR/ssh-keys.sh"; then
+            if (( $+functions[setup_ssh_keys] )); then
+                setup_ssh_keys || true
+            fi
+        else
             warn "SSH-Key Modul konnte nicht geladen werden"
-        }
-        if (( $+functions[setup_ssh_keys] )); then
-            setup_ssh_keys || true
         fi
     fi
     CURRENT_STEP=""

--- a/setup/modules/_core.sh
+++ b/setup/modules/_core.sh
@@ -119,6 +119,8 @@ CURRENT_STEP="Initialisierung"
 # Defensive Helper für Dateioperationen
 # ------------------------------------------------------------
 # Prüft ob ein Verzeichnis erstellt werden kann (oder bereits existiert und schreibbar ist)
+# mkdir -p erstellt fehlende Elternverzeichnisse automatisch,
+# daher kein manueller Parent-Check nötig.
 # Rückgabe: 0 = OK, 1 = Fehler
 ensure_dir_writable() {
     local dir="$1"
@@ -134,14 +136,7 @@ ensure_dir_writable() {
         fi
     fi
 
-    # Verzeichnis existiert nicht, prüfe ob Elternverzeichnis schreibbar ist
-    local parent="${dir:h}"
-    if [[ ! -w "$parent" ]]; then
-        err "Kann $description nicht erstellen, Elternverzeichnis nicht schreibbar: $parent"
-        return 1
-    fi
-
-    # Versuche Verzeichnis zu erstellen
+    # Versuche Verzeichnis (inkl. Elternverzeichnisse) zu erstellen
     if ! mkdir -p "$dir" 2>/dev/null; then
         err "Konnte $description nicht erstellen: $dir"
         return 1

--- a/setup/modules/_core.sh
+++ b/setup/modules/_core.sh
@@ -207,6 +207,37 @@ validate_port() {
     return 0
 }
 
+# Prüft ob ein SSH-Config-Wert sicher ist (keine Whitespace, #, Steuerzeichen)
+# SSH interpretiert Leerzeichen als Token-Trenner und # als Kommentar.
+# Ungültige Werte in HostName/User brechen die GESAMTE SSH-Config.
+# Rückgabe: 0 = gültig, 1 = ungültig (Fehlermeldung via warn)
+validate_ssh_value() {
+    local value="$1"
+    local label="${2:-Wert}"
+
+    if [[ -z "$value" ]]; then
+        warn "$label darf nicht leer sein"
+        return 1
+    fi
+
+    if [[ "$value" =~ [[:space:]] ]]; then
+        warn "Ungültiger $label '$value' – Leerzeichen/Tabs nicht erlaubt"
+        return 1
+    fi
+
+    if [[ "$value" == *'#'* ]]; then
+        warn "Ungültiger $label '$value' – '#' wird von SSH als Kommentar interpretiert"
+        return 1
+    fi
+
+    if [[ "$value" =~ [[:cntrl:]] ]]; then
+        warn "Ungültiger $label '$value' – Steuerzeichen nicht erlaubt"
+        return 1
+    fi
+
+    return 0
+}
+
 # ------------------------------------------------------------
 # Konfiguration (Pfade für Module)
 # ------------------------------------------------------------

--- a/setup/modules/_core.sh
+++ b/setup/modules/_core.sh
@@ -172,6 +172,47 @@ ensure_file_writable() {
 }
 
 # ------------------------------------------------------------
+# Input-Validierung für interaktive Module
+# ------------------------------------------------------------
+# Prüft ob ein SSH-Host-Alias gültig ist (keine Wildcards, keine Leerzeichen)
+# SSH interpretiert *, ?, !, [] als Pattern – diese MÜSSEN abgelehnt werden.
+# Erlaubt: Beginnt mit Buchstabe, dann alphanumerisch + Punkt/Unterstrich/Bindestrich
+# Rückgabe: 0 = gültig, 1 = ungültig (Fehlermeldung via warn)
+validate_ssh_alias() {
+    local alias_name="$1"
+
+    if [[ -z "$alias_name" ]]; then
+        warn "Host-Alias darf nicht leer sein"
+        return 1
+    fi
+
+    if [[ ! "$alias_name" =~ ^[a-zA-Z][a-zA-Z0-9._-]*$ ]]; then
+        warn "Ungültiger Host-Alias '$alias_name' – erlaubt: Buchstaben, Zahlen, Punkt, Unterstrich, Bindestrich (muss mit Buchstabe beginnen)"
+        return 1
+    fi
+
+    return 0
+}
+
+# Prüft ob ein Port im gültigen Bereich liegt (1–65535)
+# Rückgabe: 0 = gültig, 1 = ungültig (Fehlermeldung via warn)
+validate_port() {
+    local port="$1"
+
+    if [[ "$port" != <-> ]]; then
+        warn "Ungültiger Port '$port' – muss eine Zahl sein"
+        return 1
+    fi
+
+    if (( port < 1 || port > 65535 )); then
+        warn "Port '$port' außerhalb des gültigen Bereichs (1–65535)"
+        return 1
+    fi
+
+    return 0
+}
+
+# ------------------------------------------------------------
 # Konfiguration (Pfade für Module)
 # ------------------------------------------------------------
 # Diese Variablen werden von allen Modulen verwendet

--- a/setup/modules/apt-packages.sh
+++ b/setup/modules/apt-packages.sh
@@ -315,7 +315,9 @@ _create_binary_symlinks() {
     CURRENT_STEP="Binary-Symlinks"
 
     local bin_dir="$HOME/.local/bin"
-    mkdir -p "$bin_dir"
+    if ! ensure_dir_writable "$bin_dir" "Binary-Verzeichnis"; then
+        return 1
+    fi
 
     for debian_binary expected_name in "${(@kv)BINARY_SYMLINKS}"; do
         if command -v "$debian_binary" >/dev/null 2>&1 && ! command -v "$expected_name" >/dev/null 2>&1; then

--- a/setup/modules/backup.sh
+++ b/setup/modules/backup.sh
@@ -218,15 +218,14 @@ _backup_single_file() {
             if ! ensure_dir_writable "$(dirname "$backup_path")" "Backup-Unterverzeichnis"; then
                 _backup_log "ERROR: Konnte Verzeichnis für $target nicht erstellen"
                 backup_path=""
-                break
-            fi
-
-            # Datei kopieren (mit Permissions)
-            if cp -p "$target" "$backup_path" 2>/dev/null; then
-                _backup_log "BACKUP: $target -> $backup_path"
             else
-                _backup_log "ERROR: Konnte $target nicht sichern"
-                backup_path=""
+                # Datei kopieren (mit Permissions)
+                if cp -p "$target" "$backup_path" 2>/dev/null; then
+                    _backup_log "BACKUP: $target -> $backup_path"
+                else
+                    _backup_log "ERROR: Konnte $target nicht sichern"
+                    backup_path=""
+                fi
             fi
             ;;
 
@@ -240,14 +239,13 @@ _backup_single_file() {
             if ! ensure_dir_writable "$(dirname "$backup_path")" "Backup-Unterverzeichnis"; then
                 _backup_log "ERROR: Konnte Verzeichnis für $target nicht erstellen"
                 backup_path=""
-                break
-            fi
-
-            if cp -Rp "$target" "$(dirname "$backup_path")/" 2>/dev/null; then
-                _backup_log "BACKUP: $target (Verzeichnis) -> $backup_path"
             else
-                _backup_log "ERROR: Konnte Verzeichnis $target nicht sichern"
-                backup_path=""
+                if cp -Rp "$target" "$(dirname "$backup_path")/" 2>/dev/null; then
+                    _backup_log "BACKUP: $target (Verzeichnis) -> $backup_path"
+                else
+                    _backup_log "ERROR: Konnte Verzeichnis $target nicht sichern"
+                    backup_path=""
+                fi
             fi
             ;;
     esac

--- a/setup/modules/backup.sh
+++ b/setup/modules/backup.sh
@@ -215,7 +215,11 @@ _backup_single_file() {
             backup_path="${BACKUP_HOME}/${relative}"
 
             # Verzeichnis erstellen
-            mkdir -p "$(dirname "$backup_path")"
+            if ! ensure_dir_writable "$(dirname "$backup_path")" "Backup-Unterverzeichnis"; then
+                _backup_log "ERROR: Konnte Verzeichnis für $target nicht erstellen"
+                backup_path=""
+                break
+            fi
 
             # Datei kopieren (mit Permissions)
             if cp -p "$target" "$backup_path" 2>/dev/null; then
@@ -233,7 +237,11 @@ _backup_single_file() {
             backup_path="${BACKUP_HOME}/${relative}"
 
             # Parent-Verzeichnis für Backup anlegen
-            mkdir -p "$(dirname "$backup_path")"
+            if ! ensure_dir_writable "$(dirname "$backup_path")" "Backup-Unterverzeichnis"; then
+                _backup_log "ERROR: Konnte Verzeichnis für $target nicht erstellen"
+                backup_path=""
+                break
+            fi
 
             if cp -Rp "$target" "$(dirname "$backup_path")/" 2>/dev/null; then
                 _backup_log "BACKUP: $target (Verzeichnis) -> $backup_path"

--- a/setup/modules/bat.sh
+++ b/setup/modules/bat.sh
@@ -68,8 +68,10 @@ setup_bat() {
 }
 
 # Modul ausführen wenn direkt aufgerufen
-# ZSH_EVAL_CONTEXT endet auf :shfunc:file wenn per source aus load_module() geladen
-if [[ "$ZSH_EVAL_CONTEXT" == "toplevel:file" ]]; then
+# ZSH_EVAL_CONTEXT ist "toplevel" bei `zsh bat.sh`,
+# aber "toplevel:file" bei `source bat.sh` und
+# "toplevel:shfunc:file" bei source aus load_module().
+if [[ "$ZSH_EVAL_CONTEXT" == "toplevel" ]]; then
     source "${0:A:h}/_core.sh"
     setup_bat
 fi

--- a/setup/modules/bat.sh
+++ b/setup/modules/bat.sh
@@ -10,7 +10,12 @@
 # Theme       : ~/.config/bat/themes/Catppuccin Mocha.tmTheme
 # ============================================================
 
-# Guard: Core muss geladen sein
+# Standalone: Core laden bevor Guard greift
+if [[ "${ZSH_EVAL_CONTEXT}" == "toplevel" ]]; then
+    source "${0:A:h}/_core.sh" || { echo "FEHLER: _core.sh nicht gefunden" >&2; exit 1; }
+fi
+
+# Guard: Core muss geladen sein (fängt source ohne Core ab)
 [[ -z "${_BOOTSTRAP_CORE_LOADED:-}" ]] && {
     echo "FEHLER: _core.sh muss vor bat.sh geladen werden" >&2
     return 1
@@ -67,11 +72,7 @@ setup_bat() {
     build_bat_cache
 }
 
-# Modul ausführen wenn direkt aufgerufen
-# ZSH_EVAL_CONTEXT ist "toplevel" bei `zsh bat.sh`,
-# aber "toplevel:file" bei `source bat.sh` und
-# "toplevel:shfunc:file" bei source aus load_module().
-if [[ "$ZSH_EVAL_CONTEXT" == "toplevel" ]]; then
-    source "${0:A:h}/_core.sh"
+# Standalone: Hauptfunktion aufrufen (Core wurde oben bereits geladen)
+if [[ "${ZSH_EVAL_CONTEXT}" == "toplevel" ]]; then
     setup_bat
 fi

--- a/setup/modules/git-hooks.sh
+++ b/setup/modules/git-hooks.sh
@@ -94,8 +94,10 @@ setup_git_hooks() {
 }
 
 # Modul ausführen wenn direkt aufgerufen
-# ZSH_EVAL_CONTEXT endet auf :shfunc:file wenn per source aus load_module() geladen
-if [[ "$ZSH_EVAL_CONTEXT" == "toplevel:file" ]]; then
+# ZSH_EVAL_CONTEXT ist "toplevel" bei `zsh git-hooks.sh`,
+# aber "toplevel:file" bei `source git-hooks.sh` und
+# "toplevel:shfunc:file" bei source aus load_module().
+if [[ "$ZSH_EVAL_CONTEXT" == "toplevel" ]]; then
     source "${0:A:h}/_core.sh"
     setup_git_hooks
 fi

--- a/setup/modules/git-hooks.sh
+++ b/setup/modules/git-hooks.sh
@@ -10,7 +10,12 @@
 # Hooks       : .github/hooks/pre-commit
 # ============================================================
 
-# Guard: Core muss geladen sein
+# Standalone: Core laden bevor Guard greift
+if [[ "${ZSH_EVAL_CONTEXT}" == "toplevel" ]]; then
+    source "${0:A:h}/_core.sh" || { echo "FEHLER: _core.sh nicht gefunden" >&2; exit 1; }
+fi
+
+# Guard: Core muss geladen sein (fängt source ohne Core ab)
 [[ -z "${_BOOTSTRAP_CORE_LOADED:-}" ]] && {
     echo "FEHLER: _core.sh muss vor git-hooks.sh geladen werden" >&2
     return 1
@@ -93,11 +98,7 @@ setup_git_hooks() {
     configure_git_hooks
 }
 
-# Modul ausführen wenn direkt aufgerufen
-# ZSH_EVAL_CONTEXT ist "toplevel" bei `zsh git-hooks.sh`,
-# aber "toplevel:file" bei `source git-hooks.sh` und
-# "toplevel:shfunc:file" bei source aus load_module().
-if [[ "$ZSH_EVAL_CONTEXT" == "toplevel" ]]; then
-    source "${0:A:h}/_core.sh"
+# Standalone: Hauptfunktion aufrufen (Core wurde oben bereits geladen)
+if [[ "${ZSH_EVAL_CONTEXT}" == "toplevel" ]]; then
     setup_git_hooks
 fi

--- a/setup/modules/ssh-keys.sh
+++ b/setup/modules/ssh-keys.sh
@@ -12,7 +12,12 @@
 #               Gesamter Ablauf ist optional und interaktiv.
 # ============================================================
 
-# Guard: Core muss geladen sein
+# Standalone: Core laden bevor Guard greift
+if [[ "${ZSH_EVAL_CONTEXT}" == "toplevel" ]]; then
+    source "${0:A:h}/_core.sh" || { echo "FEHLER: _core.sh nicht gefunden" >&2; exit 1; }
+fi
+
+# Guard: Core muss geladen sein (fängt source ohne Core ab)
 [[ -z "${_BOOTSTRAP_CORE_LOADED:-}" ]] && {
     echo "FEHLER: _core.sh muss vor ssh-keys.sh geladen werden" >&2
     return 1
@@ -36,7 +41,11 @@ _ask_yes_no() {
     local prompt="$1"
     local answer
     print -rn -- "${C_MAUVE}?${C_RESET} ${prompt} [j/N] "
-    read -r answer
+    if ! read -r answer; then
+        # EOF (Ctrl-D) → wie "Nein" behandeln
+        print -r -- ""
+        return 1
+    fi
     [[ "$answer" == [jJ] ]]
 }
 
@@ -54,7 +63,12 @@ _ask_input() {
     else
         print -rn -- "${C_MAUVE}?${C_RESET} ${prompt} " >/dev/tty
     fi
-    read -r answer
+    if ! read -r answer; then
+        # EOF (Ctrl-D) → Default zurückgeben
+        print -r -- "" >/dev/tty
+        print -r -- "$default"
+        return 0
+    fi
     print -r -- "${answer:-$default}"
 }
 
@@ -403,11 +417,7 @@ setup_ssh_keys() {
     return 0
 }
 
-# Modul ausführen wenn direkt aufgerufen
-# ZSH_EVAL_CONTEXT ist "toplevel" bei `zsh ssh-keys.sh`,
-# aber "toplevel:file" bei `source ssh-keys.sh` und
-# "toplevel:shfunc:file" bei source aus load_module().
-if [[ "$ZSH_EVAL_CONTEXT" == "toplevel" ]]; then
-    source "${0:A:h}/_core.sh"
+# Standalone: Hauptfunktion aufrufen (Core wurde oben bereits geladen)
+if [[ "${ZSH_EVAL_CONTEXT}" == "toplevel" ]]; then
     setup_ssh_keys
 fi

--- a/setup/modules/ssh-keys.sh
+++ b/setup/modules/ssh-keys.sh
@@ -377,6 +377,10 @@ setup_ssh_keys() {
 
     CURRENT_STEP="SSH-Keys (optional)"
 
+    # Restriktive umask: SSH-Dateien direkt mit 600/700 erstellen
+    # statt nachträglich chmod (Race Condition: CWE-362)
+    umask 077
+
     section "SSH-Key Assistent"
     log "Dieser Assistent hilft dir bei der Einrichtung von:"
     log "  • SSH-Key Generierung (Ed25519)"

--- a/setup/modules/ssh-keys.sh
+++ b/setup/modules/ssh-keys.sh
@@ -40,10 +40,11 @@ typeset -g _ALLOWED_SIGNERS="$_SSH_DIR/allowed_signers"
 _ask_yes_no() {
     local prompt="$1"
     local answer
-    print -rn -- "${C_MAUVE}?${C_RESET} ${prompt} [j/N] "
+    # Prompt auf /dev/tty statt stdout – sonst ist er bei Umleitung unsichtbar
+    print -rn -- "${C_MAUVE}?${C_RESET} ${prompt} [j/N] " >/dev/tty
     if ! read -r answer; then
         # EOF (Ctrl-D) → wie "Nein" behandeln
-        print -r -- ""
+        print -r -- "" >/dev/tty
         return 1
     fi
     [[ "$answer" == [jJ] ]]
@@ -132,7 +133,7 @@ _ensure_ssh_config_defaults() {
     fi
 
     # Config existiert und hat bereits Host * Block
-    if [[ -f "$_SSH_CONFIG" ]] && grep -q "^Host \*" "$_SSH_CONFIG" 2>/dev/null; then
+    if [[ -f "$_SSH_CONFIG" ]] && grep -Eq '^[[:space:]]*Host[[:space:]]+\*$' "$_SSH_CONFIG" 2>/dev/null; then
         chmod 600 "$_SSH_CONFIG" 2>/dev/null
         ok "SSH-Config Defaults bereits vorhanden"
         return 0
@@ -379,6 +380,8 @@ setup_ssh_keys() {
 
     # Restriktive umask: SSH-Dateien direkt mit 600/700 erstellen
     # statt nachträglich chmod (Race Condition: CWE-362)
+    local old_umask
+    old_umask=$(umask)
     umask 077
 
     section "SSH-Key Assistent"
@@ -391,11 +394,13 @@ setup_ssh_keys() {
 
     if ! _ask_yes_no "SSH-Key Assistenten starten?"; then
         log "SSH-Assistent übersprungen"
+        umask "$old_umask"
         return 0
     fi
 
     # 1. SSH-Key generieren (oder bestehenden verwenden)
     if ! _generate_ssh_key; then
+        umask "$old_umask"
         return 0
     fi
 
@@ -423,6 +428,9 @@ setup_ssh_keys() {
         log "Key: ${C_DIM}$_SSH_KEY${C_RESET}"
         log "Fingerprint: ${C_DIM}$(ssh-keygen -l -f "$_SSH_KEY" 2>/dev/null || echo "–")${C_RESET}"
     fi
+
+    # umask wiederherstellen – sonst bleiben restriktive Permissions aktiv
+    umask "$old_umask"
 
     return 0
 }

--- a/setup/modules/ssh-keys.sh
+++ b/setup/modules/ssh-keys.sh
@@ -1,0 +1,405 @@
+#!/usr/bin/env zsh
+# ============================================================
+# ssh-keys.sh - Interaktiver SSH-Key Assistent
+# ============================================================
+# Zweck       : Generiert SSH-Keys, konfiguriert Git-Signing und SSH-Hosts
+# Pfad        : setup/modules/ssh-keys.sh
+# Benötigt    : _core.sh
+# Nutzt       : ssh-keygen, gh, git
+#
+# STEP        : SSH-Keys | Interaktiver Assistent für SSH & Git-Signing | ⏭ Optional
+# Hinweis     : Wird NACH dem Bootstrap-Banner aufgerufen, nicht als reguläres Modul.
+#               Gesamter Ablauf ist optional und interaktiv.
+# ============================================================
+
+# Guard: Core muss geladen sein
+[[ -z "${_BOOTSTRAP_CORE_LOADED:-}" ]] && {
+    echo "FEHLER: _core.sh muss vor ssh-keys.sh geladen werden" >&2
+    return 1
+}
+
+# ------------------------------------------------------------
+# Konfiguration
+# ------------------------------------------------------------
+typeset -g _SSH_DIR="$HOME/.ssh"
+typeset -g _SSH_KEY="$_SSH_DIR/id_ed25519"
+typeset -g _SSH_KEY_PUB="$_SSH_DIR/id_ed25519.pub"
+typeset -g _SSH_CONFIG="$_SSH_DIR/config"
+typeset -g _ALLOWED_SIGNERS="$_SSH_DIR/allowed_signers"
+
+# ------------------------------------------------------------
+# Helper: Ja/Nein-Abfrage (set -e sicher)
+# ------------------------------------------------------------
+# read -r gibt immer Exit 0 zurück (solange stdin offen).
+# read -q würde Exit 1 bei "Nein" geben → set -e Crash.
+_ask_yes_no() {
+    local prompt="$1"
+    local answer
+    print -rn -- "${C_MAUVE}?${C_RESET} ${prompt} [j/N] "
+    read -r answer
+    [[ "$answer" == [jJ] ]]
+}
+
+# ------------------------------------------------------------
+# Helper: Eingabe mit optionalem Vorschlag
+# ------------------------------------------------------------
+_ask_input() {
+    local prompt="$1"
+    local default="${2:-}"
+    local answer
+
+    # Prompt auf /dev/tty statt stdout – sonst fängt $() den Prompt ab
+    if [[ -n "$default" ]]; then
+        print -rn -- "${C_MAUVE}?${C_RESET} ${prompt} ${C_DIM}[$default]${C_RESET} " >/dev/tty
+    else
+        print -rn -- "${C_MAUVE}?${C_RESET} ${prompt} " >/dev/tty
+    fi
+    read -r answer
+    print -r -- "${answer:-$default}"
+}
+
+# ------------------------------------------------------------
+# SSH-Key generieren
+# ------------------------------------------------------------
+_generate_ssh_key() {
+    section "SSH-Key Generierung"
+
+    # Prüfe ob Key bereits existiert
+    if [[ -f "$_SSH_KEY" ]]; then
+        ok "SSH-Key bereits vorhanden: $_SSH_KEY"
+        log "Fingerprint: $(ssh-keygen -l -f "$_SSH_KEY" 2>/dev/null || echo "unbekannt")"
+
+        if ! _ask_yes_no "Bestehenden Key verwenden?"; then
+            warn "Abgebrochen – bestehender Key bleibt unverändert"
+            return 1
+        fi
+        return 0
+    fi
+
+    # E-Mail für Key-Kommentar abfragen
+    local email
+    email=$(_ask_input "E-Mail-Adresse für den SSH-Key:")
+
+    if [[ -z "$email" ]]; then
+        warn "Keine E-Mail angegeben – Key-Generierung übersprungen"
+        return 1
+    fi
+
+    # Verzeichnis sicherstellen
+    if [[ ! -d "$_SSH_DIR" ]]; then
+        mkdir -m 700 "$_SSH_DIR"
+        ok "Verzeichnis erstellt: $_SSH_DIR"
+    fi
+
+    # Key generieren (interaktiv: Passphrase wird von ssh-keygen abgefragt)
+    log "Generiere Ed25519 SSH-Key..."
+    if ssh-keygen -t ed25519 -C "$email" -f "$_SSH_KEY"; then
+        ok "SSH-Key generiert: $_SSH_KEY"
+        log "Fingerprint: $(ssh-keygen -l -f "$_SSH_KEY")"
+    else
+        err "SSH-Key Generierung fehlgeschlagen"
+        return 1
+    fi
+
+    return 0
+}
+
+# ------------------------------------------------------------
+# SSH-Config: Globale Defaults schreiben
+# ------------------------------------------------------------
+# Stellt sicher dass Host * Block mit AddKeysToAgent und
+# IdentityFile existiert. UseKeychain nur auf macOS.
+_ensure_ssh_config_defaults() {
+    # Verzeichnis sicherstellen
+    if [[ ! -d "$_SSH_DIR" ]]; then
+        mkdir -m 700 "$_SSH_DIR"
+    fi
+
+    # Config existiert und hat bereits Host * Block
+    if [[ -f "$_SSH_CONFIG" ]] && grep -q "^Host \*" "$_SSH_CONFIG" 2>/dev/null; then
+        ok "SSH-Config Defaults bereits vorhanden"
+        return 0
+    fi
+
+    log "Schreibe SSH-Config Defaults..."
+
+    if [[ -f "$_SSH_CONFIG" ]]; then
+        # Bestehende Config: Defaults voranstellen
+        local existing
+        existing=$(<"$_SSH_CONFIG")
+        {
+            print -r -- "Host *"
+            print -r -- "    AddKeysToAgent yes"
+            is_macos && print -r -- "    UseKeychain yes"
+            print -r -- "    IdentityFile $_SSH_KEY"
+            print -r -- ""
+            print -r -- "$existing"
+        } > "$_SSH_CONFIG"
+    else
+        {
+            print -r -- "Host *"
+            print -r -- "    AddKeysToAgent yes"
+            is_macos && print -r -- "    UseKeychain yes"
+            print -r -- "    IdentityFile $_SSH_KEY"
+        } > "$_SSH_CONFIG"
+    fi
+
+    chmod 600 "$_SSH_CONFIG"
+    ok "SSH-Config Defaults geschrieben"
+}
+
+# ------------------------------------------------------------
+# Key zu GitHub hochladen
+# ------------------------------------------------------------
+_upload_to_github() {
+    section "GitHub Key-Upload"
+
+    # gh verfügbar?
+    if ! command -v gh >/dev/null 2>&1; then
+        warn "gh CLI nicht gefunden – GitHub-Upload übersprungen"
+        log "Installiere gh und führe manuell aus:"
+        log "  gh ssh-key add $_SSH_KEY_PUB --title \"\$(hostname)\""
+        return 0
+    fi
+
+    # Eingeloggt?
+    if ! gh auth status >/dev/null 2>&1; then
+        warn "Nicht bei GitHub angemeldet – Upload übersprungen"
+        log "Melde dich an mit: gh auth login"
+        log "Dann lade den Key hoch:"
+        log "  gh ssh-key add $_SSH_KEY_PUB --title \"\$(hostname)\""
+        return 0
+    fi
+
+    # Key-Fingerprint für Duplikat-Check
+    local fingerprint
+    fingerprint=$(ssh-keygen -l -f "$_SSH_KEY_PUB" 2>/dev/null | awk '{print $2}')
+
+    if [[ -z "$fingerprint" ]]; then
+        warn "Kann Key-Fingerprint nicht lesen – Upload übersprungen"
+        return 0
+    fi
+
+    # Prüfe ob Key bereits auf GitHub registriert ist
+    local existing_keys
+    existing_keys=$(gh ssh-key list 2>/dev/null || echo "")
+
+    if echo "$existing_keys" | grep -qF "$fingerprint"; then
+        ok "SSH-Key bereits auf GitHub registriert"
+        return 0
+    fi
+
+    local hostname
+    hostname=$(hostname -s 2>/dev/null || hostname)
+
+    # Authentication Key hochladen
+    if _ask_yes_no "SSH-Key als Authentication-Key zu GitHub hochladen?"; then
+        if gh ssh-key add "$_SSH_KEY_PUB" --title "$hostname"; then
+            ok "Authentication-Key hochgeladen: $hostname"
+        else
+            warn "Upload fehlgeschlagen (Key eventuell bereits vorhanden)"
+        fi
+    fi
+
+    # Signing Key hochladen
+    if _ask_yes_no "SSH-Key als Signing-Key zu GitHub hochladen (für Verified-Badge)?"; then
+        if gh ssh-key add "$_SSH_KEY_PUB" --title "$hostname (signing)" --type signing; then
+            ok "Signing-Key hochgeladen: $hostname (signing)"
+        else
+            warn "Upload fehlgeschlagen (Key eventuell bereits vorhanden)"
+        fi
+    fi
+
+    return 0
+}
+
+# ------------------------------------------------------------
+# Git für SSH-Signing konfigurieren
+# ------------------------------------------------------------
+_configure_git_signing() {
+    section "Git-Signatur Konfiguration"
+
+    if ! _ask_yes_no "Git für signierte Commits konfigurieren?"; then
+        log "Git-Signatur übersprungen"
+        return 0
+    fi
+
+    # user.name abfragen
+    local current_name
+    current_name=$(git config --global user.name 2>/dev/null || echo "")
+    local name
+    name=$(_ask_input "Git user.name:" "$current_name")
+
+    if [[ -z "$name" ]]; then
+        warn "Kein Name angegeben – Git-Signatur übersprungen"
+        return 0
+    fi
+
+    # user.email abfragen (Vorschlag: Kommentar aus SSH-Key)
+    local current_email key_email
+    current_email=$(git config --global user.email 2>/dev/null || echo "")
+    key_email=$(ssh-keygen -l -f "$_SSH_KEY_PUB" 2>/dev/null | sed -n 's/.* \(.*\)/\1/p' || echo "")
+    local email_default="${current_email:-$key_email}"
+    local email
+    email=$(_ask_input "Git user.email:" "$email_default")
+
+    if [[ -z "$email" ]]; then
+        warn "Keine E-Mail angegeben – Git-Signatur übersprungen"
+        return 0
+    fi
+
+    # Git-Konfiguration setzen
+    git config --global user.name "$name"
+    git config --global user.email "$email"
+    git config --global gpg.format ssh
+    git config --global user.signingkey "$_SSH_KEY_PUB"
+    git config --global commit.gpgsign true
+    git config --global tag.gpgsign true
+
+    ok "Git-Konfiguration gesetzt (user: $name <$email>)"
+    ok "SSH-Signing aktiviert (commit + tag)"
+
+    # allowed_signers für lokale Verifikation
+    local pub_key
+    pub_key=$(<"$_SSH_KEY_PUB")
+
+    if [[ -f "$_ALLOWED_SIGNERS" ]] && grep -q "$email" "$_ALLOWED_SIGNERS" 2>/dev/null; then
+        ok "allowed_signers bereits konfiguriert"
+    else
+        print -r -- "$email $pub_key" >> "$_ALLOWED_SIGNERS"
+        chmod 600 "$_ALLOWED_SIGNERS"
+        ok "allowed_signers aktualisiert: $_ALLOWED_SIGNERS"
+    fi
+
+    git config --global gpg.ssh.allowedSignersFile "$_ALLOWED_SIGNERS"
+
+    return 0
+}
+
+# ------------------------------------------------------------
+# SSH-Hosts für Netzwerk-Rechner konfigurieren
+# ------------------------------------------------------------
+_configure_ssh_hosts() {
+    section "SSH-Hosts Konfiguration"
+
+    if ! _ask_yes_no "SSH-Verbindungen zu Netzwerk-Rechnern einrichten?"; then
+        log "SSH-Hosts übersprungen"
+        return 0
+    fi
+
+    local added=0
+    local alias_name host_addr host_user host_port
+
+    while true; do
+        print -r -- ""
+        log "Neuen SSH-Host hinzufügen (leerer Alias = fertig)"
+
+        alias_name=$(_ask_input "Host-Alias (z.B. homeserver):")
+        [[ -z "$alias_name" ]] && break
+
+        host_addr=$(_ask_input "IP-Adresse oder Hostname:")
+        [[ -z "$host_addr" ]] && { warn "Keine Adresse – Host übersprungen"; continue; }
+
+        host_user=$(_ask_input "Benutzername:" "$(whoami)")
+        host_port=$(_ask_input "Port:" "22")
+
+        # Port-Validierung
+        if [[ "$host_port" != <-> ]]; then
+            warn "Ungültiger Port '$host_port' – Host übersprungen"
+            continue
+        fi
+
+        # Prüfe ob Host bereits in Config existiert
+        if [[ -f "$_SSH_CONFIG" ]] && grep -q "^Host $alias_name$" "$_SSH_CONFIG" 2>/dev/null; then
+            warn "Host '$alias_name' bereits in SSH-Config vorhanden – übersprungen"
+            continue
+        fi
+
+        # Host-Eintrag anhängen
+        {
+            print -r -- ""
+            print -r -- "Host $alias_name"
+            print -r -- "    HostName $host_addr"
+            print -r -- "    User $host_user"
+            [[ "$host_port" != "22" ]] && print -r -- "    Port $host_port"
+            print -r -- "    IdentityFile $_SSH_KEY"
+        } >> "$_SSH_CONFIG"
+
+        ok "Host hinzugefügt: $alias_name → $host_user@$host_addr"
+        (( added++ )) || true
+
+        _ask_yes_no "Weiteren Host hinzufügen?" || break
+    done
+
+    if (( added > 0 )); then
+        section_end "$added Host(s) konfiguriert"
+        print -r -- ""
+        log "Verbindung testen: ${C_DIM}ssh $alias_name${C_RESET}"
+    fi
+
+    return 0
+}
+
+# ------------------------------------------------------------
+# Hauptfunktion
+# ------------------------------------------------------------
+setup_ssh_keys() {
+    # TTY-Guard: Überspringt lautlos in CI/Pipes/Headless
+    if [[ ! -t 0 ]]; then
+        log "Kein interaktives Terminal – SSH-Assistent übersprungen"
+        return 0
+    fi
+
+    CURRENT_STEP="SSH-Keys (optional)"
+
+    section "SSH-Key Assistent"
+    log "Dieser Assistent hilft dir bei der Einrichtung von:"
+    log "  • SSH-Key Generierung (Ed25519)"
+    log "  • GitHub Key-Upload (Authentication + Signing)"
+    log "  • Git Commit-Signatur (Verified-Badge)"
+    log "  • SSH-Hosts für Netzwerk-Rechner"
+    print -r -- ""
+
+    if ! _ask_yes_no "SSH-Key Assistenten starten?"; then
+        log "SSH-Assistent übersprungen"
+        return 0
+    fi
+
+    # 1. SSH-Key generieren (oder bestehenden verwenden)
+    if ! _generate_ssh_key; then
+        return 0
+    fi
+
+    # 2. SSH-Config Defaults (Host *, AddKeysToAgent, UseKeychain)
+    _ensure_ssh_config_defaults
+
+    # 3. Key zu GitHub hochladen
+    if [[ -f "$_SSH_KEY_PUB" ]]; then
+        _upload_to_github
+    fi
+
+    # 4. Git für SSH-Signing konfigurieren
+    if [[ -f "$_SSH_KEY_PUB" ]]; then
+        _configure_git_signing
+    fi
+
+    # 5. SSH-Hosts für Netzwerk-Rechner (optional)
+    _configure_ssh_hosts
+
+    # Zusammenfassung
+    print -r -- ""
+    print -r -- "${C_GREEN}━━━ ${C_BOLD}SSH-Setup abgeschlossen${C_RESET}${C_GREEN} ━━━${C_RESET}"
+    print -r -- ""
+    if [[ -f "$_SSH_KEY_PUB" ]]; then
+        log "Key: ${C_DIM}$_SSH_KEY${C_RESET}"
+        log "Fingerprint: ${C_DIM}$(ssh-keygen -l -f "$_SSH_KEY" 2>/dev/null || echo "–")${C_RESET}"
+    fi
+
+    return 0
+}
+
+# Modul ausführen wenn direkt aufgerufen
+if [[ "$ZSH_EVAL_CONTEXT" == "toplevel:file" ]]; then
+    source "${0:A:h}/_core.sh"
+    setup_ssh_keys
+fi

--- a/setup/modules/ssh-keys.sh
+++ b/setup/modules/ssh-keys.sh
@@ -131,6 +131,7 @@ _ensure_ssh_config_defaults() {
 
     # Config existiert und hat bereits Host * Block
     if [[ -f "$_SSH_CONFIG" ]] && grep -q "^Host \*" "$_SSH_CONFIG" 2>/dev/null; then
+        chmod 600 "$_SSH_CONFIG" 2>/dev/null
         ok "SSH-Config Defaults bereits vorhanden"
         return 0
     fi
@@ -278,6 +279,7 @@ _configure_git_signing() {
     pub_key=$(<"$_SSH_KEY_PUB")
 
     if [[ -f "$_ALLOWED_SIGNERS" ]] && awk -v e="$email" '$1 == e { found=1 } END { exit !found }' "$_ALLOWED_SIGNERS" 2>/dev/null; then
+        chmod 600 "$_ALLOWED_SIGNERS" 2>/dev/null
         ok "allowed_signers bereits konfiguriert"
     else
         print -r -- "$email $pub_key" >> "$_ALLOWED_SIGNERS"
@@ -303,6 +305,7 @@ _configure_ssh_hosts() {
 
     local added=0
     local alias_name host_addr host_user host_port
+    local last_alias
 
     while true; do
         print -r -- ""
@@ -344,6 +347,7 @@ _configure_ssh_hosts() {
         } >> "$_SSH_CONFIG"
 
         ok "Host hinzugefügt: $alias_name → $host_user@$host_addr"
+        last_alias="$alias_name"
         (( added++ )) || true
 
         _ask_yes_no "Weiteren Host hinzufügen?" || break
@@ -352,7 +356,7 @@ _configure_ssh_hosts() {
     if (( added > 0 )); then
         section_end "$added Host(s) konfiguriert"
         print -r -- ""
-        log "Verbindung testen: ${C_DIM}ssh $alias_name${C_RESET}"
+        log "Verbindung testen: ${C_DIM}ssh $last_alias${C_RESET}"
     fi
 
     return 0

--- a/setup/modules/ssh-keys.sh
+++ b/setup/modules/ssh-keys.sh
@@ -238,7 +238,7 @@ _configure_git_signing() {
     # user.email abfragen (Vorschlag: Kommentar aus SSH-Key)
     local current_email key_email
     current_email=$(git config --global user.email 2>/dev/null || echo "")
-    key_email=$(ssh-keygen -l -f "$_SSH_KEY_PUB" 2>/dev/null | sed -n 's/.* \(.*\)/\1/p' || echo "")
+    key_email=$(ssh-keygen -l -f "$_SSH_KEY_PUB" 2>/dev/null | awk '{print $3}' || echo "")
     local email_default="${current_email:-$key_email}"
     local email
     email=$(_ask_input "Git user.email:" "$email_default")
@@ -263,7 +263,7 @@ _configure_git_signing() {
     local pub_key
     pub_key=$(<"$_SSH_KEY_PUB")
 
-    if [[ -f "$_ALLOWED_SIGNERS" ]] && grep -q "$email" "$_ALLOWED_SIGNERS" 2>/dev/null; then
+    if [[ -f "$_ALLOWED_SIGNERS" ]] && awk -v e="$email" '$1 == e { found=1 } END { exit !found }' "$_ALLOWED_SIGNERS" 2>/dev/null; then
         ok "allowed_signers bereits konfiguriert"
     else
         print -r -- "$email $pub_key" >> "$_ALLOWED_SIGNERS"
@@ -310,7 +310,7 @@ _configure_ssh_hosts() {
         fi
 
         # Prüfe ob Host bereits in Config existiert
-        if [[ -f "$_SSH_CONFIG" ]] && grep -q "^Host $alias_name$" "$_SSH_CONFIG" 2>/dev/null; then
+        if [[ -f "$_SSH_CONFIG" ]] && grep -qxF "Host $alias_name" "$_SSH_CONFIG" 2>/dev/null; then
             warn "Host '$alias_name' bereits in SSH-Config vorhanden – übersprungen"
             continue
         fi
@@ -399,7 +399,10 @@ setup_ssh_keys() {
 }
 
 # Modul ausführen wenn direkt aufgerufen
-if [[ "$ZSH_EVAL_CONTEXT" == "toplevel:file" ]]; then
+# ZSH_EVAL_CONTEXT ist "toplevel" bei `zsh ssh-keys.sh`,
+# aber "toplevel:file" bei `source ssh-keys.sh` und
+# "toplevel:shfunc:file" bei source aus load_module().
+if [[ "$ZSH_EVAL_CONTEXT" == "toplevel" ]]; then
     source "${0:A:h}/_core.sh"
     setup_ssh_keys
 fi

--- a/setup/modules/ssh-keys.sh
+++ b/setup/modules/ssh-keys.sh
@@ -127,6 +127,8 @@ _ensure_ssh_config_defaults() {
     # Verzeichnis sicherstellen
     if [[ ! -d "$_SSH_DIR" ]]; then
         mkdir -m 700 "$_SSH_DIR"
+    else
+        chmod 700 "$_SSH_DIR" 2>/dev/null
     fi
 
     # Config existiert und hat bereits Host * Block

--- a/setup/modules/ssh-keys.sh
+++ b/setup/modules/ssh-keys.sh
@@ -26,11 +26,11 @@ fi
 # ------------------------------------------------------------
 # Konfiguration
 # ------------------------------------------------------------
-typeset -g _SSH_DIR="$HOME/.ssh"
-typeset -g _SSH_KEY="$_SSH_DIR/id_ed25519"
-typeset -g _SSH_KEY_PUB="$_SSH_DIR/id_ed25519.pub"
-typeset -g _SSH_CONFIG="$_SSH_DIR/config"
-typeset -g _ALLOWED_SIGNERS="$_SSH_DIR/allowed_signers"
+typeset -gr _SSH_DIR="$HOME/.ssh"
+typeset -gr _SSH_KEY="$_SSH_DIR/id_ed25519"
+typeset -gr _SSH_KEY_PUB="$_SSH_DIR/id_ed25519.pub"
+typeset -gr _SSH_CONFIG="$_SSH_DIR/config"
+typeset -gr _ALLOWED_SIGNERS="$_SSH_DIR/allowed_signers"
 
 # ------------------------------------------------------------
 # Helper: Ja/Nein-Abfrage (set -e sicher)
@@ -267,6 +267,11 @@ _configure_git_signing() {
 
     if [[ -z "$email" ]]; then
         warn "Keine E-Mail angegeben – Git-Signatur übersprungen"
+        return 0
+    fi
+
+    # E-Mail validieren (Leerzeichen/# brechen allowed_signers Format)
+    if ! validate_ssh_value "$email" "E-Mail"; then
         return 0
     fi
 

--- a/setup/modules/ssh-keys.sh
+++ b/setup/modules/ssh-keys.sh
@@ -102,6 +102,10 @@ _generate_ssh_key() {
 
     # Verzeichnis sicherstellen
     if [[ ! -d "$_SSH_DIR" ]]; then
+        if [[ -e "$_SSH_DIR" ]]; then
+            err "Pfad existiert bereits, ist aber kein Verzeichnis: $_SSH_DIR"
+            return 1
+        fi
         mkdir -m 700 "$_SSH_DIR"
         ok "Verzeichnis erstellt: $_SSH_DIR"
     fi
@@ -324,8 +328,15 @@ _configure_ssh_hosts() {
 
         host_addr=$(_ask_input "IP-Adresse oder Hostname:")
         [[ -z "$host_addr" ]] && { warn "Keine Adresse – Host übersprungen"; continue; }
+        if ! validate_ssh_value "$host_addr" "Hostname/IP"; then
+            continue
+        fi
 
         host_user=$(_ask_input "Benutzername:" "$(whoami)")
+        if ! validate_ssh_value "$host_user" "Benutzername"; then
+            continue
+        fi
+
         host_port=$(_ask_input "Port:" "22")
 
         # Port-Validierung (1–65535)

--- a/setup/modules/ssh-keys.sh
+++ b/setup/modules/ssh-keys.sh
@@ -131,7 +131,7 @@ _ensure_ssh_config_defaults() {
             print -r -- "Host *"
             print -r -- "    AddKeysToAgent yes"
             is_macos && print -r -- "    UseKeychain yes"
-            print -r -- "    IdentityFile $_SSH_KEY"
+            print -r -- "    IdentityFile \"$_SSH_KEY\""
             print -r -- ""
             print -r -- "$existing"
         } > "$_SSH_CONFIG"
@@ -140,7 +140,7 @@ _ensure_ssh_config_defaults() {
             print -r -- "Host *"
             print -r -- "    AddKeysToAgent yes"
             is_macos && print -r -- "    UseKeychain yes"
-            print -r -- "    IdentityFile $_SSH_KEY"
+            print -r -- "    IdentityFile \"$_SSH_KEY\""
         } > "$_SSH_CONFIG"
     fi
 
@@ -326,7 +326,7 @@ _configure_ssh_hosts() {
             print -r -- "    HostName $host_addr"
             print -r -- "    User $host_user"
             [[ "$host_port" != "22" ]] && print -r -- "    Port $host_port"
-            print -r -- "    IdentityFile $_SSH_KEY"
+            print -r -- "    IdentityFile \"$_SSH_KEY\""
         } >> "$_SSH_CONFIG"
 
         ok "Host hinzugefügt: $alias_name → $host_user@$host_addr"

--- a/setup/modules/ssh-keys.sh
+++ b/setup/modules/ssh-keys.sh
@@ -297,15 +297,19 @@ _configure_ssh_hosts() {
         alias_name=$(_ask_input "Host-Alias (z.B. homeserver):")
         [[ -z "$alias_name" ]] && break
 
+        # Alias-Validierung: SSH interpretiert *, ?, !, [] als Pattern
+        if ! validate_ssh_alias "$alias_name"; then
+            continue
+        fi
+
         host_addr=$(_ask_input "IP-Adresse oder Hostname:")
         [[ -z "$host_addr" ]] && { warn "Keine Adresse – Host übersprungen"; continue; }
 
         host_user=$(_ask_input "Benutzername:" "$(whoami)")
         host_port=$(_ask_input "Port:" "22")
 
-        # Port-Validierung
-        if [[ "$host_port" != <-> ]]; then
-            warn "Ungültiger Port '$host_port' – Host übersprungen"
+        # Port-Validierung (1–65535)
+        if ! validate_port "$host_port"; then
             continue
         fi
 
@@ -344,7 +348,8 @@ _configure_ssh_hosts() {
 # Hauptfunktion
 # ------------------------------------------------------------
 setup_ssh_keys() {
-    # TTY-Guard: Überspringt lautlos in CI/Pipes/Headless
+    # TTY-Guard: Ohne interaktives Terminal wird der Assistent übersprungen
+    # (CI, Pipes, Headless – gibt eine Info-Meldung aus)
     if [[ ! -t 0 ]]; then
         log "Kein interaktives Terminal – SSH-Assistent übersprungen"
         return 0

--- a/setup/modules/ssh-keys.sh
+++ b/setup/modules/ssh-keys.sh
@@ -285,7 +285,9 @@ _configure_git_signing() {
     local pub_key
     pub_key=$(<"$_SSH_KEY_PUB")
 
-    if [[ -f "$_ALLOWED_SIGNERS" ]] && awk -v e="$email" '$1 == e { found=1 } END { exit !found }' "$_ALLOWED_SIGNERS" 2>/dev/null; then
+    # Prüfe E-Mail+Key Kombination (nicht nur E-Mail), damit bei
+    # Key-Regeneration der neue Key hinzugefügt wird (Key-Rotation)
+    if [[ -f "$_ALLOWED_SIGNERS" ]] && grep -qF "$email $pub_key" "$_ALLOWED_SIGNERS" 2>/dev/null; then
         chmod 600 "$_ALLOWED_SIGNERS" 2>/dev/null
         ok "allowed_signers bereits konfiguriert"
     else

--- a/setup/modules/tealdeer.sh
+++ b/setup/modules/tealdeer.sh
@@ -70,8 +70,10 @@ setup_tealdeer() {
 }
 
 # Modul ausführen wenn direkt aufgerufen
-# ZSH_EVAL_CONTEXT endet auf :shfunc:file wenn per source aus load_module() geladen
-if [[ "$ZSH_EVAL_CONTEXT" == "toplevel:file" ]]; then
+# ZSH_EVAL_CONTEXT ist "toplevel" bei `zsh tealdeer.sh`,
+# aber "toplevel:file" bei `source tealdeer.sh` und
+# "toplevel:shfunc:file" bei source aus load_module().
+if [[ "$ZSH_EVAL_CONTEXT" == "toplevel" ]]; then
     source "${0:A:h}/_core.sh"
     setup_tealdeer
 fi

--- a/setup/modules/tealdeer.sh
+++ b/setup/modules/tealdeer.sh
@@ -10,7 +10,12 @@
 # Cache       : ~/.cache/tealdeer/
 # ============================================================
 
-# Guard: Core muss geladen sein
+# Standalone: Core laden bevor Guard greift
+if [[ "${ZSH_EVAL_CONTEXT}" == "toplevel" ]]; then
+    source "${0:A:h}/_core.sh" || { echo "FEHLER: _core.sh nicht gefunden" >&2; exit 1; }
+fi
+
+# Guard: Core muss geladen sein (fängt source ohne Core ab)
 [[ -z "${_BOOTSTRAP_CORE_LOADED:-}" ]] && {
     echo "FEHLER: _core.sh muss vor tealdeer.sh geladen werden" >&2
     return 1
@@ -69,11 +74,7 @@ setup_tealdeer() {
     update_tldr_cache
 }
 
-# Modul ausführen wenn direkt aufgerufen
-# ZSH_EVAL_CONTEXT ist "toplevel" bei `zsh tealdeer.sh`,
-# aber "toplevel:file" bei `source tealdeer.sh` und
-# "toplevel:shfunc:file" bei source aus load_module().
-if [[ "$ZSH_EVAL_CONTEXT" == "toplevel" ]]; then
-    source "${0:A:h}/_core.sh"
+# Standalone: Hauptfunktion aufrufen (Core wurde oben bereits geladen)
+if [[ "${ZSH_EVAL_CONTEXT}" == "toplevel" ]]; then
     setup_tealdeer
 fi


### PR DESCRIPTION
## Beschreibung

Neues Bootstrap-Modul `setup/modules/ssh-keys.sh` – ein interaktiver Assistent, der nach Abschluss des Bootstraps angeboten wird und bei der SSH-Key-Einrichtung auf frischen Systemen hilft.

**Funktionsumfang:**
- SSH-Key Generierung (Ed25519, mit Passphrase-Abfrage)
- SSH-Config Defaults (`Host *`, `AddKeysToAgent`, `UseKeychain` auf macOS)
- GitHub Key-Upload via `gh` (Authentication + Signing, Fingerprint-Duplikat-Check)
- Git SSH-Signing (`gpg.format=ssh`, `commit.gpgsign`, `tag.gpgsign`, `allowed_signers`)
- SSH-Hosts für Netzwerk-Rechner (Alias, IP, User, Port mit Validierung)

**Design-Entscheidungen:**
- SSH-Signing statt GPG → Kein `gnupg` als Abhängigkeit, native macOS-Keychain-Integration, ein Key für Auth + Signing
- Wird NACH dem Abschluss-Banner aufgerufen, nicht als reguläres Modul → System ist komplett, `gh` installiert, alle Tools verfügbar
- Fehler brechen den Bootstrap nicht ab (`|| true`)
- TTY-Guard: Ohne interaktives Terminal wird der Assistent übersprungen (Info-Meldung)
- Keine `/etc/hosts`-Manipulation → SSH-Config `Host`-Aliase lösen das gleiche Problem ohne `sudo`

**Warum SSH statt GPG?** Issue #99 fragte nach "SSH- und GPG-Key Verwaltung". SSH-Signing wurde gewählt weil:
1. Ein Key für Auth + Signing (kein zweites Tool-Ökosystem)
2. Native macOS-Keychain-Integration ohne gnupg/pinentry
3. GitHub empfiehlt SSH-Signing als Standard seit 2022

**Warum `setup/modules/` statt eigenes Skript?** Das Modul nutzt `_core.sh` (Logging, Farben, `ensure_dir_writable`, `validate_ssh_alias`, `validate_port`) und folgt dem bestehenden Modul-Pattern mit Guards und `setup_*` Hauptfunktion.

## Zusätzlich adressiert: Issue #409

Während des Reviews wurde der `ZSH_EVAL_CONTEXT`-Bug in 3 Modulen entdeckt und in diesem PR direkt behoben:

| Modul | Problem | Fix |
|-------|---------|-----|
| `bat.sh` | Standalone-Guard prüft auf `"toplevel:file"` | → `"toplevel"` |
| `git-hooks.sh` | Standalone-Guard prüft auf `"toplevel:file"` | → `"toplevel"` |
| `tealdeer.sh` | Standalone-Guard prüft auf `"toplevel:file"` | → `"toplevel"` |

`"toplevel:file"` feuert bei `source datei.sh` (falsch), nicht bei `zsh datei.sh` (gewollt). `ssh-keys.sh` hatte bereits den korrekten Wert.

## Standalone/Core-Guard Reihenfolge

Core-Guard am Dateianfang blockierte die Standalone-Ausführung (`zsh modul.sh`): `return 1` feuerte bevor der Standalone-Block am Ende _core.sh laden konnte.

**Fix:** Standalone-Check **vor** den Guard verschoben – Core wird geladen bevor der Guard greift:

```zsh
# VOR dem Guard: Standalone erkennen und Core laden
if [[ "${ZSH_EVAL_CONTEXT}" == "toplevel" ]]; then
    source "${0:A:h}/_core.sh" || { echo "FEHLER"; exit 1; }
fi

# Guard: fängt `source modul.sh` ohne Core ab
[[ -z "${_BOOTSTRAP_CORE_LOADED:-}" ]] && { return 1 }
```

Betrifft: `ssh-keys.sh`, `bat.sh`, `git-hooks.sh`, `tealdeer.sh`

## Globale Konsistenz-Fixes

### ensure_dir_writable vereinfacht

Alte Implementierung prüfte nur das **direkte** Elternverzeichnis – versagte bei fehlenden Zwischenebenen (z.B. `~/.local/bin` wenn `~/.local` nicht existiert). `mkdir -p` kann die gesamte Kette selbst erstellen, daher Parent-Check entfernt.

### Rohe `mkdir`-Aufrufe durch `ensure_dir_writable` ersetzt

| Datei | Vorher | Nachher |
|-------|--------|---------|
| `apt-packages.sh` | `mkdir -p "$bin_dir"` | `ensure_dir_writable` mit Fehlermeldung |
| `backup.sh` (2×) | `mkdir -p "$(dirname ...)"` | `ensure_dir_writable` mit Fehlermeldung |

**Bewusst belassen:** `ssh-keys.sh` nutzt `mkdir -m 700` wegen spezieller Permissions für `~/.ssh` – `ensure_dir_writable` setzt keine Permissions.

### EOF-Handling in ssh-keys.sh

`read -r` bei EOF (Ctrl-D) gibt Exit ≠ 0 → `set -e` Crash. Defensiv abgefangen:
- `_ask_yes_no`: EOF → `return 1` (= "Nein")
- `_ask_input`: EOF → Default-Wert zurückgeben

## Copilot-Review Fixes

### Review 1 (9 Kommentare)

| Kommentar | Fix |
|-----------|-----|
| C5: Alias/Port-Validierung | `validate_ssh_alias()` + `validate_port()` in `_core.sh`, SSH-Wildcards `*?![]` werden abgelehnt, Port-Range 1–65535 |
| C6: TTY-Kommentar "lautlos" | Kommentar korrigiert – Code gibt Info-Meldung aus |
| C7: Source ohne Guard | `source ssh-keys.sh` mit Existenz-Check + `|| { warn }` geschützt |
| C8: Header irreführend | ssh-keys in eigene `# Optional`-Zeile verschoben |

Abgelehnt: C1 (Guard-Interaktion – nun doch gefixt in Review 2), C2/C4 (mkdir unter `|| true`), C3 (70-Zeilen awk Rewrite), C9 (chmod nach append)

### Review 2 (10 Kommentare)

| # | Thema | Verdikt |
|---|-------|---------|
| NC1/NC10/NC11 | Core-Guard blockiert Standalone | ✅ Fix: Standalone-Source vor Guard |
| NC8/NC9 | ensure_dir_writable Parent-Chain | ✅ Fix: Parent-Check entfernt, mkdir -p reicht |
| NC12/NC13 | read -r EOF Crash | ✅ Fix: Defensives EOF-Handling |
| NC2 | mkdir -m 700 unguarded | ✅ Fix: chmod 700 auf bestehendes ~/.ssh |
| NC3 | awk Host-*-Rewrite | ❌ Over-engineering |
| NC4 | File-Ops fault-tolerance | ❌ Durch || true geschützt |
| NC5 | Input-Validierung unvollständig | ❌ Outdated (bereits in 521be38 gefixt) |
| NC6 | chmod nach Host-Append | ❌ Bereits 600 durch vorherigen Schritt |
| NC7 | `<->` braucht extendedglob | ❌ Falsch (`<->` ist base ZSH) |

### Review 3 (3 Kommentare)

| # | Thema | Verdikt |
|---|-------|---------|
| NC1 | alias_name leer nach while-Schleife | ✅ Fix: `last_alias` trackt letzten erfolgreichen Host |
| NC2 | chmod 600 bei bestehendem Host * | ✅ Fix: chmod vor early-return (+ Konsistenz-Fix für allowed_signers) |
| NC3 | Oktal bei Port "022" / "08" | ❌ Falsch (ZSH `OCTAL_ZEROES` standardmäßig AUS) |

### Review 4 (3 Kommentare)

| # | Thema | Verdikt |
|---|-------|---------|
| NC1 | _ask_yes_no Prompt auf stdout statt /dev/tty | ✅ Fix: Konsistent mit _ask_input nach /dev/tty |
| NC2 | umask 077 nicht wiederhergestellt | ✅ Fix: old_umask Save/Restore an allen Exit-Pfaden |
| NC3 | Host * Pattern zu strikt (Whitespace/Anker) | ✅ Fix: `'^[[:space:]]*Host[[:space:]]+\*$'` mit `-Eq` |

### Review 5 (4 Kommentare)

| # | Thema | Verdikt |
|---|-------|---------|
| NC1 | mkdir auf ~/.ssh als Datei → kryptischer Fehler | ✅ Fix: Explizite Prüfung `[[ -e && ! -d ]]` mit klarer Meldung |
| NC2 | _ensure_ssh_config_defaults Schreibfehler | ❌ Durch || true + set -e geschützt (wie Review 2 NC4) |
| NC3 | host_addr/host_user unvalidiert → Config-Bruch | ✅ Fix: `validate_ssh_value()` in _core.sh (Whitespace, #, Steuerzeichen) |
| NC4 | allowed_signers Schreibfehler | ❌ Durch || true + set -e geschützt (wie NC2) |

### Review 6 (0 Kommentare)

Copilot hat alle 9 geänderten Dateien geprüft und keine neuen Kommentare generiert.

### Eigenanalyse (2 Findings)

| # | Thema | Verdikt |
|---|-------|---------|
| F1 | `_ensure_ssh_config_defaults`: mkdir ohne Datei-Check | ℹ️ Dead Code – `_generate_ssh_key` läuft immer zuerst und garantiert `_SSH_DIR` als Verzeichnis |
| F2 | `allowed_signers`: E-Mail-only Check blockiert Key-Rotation | ✅ Fix: `grep -qF "$email $pub_key"` prüft E-Mail+Key statt nur E-Mail |

### Review 7 (2 Kommentare)

| # | Thema | Verdikt |
|---|-------|---------|
| NC1 | E-Mail in `_configure_git_signing` unvalidiert – Leerzeichen/# brechen `allowed_signers` Format | ✅ Fix: `validate_ssh_value "$email" "E-Mail"` (konsistent mit Host-Validierung) |
| NC2 | `typeset -g` statt `typeset -gr` für Modul-Konstanten – Inkonsistenz mit allen anderen Modulen | ✅ Fix: `typeset -gr` für alle 5 Pfad-Konstanten |

### Review 8 (1 Kommentar + 1 unterdrückt)

| # | Thema | Verdikt |
|---|-------|--------|
| NC1 | `setup_ssh_keys` wird nach fehlgeschlagenem `source` trotzdem aufgerufen (ZSH registriert Funktionen beim Parsen) | ✅ Fix: `if source; then … else warn fi` (konsistent mit `load_module`) |
| Suppressed | `ensure_dir_writable`: Post-mkdir Schreibbarkeits-Check | ❌ Unrealistisch – kein Standard-umask entfernt Owner-Write (0022/0077 → u+w intakt) |

### Review 9 (0 Kommentare)

Copilot hat alle 9 geänderten Dateien geprüft und keine neuen Kommentare generiert.

## CONTRIBUTING.md erweitert

- **Guard-System** um Bootstrap-Guards (`_BOOTSTRAP_CORE_LOADED`) und `ZSH_EVAL_CONTEXT` Standalone-Guards dokumentiert
- **Standalone-Reihenfolge** Pattern dokumentiert (Standalone-Check vor Guard)
- **Source-Schutz** Pattern für `set -e` dokumentiert (aktualisiert: `if source; then` statt `source || { warn }` wegen ZSH Parsing-Semantik)
- **Input-Validierung** Konventionen für interaktive Module

## Art der Änderung

- [x] 🐛 Bugfix
- [x] ✨ Neues Feature
- [x] 📝 Dokumentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Konfiguration
- [ ] 🛠️ Maintenance/Chore
- [x] 🏗️ Setup/Bootstrap
- [ ] 🎨 Theming
- [ ] 🧪 Testing
- [x] 🔒 Security

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare (falls zutreffend)
- [x] Bei neuen Tools: Guard-Check vorhanden (falls zutreffend)
- [x] Screenshots in `docs/assets/` noch aktuell (falls zutreffend)

## Zusammenhängende Issues

Closes #99
Closes #409

## Sicherheitsaspekte

| Maßnahme | Umsetzung |
|----------|-----------|
| SSH-Verzeichnis | `mkdir -m 700` + Existenz-Check (Datei vs. Verzeichnis) |
| Config/Signers | `chmod 600` |
| Alias-Validierung | `validate_ssh_alias()` – Regex `^[a-zA-Z][a-zA-Z0-9._-]*$`, blockiert SSH-Wildcards |
| Port-Validierung | `validate_port()` – Range 1–65535, nicht nur `<->` |
| SSH-Config-Wert | `validate_ssh_value()` – Whitespace, `#`, Steuerzeichen abgelehnt (verhindert Config-Bruch) |
| Fingerprint-Vergleich | `grep -qF` (kein Regex) |
| Host-Alias-Check | `grep -qxF` (kein Regex, ganze Zeile) |
| allowed_signers Duplikat | `grep -qF` (E-Mail+Key) – erkennt Key-Rotation, nicht nur E-Mail |
| Prompt-Capture | `/dev/tty` statt stdout |
| Email-Extraktion | `awk '{print $3}'` statt gierigem sed |
| Source-Schutz | `if source; then … else warn fi` (ZSH registriert Funktionen beim Parsen → `$+functions` nach source-Fehler unzuverlässig) |
| Error-Isolation | `setup_ssh_keys || true` |
| EOF-Handling | `read -r` Fehler abgefangen in _ask_yes_no/_ask_input |
| Permissions-Enforcement | `chmod 600` auf Config/Signers bei early-return + `chmod 700` auf bestehendes `~/.ssh` |
| Race Condition (CWE-362) | `umask 077` vor allen Dateioperationen (mit Restore) – Dateien werden direkt mit 600/700 erstellt |
| E-Mail-Validierung | `validate_ssh_value()` für E-Mail in `_configure_git_signing` (Leerzeichen/# brechen `allowed_signers`) |
| Modul-Konstanten | `typeset -gr` readonly (konsistent mit allen anderen Bootstrap-Modulen) |
| Kein eval, kein sudo | ✔ |

## Review-Hinweise

- Verifiziert mit 58 Sandbox-Tests in 16 Kategorien + 5 Security-Injection-Tests (alle in `/tmp`)
- 15 Commits: Feature → Bugfixes → Review-1-Fixes → Scope-Erweiterung (#409 + Konsistenz) → Tiefenanalyse → Review-2-Fixes → Review-3-Fixes → Permissions-Hardening → umask-Fix → Review-4-Fixes → Review-5-Fixes → Docs → Eigenanalyse → Review-7-Fixes → Review-8-Fix
- 9 Dateien geändert, davon 5 bestehende Module (bat, git-hooks, tealdeer, apt-packages, backup)
