### PR TITLE
fix: Input-Escaping in terminal-profile.sh

### DIFF
--- a/setup/modules/terminal-profile.sh
+++ b/setup/modules/terminal-profile.sh
@@ -56,12 +56,14 @@ detect_profile_file() {
 # ------------------------------------------------------------
 profile_exists() {
     local profile_name="$1"
-    local profile_grep_pattern="(^[[:space:]]+\"$profile_name\"|^[[:space:]]+$profile_name)[[:space:]]+="
 
     local settings
     settings=$(defaults read com.apple.Terminal "Window Settings" 2>/dev/null || true)
     [[ -z "$settings" ]] && return 1
-    print -r -- "$settings" | grep -qE "$profile_grep_pattern"
+    # Fixed-String-Suche nach Dictionary-Key im plist-Format
+    # Keys erscheinen als '    "name" =' oder '    name ='
+    print -r -- "$settings" | grep -qF "\"${profile_name}\" =" ||
+        print -r -- "$settings" | grep -qF " ${profile_name} ="
 }
 
 # ------------------------------------------------------------
@@ -112,24 +114,27 @@ import_profile() {
 set_profile_as_default() {
     local profile_name="$1"
 
-    osascript <<EOF
-tell application "Terminal"
-    set targetProfile to null
-    repeat with s in settings sets
-        if name of s is "$profile_name" then
-            set targetProfile to s
-            exit repeat
-        end if
-    end repeat
+    osascript - "$profile_name" <<'EOF'
+on run argv
+    set profileName to item 1 of argv
+    tell application "Terminal"
+        set targetProfile to null
+        repeat with s in settings sets
+            if name of s is profileName then
+                set targetProfile to s
+                exit repeat
+            end if
+        end repeat
 
-    if targetProfile is not null then
-        set default settings to targetProfile
-        set startup settings to targetProfile
-        return "success"
-    else
-        return "profile not found"
-    end if
-end tell
+        if targetProfile is not null then
+            set default settings to targetProfile
+            set startup settings to targetProfile
+            return "success"
+        else
+            return "profile not found"
+        end if
+    end tell
+end run
 EOF
 }
 

--- a/setup/modules/terminal-profile.sh
+++ b/setup/modules/terminal-profile.sh
@@ -62,8 +62,10 @@ profile_exists() {
     [[ -z "$settings" ]] && return 1
     # Fixed-String-Suche nach Dictionary-Key im plist-Format
     # Keys erscheinen als '    "name" =' oder '    name ='
-    print -r -- "$settings" | grep -qF "\"${profile_name}\" =" ||
-        print -r -- "$settings" | grep -qF " ${profile_name} ="
+    # -e schützt vor Interpretation als Option falls Name mit "-" beginnt
+    print -r -- "$settings" | grep -qF \
+        -e "\"${profile_name}\" =" \
+        -e " ${profile_name} ="
 }
 
 # ------------------------------------------------------------


### PR DESCRIPTION
## Beschreibung

Behebt unsicheres Input-Escaping in `terminal-profile.sh`. Zwei Stellen, an denen der Profilname ohne Escaping in Regex-Patterns bzw. AppleScript-Code interpoliert wurde.

Closes #415

## Art der Änderung

- [x] 🐛 Bugfix
- [x] 🔒 Security

## Änderungen

### `profile_exists()` — Regex-Injection + Bindestrich-Sicherheit
`grep -qE` mit interpoliertem `$profile_name` im Pattern durch `grep -qF -e` (Fixed String, explizite Pattern-Angabe) ersetzt. Eliminiert Regex-Injection vollständig und verhindert, dass Profilnamen mit führendem Bindestrich als grep-Option interpretiert werden (`grep -qF "-test"` → `grep: invalid option -- t`).

### `set_profile_as_default()` — Shell-Injection in AppleScript
Unquoted Heredoc (`<<EOF`) mit Shell-Interpolation durch quoted Heredoc (`<<'EOF'`) mit `osascript`-Argumenten ersetzt. Der Profilname wird als Argument übergeben und im AppleScript via `on run argv` empfangen — keine Shell-Interpolation mehr.

## Validierung

- `profile_exists("catppuccin-mocha")` → matcht ✅
- `profile_exists("test.*evil")` → kein Regex-Match ✅
- `profile_exists("-evil")` → kein grep-Fehler, kein Match ✅
- `profile_exists("nichtvorhanden")` → kein Match ✅
- `set_profile_as_default("catppuccin-mocha")` → `success` ✅
- Health-Check: 0 Fehler ✅
- Doku-Check: Alles aktuell ✅

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [ ] Neue Aliase/Funktionen haben Beschreibungskommentare (falls zutreffend)
- [ ] Bei neuen Tools: Guard-Check vorhanden (falls zutreffend)
- [ ] Screenshots in `docs/assets/` noch aktuell (falls zutreffend)