### PR TITLE
refactor: os-release per grep parsen statt source

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -54,8 +54,8 @@ detect_platform() {
             _distro_id_like=""
             if [ -n "$_osrelease" ]; then
                 # grep-basiert statt source – Defense-in-Depth (keine Code-Ausführung)
-                _distro_id=$(grep -m1 '^ID=' "$_osrelease" | cut -d= -f2- | tr -d "\"'")
-                _distro_id_like=$(grep -m1 '^ID_LIKE=' "$_osrelease" | cut -d= -f2- | tr -d "\"'")
+                _distro_id=$(grep -m1 '^ID=' "$_osrelease" 2>/dev/null | cut -d= -f2- | tr -d "\"'")
+                _distro_id_like=$(grep -m1 '^ID_LIKE=' "$_osrelease" 2>/dev/null | cut -d= -f2- | tr -d "\"'")
             fi
 
             case "$_distro_id" in

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -43,7 +43,6 @@ detect_platform() {
             # Bei Änderung der ID-Cases hier auch platform.zsh anpassen.
             # Sync wird via CI validiert (validate.yml → Plattform-Sync prüfen)
             # IDs: fedora | debian|ubuntu|raspbian | arch|manjaro
-            # Empfohlenes Pattern: einmal sourcen (systemd os-release Dokumentation)
             _osrelease=""
             if [ -f /etc/os-release ]; then
                 _osrelease="/etc/os-release"
@@ -54,11 +53,9 @@ detect_platform() {
             _distro_id=""
             _distro_id_like=""
             if [ -n "$_osrelease" ]; then
-                # Einmal sourcen, beide Werte per Separator ausgeben
-                # ID/ID_LIKE enthalten per freedesktop-Spec nur [a-z0-9._- ]
-                _distro_info=$(. "$_osrelease" && printf '%s:%s' "$ID" "${ID_LIKE:-}")
-                _distro_id="${_distro_info%%:*}"
-                _distro_id_like="${_distro_info#*:}"
+                # grep-basiert statt source – Defense-in-Depth (keine Code-Ausführung)
+                _distro_id=$(grep -m1 '^ID=' "$_osrelease" | cut -d= -f2- | tr -d "\"'")
+                _distro_id_like=$(grep -m1 '^ID_LIKE=' "$_osrelease" | cut -d= -f2- | tr -d "\"'")
             fi
 
             case "$_distro_id" in

--- a/setup/modules/validation.sh
+++ b/setup/modules/validation.sh
@@ -80,7 +80,8 @@ _validate_debian_version() {
     [[ -z "$osrelease" && -f /usr/lib/os-release ]] && osrelease="/usr/lib/os-release"
 
     if [[ -n "$osrelease" ]]; then
-        codename=$(. "$osrelease" 2>/dev/null && printf '%s' "${VERSION_CODENAME:-}")
+        # grep-basiert statt source – Defense-in-Depth (keine Code-Ausführung)
+        codename=$(grep -m1 '^VERSION_CODENAME=' "$osrelease" 2>/dev/null | cut -d= -f2- | tr -d "\"'")
     fi
 
     if [[ -z "$codename" ]]; then

--- a/setup/modules/validation.sh
+++ b/setup/modules/validation.sh
@@ -81,7 +81,8 @@ _validate_debian_version() {
 
     if [[ -n "$osrelease" ]]; then
         # grep-basiert statt source – Defense-in-Depth (keine Code-Ausführung)
-        codename=$(grep -m1 '^VERSION_CODENAME=' "$osrelease" 2>/dev/null | cut -d= -f2- | tr -d "\"'")
+        # { grep || true; } verhindert Abbruch unter pipefail bei fehlendem Key
+        codename=$({ grep -m1 '^VERSION_CODENAME=' "$osrelease" 2>/dev/null || true; } | cut -d= -f2- | tr -d "\"'")
     fi
 
     if [[ -z "$codename" ]]; then

--- a/terminal/.config/platform.zsh
+++ b/terminal/.config/platform.zsh
@@ -65,11 +65,10 @@ if [[ -z "${_PLATFORM_DISTRO+x}" ]]; then
             [[ -z "$_osrelease" && -f /usr/lib/os-release ]] && _osrelease="/usr/lib/os-release"
 
             if [[ -n "$_osrelease" ]]; then
-                local _distro_id _distro_id_like _distro_info
-                # Einmal sourcen, beide Werte in einer Subshell lesen
-                _distro_info=$(. "$_osrelease" 2>/dev/null && printf '%s\n%s' "$ID" "${ID_LIKE:-}")
-                _distro_id="${_distro_info%%$'\n'*}"
-                _distro_id_like="${_distro_info#*$'\n'}"
+                local _distro_id _distro_id_like
+                # grep-basiert statt source – Defense-in-Depth (keine Code-Ausführung)
+                _distro_id=$(grep -m1 '^ID=' "$_osrelease" 2>/dev/null | cut -d= -f2- | tr -d "\"'")
+                _distro_id_like=$(grep -m1 '^ID_LIKE=' "$_osrelease" 2>/dev/null | cut -d= -f2- | tr -d "\"'")
                 case "$_distro_id" in
                     fedora)                  _PLATFORM_DISTRO="fedora" ;;
                     debian|ubuntu|raspbian)  _PLATFORM_DISTRO="debian" ;;


### PR DESCRIPTION
## Beschreibung

Ersetzt `. /etc/os-release` (dot-source) durch grep-basiertes Parsing in allen drei betroffenen Dateien. Defense-in-Depth: Systemdateien werden nicht mehr als Shell-Code ausgeführt.

Das tatsächliche Risiko ist gering (`/etc/os-release` ist root-owned, Sourcen erfolgte in Subshells), aber grep-basiertes Parsing ist robuster und vermeidet die Ausführung von Fremdcode grundsätzlich.

### Betroffene Dateien

| Datei | Gelesene Keys |
|-------|---------------|
| `terminal/.config/platform.zsh` | `ID`, `ID_LIKE` |
| `setup/install.sh` | `ID`, `ID_LIKE` |
| `setup/modules/validation.sh` | `VERSION_CODENAME` |

### Parsing-Pattern

```sh
grep -m1 '^KEY=' "$osrelease" 2>/dev/null | cut -d= -f2- | tr -d "\"'"
```

- `^KEY=` — Anker verhindert False Positives (`PLATFORM_ID` matcht nicht `^ID=`)
- `cut -d= -f2-` — robust bei Werten mit `=` (URLs)
- `tr -d "\"'"` — entfernt beide Quoting-Varianten gemäß freedesktop-Spec
- `2>/dev/null` — konsistent auf allen 3 Stellen, defensiv bei Lesefehlern

### pipefail-Safety in validation.sh

`validation.sh` wird via `bootstrap.sh` unter `set -euo pipefail` ausgeführt. Ein fehlender Key (z.B. `VERSION_CODENAME` nicht in der Datei) führt zu grep Exit 1, was unter pipefail die Pipeline abbrechen lässt — der Fallback-Code mit Warnung würde nie erreicht. Fix: `{ grep ... || true; }` fängt den Exit-Code ab.

## Art der Änderung

- [x] ♻️ Refactoring
- [x] 🔒 Security

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare (falls zutreffend)
- [x] Bei neuen Tools: Guard-Check vorhanden (falls zutreffend)
- [x] Screenshots in `docs/assets/` noch aktuell (falls zutreffend)

## Zusammenhängende Issues

Closes #416
