### PR TITLE
feat(generate-docs): Diff-Ausgabe bei --check für veraltete Dateien

### DIFF
--- a/.github/scripts/generate-docs.sh
+++ b/.github/scripts/generate-docs.sh
@@ -57,9 +57,9 @@ check_all() {
 
     # README.md
     local generated=$(run_generator "readme.sh" "generate_readme_md")
-    if ! compare_content "$DOTFILES_DIR/README.md" "$generated"; then
+    if ! diff -q "$DOTFILES_DIR/README.md" <(printf '%s\n' "$generated") >/dev/null 2>&1; then
         err "README.md ist veraltet"
-        diff -u "$DOTFILES_DIR/README.md" <(printf '%s\n' "$generated") | head -30 || true
+        diff -u --label "README.md (aktuell)" --label "README.md (generiert)" "$DOTFILES_DIR/README.md" <(printf '%s\n' "$generated") | head -30 || true
         (( errors++ )) || true
     else
         ok "README.md ist aktuell"
@@ -67,9 +67,9 @@ check_all() {
 
     # docs/setup.md
     generated=$(run_generator "setup.sh" "generate_setup_md")
-    if ! compare_content "$DOCS_DIR/setup.md" "$generated"; then
+    if ! diff -q "$DOCS_DIR/setup.md" <(printf '%s\n' "$generated") >/dev/null 2>&1; then
         err "docs/setup.md ist veraltet"
-        diff -u "$DOCS_DIR/setup.md" <(printf '%s\n' "$generated") | head -30 || true
+        diff -u --label "docs/setup.md (aktuell)" --label "docs/setup.md (generiert)" "$DOCS_DIR/setup.md" <(printf '%s\n' "$generated") | head -30 || true
         (( errors++ )) || true
     else
         ok "docs/setup.md ist aktuell"
@@ -77,9 +77,9 @@ check_all() {
 
     # docs/customization.md
     generated=$(run_generator "customization.sh" "generate_customization_md")
-    if ! compare_content "$DOCS_DIR/customization.md" "$generated"; then
+    if ! diff -q "$DOCS_DIR/customization.md" <(printf '%s\n' "$generated") >/dev/null 2>&1; then
         err "docs/customization.md ist veraltet"
-        diff -u "$DOCS_DIR/customization.md" <(printf '%s\n' "$generated") | head -30 || true
+        diff -u --label "docs/customization.md (aktuell)" --label "docs/customization.md (generiert)" "$DOCS_DIR/customization.md" <(printf '%s\n' "$generated") | head -30 || true
         (( errors++ )) || true
     else
         ok "docs/customization.md ist aktuell"
@@ -87,9 +87,9 @@ check_all() {
 
     # CONTRIBUTING.md (manuell gepflegt, nur ToC wird generiert)
     generated=$(run_generator "contributing.sh" "generate_contributing_md")
-    if ! compare_content "$DOTFILES_DIR/CONTRIBUTING.md" "$generated"; then
+    if ! diff -q "$DOTFILES_DIR/CONTRIBUTING.md" <(printf '%s\n' "$generated") >/dev/null 2>&1; then
         err "CONTRIBUTING.md ist veraltet"
-        diff -u "$DOTFILES_DIR/CONTRIBUTING.md" <(printf '%s\n' "$generated") | head -30 || true
+        diff -u --label "CONTRIBUTING.md (aktuell)" --label "CONTRIBUTING.md (generiert)" "$DOTFILES_DIR/CONTRIBUTING.md" <(printf '%s\n' "$generated") | head -30 || true
         (( errors++ )) || true
     else
         ok "CONTRIBUTING.md ist aktuell"

--- a/.github/scripts/generate-docs.sh
+++ b/.github/scripts/generate-docs.sh
@@ -59,6 +59,7 @@ check_all() {
     local generated=$(run_generator "readme.sh" "generate_readme_md")
     if ! compare_content "$DOTFILES_DIR/README.md" "$generated"; then
         err "README.md ist veraltet"
+        diff -u "$DOTFILES_DIR/README.md" <(printf '%s\n' "$generated") | head -30 || true
         (( errors++ )) || true
     else
         ok "README.md ist aktuell"
@@ -68,6 +69,7 @@ check_all() {
     generated=$(run_generator "setup.sh" "generate_setup_md")
     if ! compare_content "$DOCS_DIR/setup.md" "$generated"; then
         err "docs/setup.md ist veraltet"
+        diff -u "$DOCS_DIR/setup.md" <(printf '%s\n' "$generated") | head -30 || true
         (( errors++ )) || true
     else
         ok "docs/setup.md ist aktuell"
@@ -77,6 +79,7 @@ check_all() {
     generated=$(run_generator "customization.sh" "generate_customization_md")
     if ! compare_content "$DOCS_DIR/customization.md" "$generated"; then
         err "docs/customization.md ist veraltet"
+        diff -u "$DOCS_DIR/customization.md" <(printf '%s\n' "$generated") | head -30 || true
         (( errors++ )) || true
     else
         ok "docs/customization.md ist aktuell"
@@ -86,6 +89,7 @@ check_all() {
     generated=$(run_generator "contributing.sh" "generate_contributing_md")
     if ! compare_content "$DOTFILES_DIR/CONTRIBUTING.md" "$generated"; then
         err "CONTRIBUTING.md ist veraltet"
+        diff -u "$DOTFILES_DIR/CONTRIBUTING.md" <(printf '%s\n' "$generated") | head -30 || true
         (( errors++ )) || true
     else
         ok "CONTRIBUTING.md ist aktuell"

--- a/.github/scripts/tests/test-generate-docs-integration.sh
+++ b/.github/scripts/tests/test-generate-docs-integration.sh
@@ -79,6 +79,9 @@ check_exit=$?
 assert_equals "--check erkennt veraltete README.md (Exit 1)" "1" "$check_exit"
 assert_contains "--check meldet README.md veraltet" "README.md" "$output"
 assert_contains "--check meldet veraltet" "veraltet" "$output"
+assert_contains "--check zeigt Diff-Header (---)" "---" "$output"
+assert_contains "--check zeigt Diff-Header (+++)" "+++" "$output"
+assert_contains "--check zeigt Diff mit Label" "aktuell" "$output"
 
 # Original wiederherstellen
 cp "$_TEST_TMPDIR/README.md.bak" "$DOTFILES_DIR/README.md"


### PR DESCRIPTION
## Beschreibung

`generate-docs.sh --check` meldet bisher nur "ist veraltet" — ohne zu zeigen, welche Zeilen abweichen. In CI-Logs fehlt damit der Kontext komplett.

Jetzt wird bei jeder veralteten Datei ein kompakter `diff -u` ausgegeben (max 30 Zeilen), z.B.:

```
✖ README.md ist veraltet
--- README.md (aktuell)
+++ README.md (generiert)
@@ -162,4 +162,3 @@
 ## Lizenz

 [MIT](LICENSE)
-# TEST-ÄNDERUNG
```

### Änderungen

1. **Diff-Ausgabe bei `--check`** — Betrifft alle 4 Datei-Prüfungen: README.md, docs/setup.md, docs/customization.md, CONTRIBUTING.md
2. **Byte-exakter Vergleich** — `compare_content` (String-Vergleich via `$(cat ...)`) durch `diff -q` ersetzt. `$(cat ...)` strippt Trailing-Newlines auf beiden Seiten, was bei Extra-Leerzeilen am Dateiende zu false negatives führte.
3. **Relative Dateinamen** — `--label` statt absolute Pfade im Diff-Header (vermeidet `/Users/<name>/...` in öffentlichen CI-Logs)
4. **Integrationstest erweitert** — 3 neue Assertions: Diff-Header (`---`, `+++`) und Label-Ausgabe

## Art der Änderung

- [x] ✨ Neues Feature

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler

## Zusammenhängende Issues

Closes #418

## Terminal-Ausgabe

**Happy Path (alles aktuell):**
```
✔ README.md ist aktuell
✔ docs/setup.md ist aktuell
✔ docs/customization.md ist aktuell
✔ CONTRIBUTING.md ist aktuell
```

**Fehlerfall (Datei veraltet):**
```
✖ docs/customization.md ist veraltet
--- docs/customization.md (aktuell)
+++ docs/customization.md (generiert)
@@ -2,7 +2,7 @@
-__GEÄNDERT__
+## Inhalt
```

**Trailing-Newline Edge Case (vorher false negative):**
```
✖ README.md ist veraltet
--- README.md (aktuell)
+++ README.md (generiert)
@@ -162,6 +162,3 @@
 [MIT](LICENSE)
-
-
-
```

**head -30 Begrenzung:** Output wird bei großen Diffs nach 30 Zeilen abgeschnitten.