### PR TITLE
fix(generators): Alias-Namen vor Regex-Interpolation validieren

### DIFF
--- a/.github/scripts/generators/readme.sh
+++ b/.github/scripts/generators/readme.sh
@@ -56,6 +56,8 @@ extract_fzf_functions() {
 
     for name in "${names[@]}"; do
         [[ -z "$name" ]] && continue
+        # Alias-Namen: nur Alphanumerisch, Unterstriche, Bindestriche (CONTRIBUTING.md)
+        [[ "$name" =~ ^[a-zA-Z0-9_-]+$ ]] || continue
         # Nur Funktionen mit () { im Code
         if grep -q "^[[:space:]]*${name}() {" "$alias_file" 2>/dev/null; then
             if [[ "$is_fzf_file" == "1" ]]; then


### PR DESCRIPTION
## Beschreibung

In `extract_fzf_functions()` (readme.sh) wird `$name` aus dem Aliase-Header ungefiltert in grep-BRE und awk-ERE interpoliert. Statt die Regex-Patterns zu escapen (unvollständig, wartungsintensiv) oder auf `grep -F` umzusteigen (verliert Anker), validiert ein Guard den Alias-Namen gegen die CONTRIBUTING.md-Konvention `[a-zA-Z0-9_-]` — schützt beide Stellen gleichzeitig mit einer Zeile.

## Art der Änderung

- [x] 🐛 Bugfix

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare (falls zutreffend)
- [x] Bei neuen Tools: Guard-Check vorhanden (falls zutreffend)
- [x] Screenshots in `docs/assets/` noch aktuell (falls zutreffend)

## Zusammenhängende Issues

Closes #426

## Terminal-Ausgabe

```
# Guard-Validierung
SKIP: foo.bar     # Punkt → Regex-Metazeichen
PASS: normal-func # Gültiger Name
SKIP: test+evil   # Plus → Regex-Metazeichen
PASS: bat-theme   # Bindestrich erlaubt

# Tests: 116 bestanden, 0 fehlgeschlagen
# Doku-Check: ✔ Alle Dokumentation ist aktuell
```