### PR TITLE
feat(starship): Swift-Modul hinzufügen

### DIFF
--- a/terminal/.config/starship/starship.toml
+++ b/terminal/.config/starship/starship.toml
@@ -27,6 +27,7 @@ $java\
 $kotlin\
 $haskell\
 $python\
+$swift\
 [](fg:green bg:sapphire)\
 $docker_context\
 $conda\
@@ -137,6 +138,11 @@ format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 symbol = ""
 style = "bg:green"
 format = '[[ $symbol( $version)(\(#$virtualenv\)) ](fg:crust bg:green)]($style)'
+
+[swift]
+symbol = ""
+style = "bg:green"
+format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 
 [docker_context]
 symbol = ""

--- a/terminal/.config/tealdeer/pages/starship.patch.md
+++ b/terminal/.config/tealdeer/pages/starship.patch.md
@@ -4,7 +4,7 @@
 
 - dotfiles: Prompt-Module: `os, username, directory, git_branch, git_status, time, line_break, character, cmd_duration`
 
-- dotfiles: Sprach-Module: `nodejs, c, rust, golang, php, java, kotlin, haskell, python`
+- dotfiles: Sprach-Module: `nodejs, c, rust, golang, php, java, kotlin, haskell, python, swift`
 
 - dotfiles: Infra-Module: `docker_context, conda`
 


### PR DESCRIPTION
## Beschreibung

Swift-Modul (`$swift`) zum Starship Powerline-Prompt hinzugefügt.

- Nerd Font Symbol `` (U+E755, nf-dev-swift)
- Gleicher Stil wie alle Sprach-Module: `bg:green fg:crust`
- Position im format-String: nach `$python`, vor dem Sapphire-Segment
- Aktiviert sich automatisch bei `.swift`-Dateien oder `Package.swift`

**Performance:**
- In Swift-Projekten: ~59ms (Swift-Version-Abfrage)
- In Nicht-Swift-Verzeichnissen: 0ms (kein Impact)
- Baseline im dotfiles-Repo: ~14ms (unverändert)

Entscheidung aus #312: Nur das Swift-Modul hinzufügen.

## Art der Änderung

- [x] 🔧 Konfiguration

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler (129/129)
- [ ] ~~Neue Aliase/Funktionen haben Beschreibungskommentare~~ (nicht zutreffend)
- [ ] ~~Bei neuen Tools: Guard-Check vorhanden~~ (nicht zutreffend)
- [ ] ~~Screenshots in `docs/assets/` noch aktuell~~ (nicht zutreffend)

## Zusammenhängende Issues

Closes #312

## Terminal-Ausgabe

Prompt in Swift-Projekt (`Package.swift` + `.swift`):
```
󰀵 sebastian /tmp/swift-test   v25.9.0   v6.3   21:27  ❯
```

Timings (`starship timings`):
```
swift      -  59ms  -   "  v6.3 "
nodejs     -  47ms  -   "  v25.9.0 "
directory  -  <1ms  -   " /tmp/swift-test "
os         -  <1ms  -   "󰀵"
time       -  <1ms  -   "  21:27 "
username   -  <1ms  -   " sebastian"
```