### PR TITLE
feat: claude-code durch copilot-cli ersetzen

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -216,7 +216,7 @@ ff                                  # System-Info anzeigen
 
 | Paket | Beschreibung |
 | ----- | ------------ |
-| [`claude-code`](https://docs.anthropic.com/en/docs/claude-code) | Agentic Coding |
+| [`copilot-cli`](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli) | Agentic Coding |
 | [`github`](https://desktop.github.com/) | GitHub Desktop GUI |
 | [`kitty`](https://sw.kovidgoyal.net/kitty/) | GPU-Terminal mit Image-Support |
 | [`visual-studio-code`](https://code.visualstudio.com/) | Editor |

--- a/setup/Brewfile
+++ b/setup/Brewfile
@@ -45,7 +45,7 @@ brew "mas"                                  # Mac App Store CLI | https://github
 # ------------------------------------------------------------
 # Homebrew Casks
 # ------------------------------------------------------------
-cask "claude-code"                          # Agentic Coding | https://docs.anthropic.com/en/docs/claude-code
+cask "copilot-cli"                          # Agentic Coding | https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli
 cask "github"                               # GitHub Desktop GUI | https://desktop.github.com/
 cask "kitty"                                # GPU-Terminal mit Image-Support | https://sw.kovidgoyal.net/kitty/
 cask "visual-studio-code"                   # Editor | https://code.visualstudio.com/


### PR DESCRIPTION
## Beschreibung

Ersetzt den Homebrew Cask `claude-code` durch `copilot-cli` (GitHub Copilot CLI) als Agentic-Coding-Tool im Terminal.

## Art der Änderung

- [x] ✨ Neues Feature

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare (falls zutreffend)
- [x] Bei neuen Tools: Guard-Check vorhanden (falls zutreffend)
- [x] Screenshots in `docs/assets/` noch aktuell (falls zutreffend)

## Zusammenhängende Issues

Closes #411