### PR TITLE
feat: git-filter-repo ins Brewfile aufnehmen

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -193,6 +193,7 @@ ff                                  # System-Info anzeigen
 | [`ffmpeg`](https://ffmpeg.org/) | Video/Audio-Codec |
 | [`fzf`](https://github.com/junegunn/fzf) | Fuzzy Finder |
 | [`gh`](https://cli.github.com/) | GitHub CLI |
+| [`git-filter-repo`](https://github.com/newren/git-filter-repo) | Git-History umschreiben |
 | [`imagemagick`](https://imagemagick.org/) | Bild-Manipulation |
 | [`jq`](https://jqlang.org/) | JSON-Prozessor |
 | [`lazygit`](https://github.com/jesseduffield/lazygit) | Git-TUI |

--- a/setup/Brewfile
+++ b/setup/Brewfile
@@ -23,6 +23,7 @@ brew "fd"                                   # find-Ersatz, schnell und intuitiv 
 brew "ffmpeg"                               # Video/Audio-Codec | https://ffmpeg.org/
 brew "fzf"                                  # Fuzzy Finder | https://github.com/junegunn/fzf
 brew "gh"                                   # GitHub CLI | https://cli.github.com/
+brew "git-filter-repo"                      # Git-History umschreiben | https://github.com/newren/git-filter-repo
 brew "imagemagick"                          # Bild-Manipulation | https://imagemagick.org/
 brew "jq"                                   # JSON-Prozessor | https://jqlang.org/
 brew "lazygit"                              # Git-TUI | https://github.com/jesseduffield/lazygit

--- a/setup/modules/apt-packages.sh
+++ b/setup/modules/apt-packages.sh
@@ -60,6 +60,7 @@ typeset -A BREW_TO_ALT=(
     [ffmpeg]=apt:ffmpeg
     [fzf]=apt:fzf
     [gh]=apt:gh               # Erst ab Debian Trixie in offiziellen Repos
+    [git-filter-repo]=apt:git-filter-repo
     [imagemagick]=apt:imagemagick
     [jq]=apt:jq
     [lazygit]=apt:lazygit


### PR DESCRIPTION
## Beschreibung

`git-filter-repo` war bisher manuell installiert (seit 16.03.2026) und wird jetzt deklarativ im Brewfile verwaltet. Das Tool wurde für die Bereinigung falscher Screenshots aus der README-History genutzt – ein Anwendungsfall der wiederkehren kann.

## Art der Änderung

- [x] ✨ Neues Feature

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Bei neuen Tools: Guard-Check vorhanden (falls zutreffend) — nicht nötig, kein Alias/Config

## Zusammenhängende Issues

Keines — Drift in `brew-list` Ausgabe behoben.

## Änderungen

- `setup/Brewfile`: `git-filter-repo` hinzugefügt (alphabetisch zwischen `gh` und `imagemagick`)
- `setup/modules/apt-packages.sh`: `BREW_TO_ALT` Mapping für Linux (`apt:git-filter-repo`)
- `docs/setup.md`: automatisch generiert