### PR TITLE
fix(generators): Datei-Guards in Parser-Funktionen ergänzen

### DIFF
--- a/.github/scripts/generators/common/parsers.sh
+++ b/.github/scripts/generators/common/parsers.sh
@@ -23,6 +23,8 @@ parse_header_field() {
     local value=""
     local in_field=false
 
+    [[ -f "$file" ]] || return 0
+
     while IFS= read -r line; do
         # Header endet bei Guard oder ====== Abschluss nach gefundenem Feld
         [[ "$line" == "# Guard"* ]] && break
@@ -195,6 +197,8 @@ extract_usage_codeblock() {
     local current_section=""
     local in_header=true
     local first_section=true
+
+    [[ -f "$file" ]] || return 0
 
     while IFS= read -r line; do
         local trimmed="${line#"${line%%[![:space:]]*}"}"

--- a/.github/scripts/generators/tldr/parsers.sh
+++ b/.github/scripts/generators/tldr/parsers.sh
@@ -119,6 +119,8 @@ parse_config_file_header() {
     local config_file="$1"
     local -A header_fields=()
 
+    [[ -f "$config_file" ]] || return 0
+
     # Header-Felder extrahieren (bis Guard oder leere Zeile nach Header)
     local in_header=false
     local header_ended=false

--- a/.github/scripts/tests/test-common-parsers.sh
+++ b/.github/scripts/tests/test-common-parsers.sh
@@ -138,7 +138,9 @@ assert_empty "Nichtexistentes Feld" "$result"
 
 # Nichtexistente Datei
 result=$(parse_header_field "$_TEST_TMPDIR/nonexistent.alias" "Zweck" 2>&1)
+local exit_code=$?
 assert_empty "Nichtexistente Datei" "$result"
+assert_equals "Nichtexistente Datei Exit-Code" "0" "$exit_code"
 
 # Mehrzeilige Fortsetzung (Einrückung nach Feldname)
 cat > "$_TEST_TMPDIR/multi.alias" << 'FIXTURE'
@@ -217,7 +219,9 @@ assert_empty "Leere Datei liefert leeren Codeblock" "$result"
 
 # Nichtexistente Datei
 result=$(extract_usage_codeblock "$_TEST_TMPDIR/nonexistent.alias" 2>&1)
+local exit_code=$?
 assert_empty "Nichtexistente Datei liefert leeren Codeblock" "$result"
+assert_equals "Nichtexistente Datei Codeblock Exit-Code" "0" "$exit_code"
 
 # ============================================================
 # Zusammenfassung

--- a/.github/scripts/tests/test-common-parsers.sh
+++ b/.github/scripts/tests/test-common-parsers.sh
@@ -136,6 +136,10 @@ assert_equals "Strich als Wert" "-" "$result"
 result=$(parse_header_field "$_TEST_TMPDIR/basic.alias" "Gibtsnet")
 assert_empty "Nichtexistentes Feld" "$result"
 
+# Nichtexistente Datei
+result=$(parse_header_field "$_TEST_TMPDIR/nonexistent.alias" "Zweck" 2>&1)
+assert_empty "Nichtexistente Datei" "$result"
+
 # Mehrzeilige Fortsetzung (Einrückung nach Feldname)
 cat > "$_TEST_TMPDIR/multi.alias" << 'FIXTURE'
 # ============================================================
@@ -210,6 +214,10 @@ FIXTURE
 
 result=$(extract_usage_codeblock "$_TEST_TMPDIR/empty.alias")
 assert_empty "Leere Datei liefert leeren Codeblock" "$result"
+
+# Nichtexistente Datei
+result=$(extract_usage_codeblock "$_TEST_TMPDIR/nonexistent.alias" 2>&1)
+assert_empty "Nichtexistente Datei liefert leeren Codeblock" "$result"
 
 # ============================================================
 # Zusammenfassung

--- a/.github/scripts/tests/test-tldr-parsers.sh
+++ b/.github/scripts/tests/test-tldr-parsers.sh
@@ -224,7 +224,9 @@ assert_equals "4 Header-Felder" "4" "$field_count"
 
 # Nichtexistente Datei
 result=$(parse_config_file_header "$_TEST_TMPDIR/nonexistent.conf" 2>&1)
+local exit_code=$?
 assert_empty "Nichtexistente Config-Datei" "$result"
+assert_equals "Nichtexistente Config-Datei Exit-Code" "0" "$exit_code"
 
 # ============================================================
 # parse_fzf_config_keybindings()

--- a/.github/scripts/tests/test-tldr-parsers.sh
+++ b/.github/scripts/tests/test-tldr-parsers.sh
@@ -222,6 +222,10 @@ local field_count
 field_count=$(echo "$result" | grep -c "|" || true)
 assert_equals "4 Header-Felder" "4" "$field_count"
 
+# Nichtexistente Datei
+result=$(parse_config_file_header "$_TEST_TMPDIR/nonexistent.conf" 2>&1)
+assert_empty "Nichtexistente Config-Datei" "$result"
+
 # ============================================================
 # parse_fzf_config_keybindings()
 # ============================================================


### PR DESCRIPTION
## Beschreibung

Drei Parser-Funktionen hatten keinen Guard für fehlende Dateien. `while ... done < "$file"` bei nicht-existenter Datei erzeugte einen unkontrollierten ZSH-Fehler auf stderr (Exit 0, aber Fehlermeldung).

`[[ -f "$file" ]] || return 0` ergänzt in:

- `parse_header_field()` — `common/parsers.sh`
- `extract_usage_codeblock()` — `common/parsers.sh`
- `parse_config_file_header()` — `tldr/parsers.sh`

Pattern analog zu `parse_yazi_keymap()`, das den Guard bereits hatte.

Tests für das neue Guard-Verhalten (nicht-existente Datei → leere Ausgabe, kein stderr) in `test-common-parsers.sh` und `test-tldr-parsers.sh` ergänzt.

## Art der Änderung

- [x] 🐛 Bugfix

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [ ] ~~Neue Aliase/Funktionen haben Beschreibungskommentare~~ (nicht zutreffend)
- [ ] ~~Bei neuen Tools: Guard-Check vorhanden~~ (nicht zutreffend)
- [ ] ~~Screenshots in `docs/assets/` noch aktuell~~ (nicht zutreffend)

## Zusammenhängende Issues

Closes #428

## Terminal-Ausgabe

**Vorher:**
```
$ result=$(parse_header_field "/nonexistent" "Zweck" 2>&1)
$ echo "Exit: $?, Output: '$result'"
Exit: 0, Output: 'parse_header_field:6: no such file or directory: /nonexistent'
```

**Nachher:**
```
Exit: 0, Output: ''
```