### PR TITLE
fix(health-check): typeset-Redeklaration in Font-Schleife beheben

### DIFF
--- a/.github/scripts/health-check.sh
+++ b/.github/scripts/health-check.sh
@@ -369,10 +369,10 @@ section "Nerd Font"
 typeset -a font_casks=($(grep -E '^cask "font-' "$BREWFILE" 2>/dev/null | sed 's/cask "\([^"]*\)".*/\1/'))
 
 if (( ${#font_casks[@]} > 0 )); then
+  typeset font_pattern
   for font_cask in "${font_casks[@]}"; do
     # Konvertiere cask-name zu Font-Dateiname-Pattern
     # z.B. font-meslo-lg-nerd-font → MesloLG*NerdFont*
-    typeset font_pattern
     case "$font_cask" in
       font-meslo-lg-nerd-font)
         font_pattern="MesloLG*NerdFont*"


### PR DESCRIPTION
## Beschreibung

`typeset font_pattern` (ohne Zuweisung) stand innerhalb der `for`-Schleife der Font-Prüfung. ZSH gibt bei `typeset var` in Folge-Iterationen den vorherigen Wert als Debug-Output aus:

```
font_pattern='JetBrainsMono*NerdFont*'
```

Fix: `typeset font_pattern` **vor** die Schleife verschoben (einmalige Deklaration). Innerhalb der Schleife wird nur noch zugewiesen.

## Art der Änderung

- [x] 🐛 Bugfix

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler

## Zusammenhängende Issues

Closes #414

## Terminal-Ausgabe

**Vorher:**
```
$ ./.github/scripts/health-check.sh 2>&1 | grep font_pattern
font_pattern='JetBrainsMono*NerdFont*'
```

**Nachher:**
```
$ ./.github/scripts/health-check.sh 2>&1 | grep font_pattern
(kein Output — Exit 1)
```

Font-Erkennung weiterhin intakt:
```
✔ font-jetbrains-mono-nerd-font installiert (96 Dateien)
✔ font-meslo-lg-nerd-font installiert (72 Dateien)
```