### PR TITLE
feat(copilot): Progressive Disclosure mit .instructions.md und Agent Skills

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,6 +34,7 @@
 | **Niemals Annahmen** | Erst recherchieren, dann handeln |
 | **Niemals nackte Linter** | Immer Projekt-Config verwenden, nie `npx tool datei` ohne `--config` |
 | **Niemals `/Users/<name>`** | Öffentlich sichtbar → `~` oder `$HOME` |
+| **Keine Offensichtlichkeits-Kommentare** | Header-Block und Beschreibungskommentare sind Pflicht (Generator-Input) — aber `# Setze Variable` über einer Zuweisung ist Rauschen |
 | **ZSH ist die Ziel-Shell** | POSIX sh nur in `setup/install.sh` und `setup/lib/logging.sh` (weil zsh auf frischen Linux-Systemen fehlen kann) |
 
 ---
@@ -55,6 +56,8 @@
 **Einstiegspunkt:** `dothelp` zeigt alle verfügbaren tldr-Seiten mit dotfiles-Erweiterungen.
 
 > **Bereichsspezifische Konventionen** sind in [`.github/instructions/`](instructions/) als `.instructions.md`-Dateien hinterlegt und werden automatisch geladen wenn passende Dateien bearbeitet werden.
+>
+> **Bei Aufgaben ohne offene Datei** (z.B. „prüfe die fzf-Aliase"): Zuerst die relevante Instructions-Datei aus der Verweise-Tabelle lesen, bevor du loslegst.
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,7 +54,7 @@
 
 **Einstiegspunkt:** `dothelp` zeigt alle verfügbaren tldr-Seiten mit dotfiles-Erweiterungen.
 
-> **Bereichsspezifische Konventionen** sind in [`.github/instructions/`](.github/instructions/) als `.instructions.md`-Dateien hinterlegt und werden automatisch geladen wenn passende Dateien bearbeitet werden.
+> **Bereichsspezifische Konventionen** sind in [`.github/instructions/`](instructions/) als `.instructions.md`-Dateien hinterlegt und werden automatisch geladen wenn passende Dateien bearbeitet werden.
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,7 +57,7 @@
 
 > **Bereichsspezifische Konventionen** sind in [`.github/instructions/`](instructions/) als `.instructions.md`-Dateien hinterlegt und werden automatisch geladen wenn passende Dateien bearbeitet werden.
 >
-> **Bei Aufgaben ohne offene Datei** (z.B. „prüfe die fzf-Aliase"): Zuerst die relevante Instructions-Datei aus der Verweise-Tabelle lesen, bevor du loslegst.
+> **Bei Aufgaben ohne offene Datei** (z.B. „prüfe die fzf-Aliase“): Zuerst die relevante Instructions-Datei aus der Verweise-Tabelle lesen, bevor du loslegst.
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,31 +38,6 @@
 
 ---
 
-## ZSH-Fallen
-
-```zsh
-# Arithmetik mit set -e – FALSCH:
-((count++))
-# RICHTIG:
-(( count++ )) || true
-
-# WARUM? Post-Inkrement gibt den ALTEN Wert zurück:
-# count=0 → (( count++ )) evaluiert zu 0 → Exit-Code 1 → set -e bricht ab!
-# Der Trick: || true fängt Exit-Code 1 ab, count wird trotzdem erhöht.
-
-# Bei Vergleichen ist || true NICHT nötig:
-(( count >= max )) && break  # OK – Vergleich gibt true/false
-
-# fzf Preview mit ZSH-Syntax – explizit wrappen:
---preview='zsh -c '\''[[ -f "$1" ]] && cat "$1"'\'' -- {}'
-
-# Regex für Befehle – Bindestriche erlauben:
-[a-z][a-z0-9_-]*   # RICHTIG (findet bat-theme)
-[a-z][a-z0-9_]*    # FALSCH
-```
-
----
-
 ## Architektur
 
 > **Unix-Philosophie:** *"Do One Thing and Do It Well"*
@@ -77,141 +52,17 @@
 | **Modularität** | Ein Tool = Eine `.alias`-Datei |
 | **Bootstrap** | Modulare Schritte in `setup/modules/*.sh` |
 
-### Dokumentation
-
-Doku wird automatisch aus Code generiert (Single Source of Truth):
-
-- `.alias`-Dateien → tldr-Patches/Pages (`.patch.md` oder `.page.md`), README.md (Tool-Ersetzungen)
-- `Brewfile` → `docs/setup.md` (Tool-Listen)
-- `bootstrap.sh` → README.md (macOS-Versionen), `docs/setup.md` (Bootstrap-Schritte)
-- `theme-style` → `docs/customization.md` (Farbpalette), `terminal/.config/tealdeer/pages/catppuccin.page.md`
-
-**tldr-Format:** Der Generator prüft automatisch ob eine offizielle tldr-Seite existiert:
-
-- Offizielle Seite vorhanden → `.patch.md` (erweitert diese)
-- Keine offizielle Seite → `.page.md` (ersetzt diese)
-
-**Niemals Docs manuell editieren** – Änderungen im Code machen.
-
 **Einstiegspunkt:** `dothelp` zeigt alle verfügbaren tldr-Seiten mit dotfiles-Erweiterungen.
 
-### Farben & Theming
-
-**Zentrale Definition:** `terminal/.config/theme-style`
-
-**Bei neuen Tool-Konfigurationen:**
-
-1. **Prüfe Theme-Quellen-Tabelle** in `theme-style` (Zeile 15-42)
-2. **Nutze semantische Farben** aus der Dokumentation in `theme-style`:
-   - Selection Background → Surface1 `#45475A`
-   - Accent/Border → Mauve `#CBA6F7`
-   - Marker → Lavender `#B4BEFE`
-   - Success → Green, Error → Red, Warning → Yellow
-3. **Aktualisiere Status** in Theme-Quellen-Tabelle wenn Tool hinzugefügt wird
-4. **Bevorzuge Upstream-Themes** von [github.com/catppuccin](https://github.com/catppuccin)
-
-In Skripten nutzen:
-
-```zsh
-source "$DOTFILES_DIR/terminal/.config/theme-style"
-# Dann: $C_GREEN, $C_RED, $C_BLUE, etc.
-```
+> **Bereichsspezifische Konventionen** sind in [`.github/instructions/`](.github/instructions/) als `.instructions.md`-Dateien hinterlegt und werden automatisch geladen wenn passende Dateien bearbeitet werden.
 
 ---
 
-## Alias-Dateien
-
-Format für `terminal/.config/alias/*.alias`:
-
-**Regel:** Ein Alias/Funktion gehört in die `.alias`-Datei des Tools, das er **primär** repräsentiert.
-
-- `zj()` → `zoxide.alias` (zoxide-Workflow, fzf nur UI)
-- `procs()` → `fzf.alias` (generische fzf-Funktion)
-
-```zsh
-# ============================================================
-# tool.alias - Beschreibung
-# ============================================================
-# Zweck       : Was macht diese Datei
-# Pfad        : ~/.config/alias/tool.alias
-# Docs        : https://...
-# Config      : ~/.config/tool/config (wenn lokale Config existiert)
-# Nutzt       : fzf, bat (optionale Abhängigkeiten)
-# Ersetzt     : original-cmd (was es ersetzt)
-# Aliase      : cmd1, cmd2
-# ============================================================
-
-# Guard
-if ! command -v tool >/dev/null 2>&1; then return 0; fi
-
-# Beschreibung für cmds/tldr
-alias x='command'
-
-# Funktion(param?) – Enter=Aktion, Ctrl+Y=Kopieren
-func() {
-    # Implementation
-}
-```
-
-**Wichtig:** Funktionen als `name() {` schreiben – nicht `function name`!
-
----
-
-## GitHub PRs
-
-### Merge-Workflow (KRITISCH)
+## GitHub PRs (KRITISCH)
 
 **PRs niemals eigenständig mergen** – immer den User fragen!
 
 **PRs niemals eigenständig erstellen** – immer den User fragen!
-
-**VOR jedem Merge diese Schritte ausführen:**
-
-```zsh
-# 1. CI-Status prüfen
-gh pr checks <nr>
-
-# 2. Auf Copilot-Review WARTEN (erscheint nach ~30-60 Sek)
-gh pr view <nr> --json reviews | jq '.reviews[] | select(.author.login | contains("copilot"))'
-
-# 3. Review-Kommentare LESEN und BEHEBEN
-gh api repos/{owner}/{repo}/pulls/<nr>/reviews
-# oder: mcp_io_github_git_pull_request_read mit method=get_review_comments
-
-# 4. Erst wenn alle Kommentare adressiert sind: Mergen
-```
-
-**Niemals blind mergen** nur weil CI grün ist – Copilot-Reviews enthalten wertvolles Feedback!
-
-### Review-Thread-Handling
-
-| Regel | Begründung |
-| ------- | ------------ |
-| **Review-Threads einzeln beantworten** | Erklärung im Thread dokumentiert, nicht nur global |
-| **Dann erst resolven** | Thread-Historie bleibt nachvollziehbar |
-| **Alle Kommentare prüfen** | `get_review_comments` nicht nur `get_reviews` |
-| **Outdated ≠ Resolved** | Auch veraltete Threads explizit auflösen |
-
-```zsh
-# Review-Threads auflösen via gh CLI:
-gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "PRRT_..."}) { thread { isResolved } } }'
-```
-
-### Issues und PRs erstellen
-
-**Bei Issue-Erstellung:** Templates aus `.github/ISSUE_TEMPLATE/` verwenden:
-
-- `bug_report.md` – für Bugs (inkl. Health-Check Ausgabe)
-- `feature_request.md` – für Feature Requests
-
-**Bei PR-Erstellung:** Template aus `.github/PULL_REQUEST_TEMPLATE.md` verwenden:
-
-- Checkliste durchgehen (generate-docs, health-check)
-- Art der Änderung markieren
-- Zusammenhängende Issues verlinken
-- **Label setzen** (siehe CONTRIBUTING.md)
-
-> 💡 Issue-Labels werden automatisch durch Templates gesetzt. PR-Labels manuell hinzufügen.
 
 ---
 
@@ -224,7 +75,12 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "PRRT_
 | Funktions-Syntax | `CONTRIBUTING.md#funktions-syntax` |
 | Kommentar-Format | `CONTRIBUTING.md#beschreibungskommentar-format-für-fzf-funktionen` |
 | **Labels** | `CONTRIBUTING.md#6-labels-setzen` |
-| Verzeichnisstruktur | GitHub Tree-View oder `eza --tree` |
+| Alias-Konventionen | `.github/instructions/alias-conventions.instructions.md` |
+| ZSH Shell-Konventionen | `.github/instructions/shell-zsh.instructions.md` |
+| Theming | `.github/instructions/theming.instructions.md` |
+| Setup-Module | `.github/instructions/setup-modules.instructions.md` |
+| GitHub Workflow | `.github/instructions/github-workflow.instructions.md` |
+| Generatoren | `.github/instructions/generators.instructions.md` |
 | PR-Template | `.github/PULL_REQUEST_TEMPLATE.md` |
 | Issue-Templates | `.github/ISSUE_TEMPLATE/` |
 | Installierte Tools | `setup/Brewfile` |

--- a/.github/instructions/alias-conventions.instructions.md
+++ b/.github/instructions/alias-conventions.instructions.md
@@ -28,8 +28,10 @@ Ein Alias/Funktion gehört in die `.alias`-Datei des Tools, das er **primär** r
 # Aliase      : cmd1, cmd2
 # ============================================================
 
-# Guard
-if ! command -v tool >/dev/null 2>&1; then return 0; fi
+# Guard   : Nur wenn tool installiert ist
+if ! command -v tool >/dev/null 2>&1; then
+    return 0
+fi
 
 # Beschreibung für cmds/tldr
 alias x='command'
@@ -44,7 +46,7 @@ func() {
 
 - Funktionen als `name() {` schreiben – **nicht** `function name` oder `function name()`
 - Private Funktionen mit `_` Präfix (werden von Validatoren ignoriert)
-- Guard-Check am Anfang: `if ! command -v tool >/dev/null 2>&1; then return 0; fi`
+- Guard-Check am Anfang: Mehrzeilig mit `# Guard :` Kommentar (siehe Template oben)
 - **Jede Funktion und jeder Alias** braucht einen Beschreibungskommentar direkt darüber
 - `# Config :` ist Pflicht wenn das Tool eine lokale Config hat
 - Header-Felder auf 12 Zeichen padden, dann Leerzeichen + `:`

--- a/.github/instructions/alias-conventions.instructions.md
+++ b/.github/instructions/alias-conventions.instructions.md
@@ -46,9 +46,9 @@ func() {
 
 - Funktionen als `name() {` schreiben – **nicht** `function name` oder `function name()`
 - Private Funktionen mit `_` Präfix (werden von Validatoren ignoriert)
-- Guard-Check am Anfang: Mehrzeilig mit `# Guard :` Kommentar (siehe Template oben)
+- Guard-Check am Anfang: Mehrzeilig mit `# Guard   :` Kommentar (siehe Template oben)
 - **Jede Funktion und jeder Alias** braucht einen Beschreibungskommentar direkt darüber
-- `# Config :` ist Pflicht wenn das Tool eine lokale Config hat
+- `# Config      :` ist Pflicht wenn das Tool eine lokale Config hat
 - Header-Felder auf 12 Zeichen padden, dann Leerzeichen + `:`
 
 ## Namenskonvention

--- a/.github/instructions/alias-conventions.instructions.md
+++ b/.github/instructions/alias-conventions.instructions.md
@@ -1,0 +1,84 @@
+---
+name: 'Alias-Konventionen'
+description: 'Header-Format, Guard-Pattern, Funktions-Syntax und Zuordnungsregeln für .alias-Dateien'
+applyTo: 'terminal/.config/alias/*.alias'
+---
+
+# Alias-Datei Konventionen
+
+## Zuordnungsregel
+
+Ein Alias/Funktion gehört in die `.alias`-Datei des Tools, das er **primär** repräsentiert:
+
+- `zj()` → `zoxide.alias` (zoxide-Workflow, fzf nur UI)
+- `procs()` → `fzf.alias` (generische fzf-Funktion)
+
+## Datei-Struktur
+
+```zsh
+# ============================================================
+# tool.alias - Beschreibung
+# ============================================================
+# Zweck       : Was macht diese Datei
+# Pfad        : ~/.config/alias/tool.alias
+# Docs        : https://...
+# Config      : ~/.config/tool/config (wenn lokale Config existiert)
+# Nutzt       : fzf, bat (optionale Abhängigkeiten)
+# Ersetzt     : original-cmd (was es ersetzt)
+# Aliase      : cmd1, cmd2
+# ============================================================
+
+# Guard
+if ! command -v tool >/dev/null 2>&1; then return 0; fi
+
+# Beschreibung für cmds/tldr
+alias x='command'
+
+# Funktion(param?) – Enter=Aktion, Ctrl+Y=Kopieren
+func() {
+    # Implementation
+}
+```
+
+## Regeln
+
+- Funktionen als `name() {` schreiben – **nicht** `function name` oder `function name()`
+- Private Funktionen mit `_` Präfix (werden von Validatoren ignoriert)
+- Guard-Check am Anfang: `if ! command -v tool >/dev/null 2>&1; then return 0; fi`
+- **Jede Funktion und jeder Alias** braucht einen Beschreibungskommentar direkt darüber
+- `# Config :` ist Pflicht wenn das Tool eine lokale Config hat
+- Header-Felder auf 12 Zeichen padden, dann Leerzeichen + `:`
+
+## Namenskonvention
+
+| Kategorie | Schema | Beispiele |
+| --------- | ------ | --------- |
+| Tool-Wrapper | `<tool>-<aktion>` | `git-log`, `brew-add` |
+| Browser/Interaktiv | Beschreibend | `help`, `cmds`, `procs` |
+| Navigation | Kurze Verben | `go`, `edit`, `zj` |
+| Bewusste Ersetzungen | Original-Name | `cat`, `ls`, `top` |
+
+Bindestriche (`-`) statt Unterstriche. Keine Kollisionen mit System-Befehlen (außer bewusste Ersetzungen).
+
+## fzf-Funktionen – Beschreibungsformat
+
+```text
+# Name(param?) – Key=Aktion, Key=Aktion
+```
+
+- `(param)` = Pflicht, `(param?)` = optional, `(param=default)` = optional mit Default
+- Keybindings: `Enter=Aktion`, `Ctrl+S=Aktion`, durch `,` getrennt
+- Diese Kommentare sind die Single Source of Truth für tldr-Patches
+
+### Keybinding-Sync (header-wrap)
+
+Jede fzf-Funktion hat zwei synchronisierte Quellen:
+
+| Quelle | Format |
+| ------ | ------ |
+| Beschreibungskommentar | `Key=Aktion, Key=Aktion` |
+| header-wrap Argumente | `'Key: Aktion' 'Key: Aktion'` |
+
+Der Aktions-Text muss **exakt** übereinstimmen. Kein `--header=` verwenden – header-wrap übernimmt.
+
+Neue fzf-Funktion: Kommentar schreiben → `--bind "start,resize:transform-header:..."` → `check-header-sync.sh` ausführen.

--- a/.github/instructions/generators.instructions.md
+++ b/.github/instructions/generators.instructions.md
@@ -1,0 +1,43 @@
+---
+name: 'Dokumentations-Generatoren'
+description: 'Single Source of Truth, Generator-Pipeline, was generiert wohin, niemals Docs manuell editieren'
+applyTo: '.github/scripts/generators/**'
+---
+
+# Dokumentations-Generatoren
+
+## Single Source of Truth
+
+Doku wird automatisch aus Code generiert. **Niemals Docs manuell editieren** – Änderungen im Code machen.
+
+## Was generiert wohin
+
+| Quelle | Ziel |
+| ------ | ---- |
+| `.alias`-Dateien | tldr-Patches/Pages (`.patch.md`/`.page.md`), `README.md` (Tool-Ersetzungen) |
+| `Brewfile` | `docs/setup.md` (Tool-Listen) |
+| `bootstrap.sh` + `setup/modules/*.sh` | `docs/setup.md` (Bootstrap-Schritte) |
+| `theme-style` | `docs/customization.md` (Farbpalette), `terminal/.config/tealdeer/pages/catppuccin.page.md` |
+| `CONTRIBUTING.md` | Table of Contents (ToC) |
+
+## Generator-Architektur
+
+Modularisiert in `.github/scripts/generators/`:
+
+- `common/` — Core Utilities (Config, UI, Parser, Bootstrap-Parser)
+- `tldr/` — tldr-Patch-Generierung (Alias-Helper, Patch-Generator, Spezial-Tools)
+- `*.sh` — Individuelle Generatoren (readme.sh, setup.sh, customization.sh, contributing.sh)
+
+## Ausführung
+
+```zsh
+./.github/scripts/generate-docs.sh --generate   # Generieren
+./.github/scripts/generate-docs.sh --check       # Nur prüfen
+```
+
+## tldr-Format
+
+Der Generator prüft automatisch ob eine offizielle tldr-Seite existiert:
+
+- Offizielle Seite vorhanden → `.patch.md` (erweitert diese)
+- Keine offizielle Seite → `.page.md` (ersetzt diese)

--- a/.github/instructions/github-workflow.instructions.md
+++ b/.github/instructions/github-workflow.instructions.md
@@ -24,7 +24,7 @@ gh pr checks <nr>
 gh pr view <nr> --json reviews | jq '.reviews[] | select(.author.login | contains("copilot"))'
 
 # 3. Review-Kommentare LESEN und BEHEBEN
-gh api repos/{owner}/{repo}/pulls/<nr>/reviews
+gh api repos/{owner}/{repo}/pulls/<nr>/comments
 
 # 4. Erst wenn alle Kommentare adressiert sind: Mergen
 ```

--- a/.github/instructions/github-workflow.instructions.md
+++ b/.github/instructions/github-workflow.instructions.md
@@ -40,6 +40,11 @@ gh api repos/{owner}/{repo}/pulls/<nr>/reviews
 | Alle Kommentare prüfen | `get_review_comments` nicht nur `get_reviews` |
 | Outdated ≠ Resolved | Auch veraltete Threads explizit auflösen |
 
+```zsh
+# Review-Threads auflösen via gh CLI:
+gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "PRRT_..."}) { thread { isResolved } } }'
+```
+
 ### Templates
 
 - **Issues:** Templates aus `.github/ISSUE_TEMPLATE/` verwenden (`bug_report.md`, `feature_request.md`)

--- a/.github/instructions/github-workflow.instructions.md
+++ b/.github/instructions/github-workflow.instructions.md
@@ -1,0 +1,50 @@
+---
+name: 'GitHub Workflow'
+description: 'PR/Issue-Handling, Review-Workflow, Merge-Regeln, Templates und Labels'
+applyTo: '.github/**'
+---
+
+# GitHub Workflow
+
+## PRs und Issues
+
+**PRs niemals eigenständig mergen** – immer den User fragen!
+
+**PRs niemals eigenständig erstellen** – immer den User fragen!
+
+### Merge-Workflow
+
+**VOR jedem Merge:**
+
+```zsh
+# 1. CI-Status prüfen
+gh pr checks <nr>
+
+# 2. Auf Copilot-Review WARTEN (erscheint nach ~30-60 Sek)
+gh pr view <nr> --json reviews | jq '.reviews[] | select(.author.login | contains("copilot"))'
+
+# 3. Review-Kommentare LESEN und BEHEBEN
+gh api repos/{owner}/{repo}/pulls/<nr>/reviews
+
+# 4. Erst wenn alle Kommentare adressiert sind: Mergen
+```
+
+**Niemals blind mergen** nur weil CI grün ist!
+
+### Review-Thread-Handling
+
+| Regel | Begründung |
+| ----- | ---------- |
+| Threads einzeln beantworten | Erklärung im Thread dokumentiert |
+| Dann erst resolven | Thread-Historie bleibt nachvollziehbar |
+| Alle Kommentare prüfen | `get_review_comments` nicht nur `get_reviews` |
+| Outdated ≠ Resolved | Auch veraltete Threads explizit auflösen |
+
+### Templates
+
+- **Issues:** Templates aus `.github/ISSUE_TEMPLATE/` verwenden (`bug_report.md`, `feature_request.md`)
+- **PRs:** Template aus `.github/PULL_REQUEST_TEMPLATE.md` verwenden
+  - Checkliste durchgehen (generate-docs, health-check)
+  - Art der Änderung markieren
+  - Issues verlinken mit `Closes #XX` (nur englische Keywords!)
+  - **Label setzen** (siehe `CONTRIBUTING.md#6-labels-setzen`)

--- a/.github/instructions/setup-modules.instructions.md
+++ b/.github/instructions/setup-modules.instructions.md
@@ -31,9 +31,45 @@ Alle Module setzen voraus, dass `_core.sh` geladen ist (gemeinsame stdlib). Logg
 # ============================================================
 # Zweck       : Was macht dieses Modul
 # Pfad        : setup/modules/modulname.sh
+# Benötigt    : _core.sh, stow.sh (wenn Configs verlinkt sein müssen)
+#
+# STEP        : Name | Beschreibung | ✓ Schnell / ⚠️ Netzwerk
 # ============================================================
 
-# Guard: _core.sh muss geladen sein
+# Standalone: Core laden bevor Guard greift
+if [[ "${ZSH_EVAL_CONTEXT}" == "toplevel" ]]; then
+    source "${0:A:h}/_core.sh" || { echo "FEHLER: _core.sh nicht gefunden" >&2; exit 1; }
+fi
+
+# Guard: Core muss geladen sein (fängt source ohne Core ab)
+[[ -z "${_BOOTSTRAP_CORE_LOADED:-}" ]] && {
+    echo "FEHLER: _core.sh muss vor modulname.sh geladen werden" >&2
+    return 1
+}
+```
+
+**Reihenfolge ist kritisch:** Standalone-Check **vor** Guard — sonst bricht der Guard den Standalone-Modus.
+
+## Header-Felder
+
+| Feld | Pflicht | Beschreibung |
+| ---- | ------- | ------------ |
+| `Benötigt` | Ja | Abhängigkeiten (`_core.sh` + weitere Module) |
+| `STEP` | Ja | Name, Beschreibung, Geschwindigkeit — wird vom Generator für `docs/setup.md` gelesen |
+
+## Modul-Registrierung
+
+Neue Module müssen im `MODULES`-Array in `setup/bootstrap.sh` registriert werden. Position beachten — Abhängigkeiten müssen vorher laufen (z.B. `stow` vor `bat`).
+
+## Setup-Funktion
+
+Jedes Modul definiert eine `setup_<name>()`-Funktion und setzt `CURRENT_STEP` für den Error-Handler:
+
+```zsh
+setup_modulname() {
+    CURRENT_STEP="Modulname Setup"
+    # Implementation
+}
 ```
 
 ## Linux-Mapping (BREW_TO_ALT)

--- a/.github/instructions/setup-modules.instructions.md
+++ b/.github/instructions/setup-modules.instructions.md
@@ -17,6 +17,7 @@ Module in `setup/modules/*.sh` können plattformspezifisch sein:
 | `linux:` | Alle Linux-Distros |
 | `fedora:` | Nur Fedora |
 | `debian:` | Nur Debian/Ubuntu |
+| `arch:` | Nur Arch Linux |
 
 ## Core Guard
 
@@ -74,4 +75,4 @@ setup_modulname() {
 
 ## Linux-Mapping (BREW_TO_ALT)
 
-`setup/modules/apt-packages.sh` enthält das `BREW_TO_ALT`-Mapping (Homebrew-Tool → Linux-Paket). Bei neuen Tools in `setup/Brewfile` muss dieses Mapping erweitert werden.
+`setup/modules/apt-packages.sh` enthält das `BREW_TO_ALT`-Mapping (Formula → Installationsmethode). Einträge nutzen Method-Prefixe wie `apt:<pkg>`, `cargo:<crate>`, `npm:<pkg>` oder `skip`. Bei neuen Tools in `setup/Brewfile` muss dieses Mapping erweitert werden.

--- a/.github/instructions/setup-modules.instructions.md
+++ b/.github/instructions/setup-modules.instructions.md
@@ -1,0 +1,41 @@
+---
+name: 'Setup-Module'
+description: 'Konventionen für Bootstrap-Module: Plattform-Prefixes, _core.sh Guard, Modul-Format'
+applyTo: 'setup/modules/*.sh'
+---
+
+# Setup-Module Konventionen
+
+## Plattform-Prefixes
+
+Module in `setup/modules/*.sh` können plattformspezifisch sein:
+
+| Prefix | Gilt für |
+| ------ | -------- |
+| (kein) | Alle Plattformen |
+| `macos:` | Nur macOS |
+| `linux:` | Alle Linux-Distros |
+| `fedora:` | Nur Fedora |
+| `debian:` | Nur Debian/Ubuntu |
+
+## Core Guard
+
+Alle Module setzen voraus, dass `_core.sh` geladen ist (gemeinsame stdlib). Logging wird über `_core.sh` bereitgestellt.
+
+## Modul-Format
+
+```zsh
+#!/usr/bin/env zsh
+# ============================================================
+# modulname.sh - Kurzbeschreibung
+# ============================================================
+# Zweck       : Was macht dieses Modul
+# Pfad        : setup/modules/modulname.sh
+# ============================================================
+
+# Guard: _core.sh muss geladen sein
+```
+
+## Linux-Mapping (BREW_TO_ALT)
+
+`setup/modules/apt-packages.sh` enthält das `BREW_TO_ALT`-Mapping (Homebrew-Tool → Linux-Paket). Bei neuen Tools in `setup/Brewfile` muss dieses Mapping erweitert werden.

--- a/.github/instructions/setup-modules.instructions.md
+++ b/.github/instructions/setup-modules.instructions.md
@@ -75,4 +75,6 @@ setup_modulname() {
 
 ## Linux-Mapping (BREW_TO_ALT)
 
-`setup/modules/apt-packages.sh` enthält das `BREW_TO_ALT`-Mapping (Formula → Installationsmethode). Einträge nutzen Method-Prefixe wie `apt:<pkg>`, `cargo:<crate>`, `npm:<pkg>` oder `skip`. Bei neuen Tools in `setup/Brewfile` muss dieses Mapping erweitert werden.
+Auf **Arch, Fedora und Debian x86_64** installiert Homebrew/Linuxbrew direkt aus dem Brewfile — kein zusätzliches Mapping nötig.
+
+`setup/modules/apt-packages.sh` enthält das `BREW_TO_ALT`-Mapping als **Fallback für Debian ARM** (armv6/armv7, wo Homebrew nicht verfügbar ist). Einträge nutzen Method-Prefixe wie `apt:<pkg>`, `cargo:<crate>`, `npm:<pkg>` oder `skip`. Bei neuen Tools in `setup/Brewfile` sollte dieses Mapping erweitert werden, damit der ARM-Fallback vollständig bleibt.

--- a/.github/instructions/shell-zsh.instructions.md
+++ b/.github/instructions/shell-zsh.instructions.md
@@ -1,0 +1,57 @@
+---
+name: 'ZSH Shell-Konventionen'
+description: 'ZSH-Fallen, Variablen-Quoting, Shell-Syntax und Konventionen für Shell-Skripte'
+applyTo: '**/*.{sh,zsh}'
+---
+
+# ZSH Shell-Konventionen
+
+## ZSH ist die Ziel-Shell
+
+POSIX sh nur in `setup/install.sh` und `setup/lib/logging.sh` (weil zsh auf frischen Linux-Systemen fehlen kann).
+
+## ZSH-Fallen
+
+### Arithmetik mit set -e
+
+```zsh
+# FALSCH – Post-Inkrement gibt den ALTEN Wert zurück:
+((count++))
+# count=0 → (( count++ )) evaluiert zu 0 → Exit-Code 1 → set -e bricht ab!
+
+# RICHTIG:
+(( count++ )) || true
+
+# Bei Vergleichen ist || true NICHT nötig:
+(( count >= max )) && break  # OK – Vergleich gibt true/false
+```
+
+### fzf Preview mit ZSH-Syntax
+
+```zsh
+# Explizit wrappen:
+--preview='zsh -c '\''[[ -f "$1" ]] && cat "$1"'\'' -- {}'
+```
+
+### Regex für Befehle – Bindestriche erlauben
+
+```zsh
+[a-z][a-z0-9_-]*   # RICHTIG (findet bat-theme)
+[a-z][a-z0-9_]*    # FALSCH
+```
+
+## Variablen und Syntax
+
+- **Immer quoten:** `"$var"` statt `$var`
+- **ZSH-Features nutzen:** `[[ ]]`, `${var##pattern}`, Arrays
+- **Niemals `/Users/<name>`** – öffentlich sichtbar → `~` oder `$HOME`
+
+## Logging-Systeme
+
+Drei separate Systeme je nach Kontext:
+
+| Kontext | Shell | Logging |
+| ------- | ----- | ------- |
+| `.github/scripts/` | ZSH | `source "${0:A:h}/lib/log.sh"` → `log()`, `ok()`, `warn()`, `err()` |
+| `setup/install.sh` | POSIX sh | `. "$SCRIPT_DIR/lib/logging.sh"` |
+| `setup/modules/*.sh` | ZSH | Via `_core.sh` bereitgestellt |

--- a/.github/instructions/shell-zsh.instructions.md
+++ b/.github/instructions/shell-zsh.instructions.md
@@ -1,7 +1,7 @@
 ---
 name: 'ZSH Shell-Konventionen'
 description: 'ZSH-Fallen, Variablen-Quoting, Shell-Syntax und Konventionen für Shell-Skripte'
-applyTo: '**/*.{sh,zsh}'
+applyTo: '{**/*.sh,**/*.zsh,**/.zshrc,**/.zshenv,**/.zprofile,**/.zlogin}'
 ---
 
 # ZSH Shell-Konventionen

--- a/.github/instructions/theming.instructions.md
+++ b/.github/instructions/theming.instructions.md
@@ -1,0 +1,47 @@
+---
+name: 'Theming (Catppuccin Mocha)'
+description: 'Catppuccin Mocha Farbpalette, semantische Farben, Theme-Quellen-Tabelle und Upstream-Themes'
+applyTo: '**/theme-style'
+---
+
+# Theming – Catppuccin Mocha
+
+## Zentrale Definition
+
+`terminal/.config/theme-style` ist die zentrale Referenz für alle Farben.
+
+## Semantische Farben
+
+| Verwendung | Farbe | Hex |
+| ---------- | ----- | --- |
+| Selection Background | Surface1 | `#45475A` |
+| Active Border/Accent | Mauve | `#CBA6F7` |
+| Multi-Select Marker | Lavender | `#B4BEFE` |
+| Success/Valid | Green | `#A6E3A1` |
+| Error/Invalid | Red | `#F38BA8` |
+| Warning/Modified | Yellow | `#F9E2AF` |
+| Directory | Mauve | `#CBA6F7` |
+| Symlink/Info | Blue | `#89B4FA` |
+
+## Bei neuen Tool-Konfigurationen
+
+1. **Prüfe** ob ein offizielles Catppuccin-Theme existiert auf [github.com/catppuccin](https://github.com/catppuccin)
+2. **Nutze semantische Farben** konsistent (Tabelle oben)
+3. **Aktualisiere Status** in der Theme-Quellen-Tabelle in `theme-style` (Zeile 13-42)
+4. **Bevorzuge Upstream-Themes** – nur manuell wenn kein offizielles existiert
+
+## Status-Dokumentation
+
+```text
+upstream        = Unverändert aus offiziellem Repo
+upstream+X      = Mit Anpassung (X = was geändert)
+upstream-X      = Mit Entfernung (X = was entfernt)
+manual          = Manuell basierend auf catppuccin.com/palette
+```
+
+## In Skripten nutzen
+
+```zsh
+source "$DOTFILES_DIR/terminal/.config/theme-style"
+# Dann: $C_GREEN, $C_RED, $C_BLUE, etc.
+```

--- a/.github/instructions/theming.instructions.md
+++ b/.github/instructions/theming.instructions.md
@@ -36,7 +36,9 @@ applyTo: '**/theme-style'
 upstream        = Unverändert aus offiziellem Repo
 upstream+X      = Mit Anpassung (X = was geändert)
 upstream-X      = Mit Entfernung (X = was entfernt)
+builtin         = In Tool eingebaut (kein externes Theme nötig)
 manual          = Manuell basierend auf catppuccin.com/palette
+semantics       = Nur semantische Farbzuordnung, kein vollständiges Upstream-Theme
 ```
 
 ## In Skripten nutzen

--- a/.github/instructions/theming.instructions.md
+++ b/.github/instructions/theming.instructions.md
@@ -27,7 +27,7 @@ applyTo: '**/theme-style'
 
 1. **Prüfe** ob ein offizielles Catppuccin-Theme existiert auf [github.com/catppuccin](https://github.com/catppuccin)
 2. **Nutze semantische Farben** konsistent (Tabelle oben)
-3. **Aktualisiere Status** in der Theme-Quellen-Tabelle in `theme-style` (Zeile 13-42)
+3. **Aktualisiere Status** in der Theme-Quellen-Tabelle (Abschnitt „Theme-Quellen“) in `theme-style`
 4. **Bevorzuge Upstream-Themes** – nur manuell wenn kein offizielles existiert
 
 ## Status-Dokumentation

--- a/.github/instructions/theming.instructions.md
+++ b/.github/instructions/theming.instructions.md
@@ -21,7 +21,7 @@ applyTo: '**/theme-style'
 | Error/Invalid | Red | `#F38BA8` |
 | Warning/Modified | Yellow | `#F9E2AF` |
 | Directory | Mauve | `#CBA6F7` |
-| Symlink/Info | Blue | `#89B4FA` |
+| Info/Link | Blue | `#89B4FA` |
 
 ## Bei neuen Tool-Konfigurationen
 

--- a/.github/skills/add-fzf-function/SKILL.md
+++ b/.github/skills/add-fzf-function/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: add-fzf-function
+description: 'Schritt-für-Schritt Workflow um eine neue interaktive fzf-Funktion zu einer .alias-Datei hinzuzufügen: Beschreibungskommentar, header-wrap, Keybinding-Sync und Validierung.'
+argument-hint: '<funktionsname> in <tool>.alias'
+---
+
+# Neue fzf-Funktion hinzufügen
+
+Folge diesen Schritten **in Reihenfolge** um eine fzf-Funktion korrekt zu implementieren.
+
+## Schritt 1: Zuordnung klären
+
+Die Funktion gehört in die `.alias`-Datei des Tools, das sie **primär** repräsentiert:
+
+| Funktion | Datei | Begründung |
+| -------- | ----- | ---------- |
+| `zj()` | `zoxide.alias` | zoxide-Workflow, fzf nur UI |
+| `bat-theme()` | `bat.alias` | bat-spezifisch |
+| `procs()` | `fzf.alias` | generische Funktion ohne Tool-Bindung |
+
+**Faustregel:** Frage „Ohne welches Tool wäre diese Funktion sinnlos?" → Dort gehört sie hin.
+
+## Schritt 2: Beschreibungskommentar schreiben
+
+**Format (Single Source of Truth für tldr-Patches):**
+
+```text
+# Name(param?) – Key=Aktion, Key=Aktion
+```
+
+| Notation | Bedeutung |
+| -------- | --------- |
+| `(param)` | Pflichtparameter |
+| `(param?)` | Optionaler Parameter |
+| `(param=default)` | Optional mit Default |
+
+Keybindings: `Enter=Aktion`, `Ctrl+S=Aktion`, durch `,` getrennt.
+
+**Beispiele:**
+
+```zsh
+# zoxide Browser(suche?) – Enter=Wechseln, Ctrl+D=Eintrag löschen, Ctrl+Y=Pfad kopieren
+# Theme Browser(suche?) – Enter=Theme aktivieren
+# Live-Grep(suche?) – Enter=Datei öffnen, Ctrl+Y=Pfad kopieren
+```
+
+## Schritt 3: Funktion implementieren
+
+**Syntax:** Immer `name() {` — **nicht** `function name` oder `function name()`.
+
+**Template:**
+
+```zsh
+# Beschreibung(param?) – Enter=Aktion, Ctrl+Y=Kopieren
+name() {
+    local query="${1:-}"
+    local selection
+
+    selection=$(some-command | fzf --query="$query" \
+        --preview "$FZF_HELPER_DIR/preview <type> {}" \
+        --bind "ctrl-y:execute-silent($FZF_HELPER_DIR/action copy {})" \
+        --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Aktion' 'Ctrl+Y: Kopieren'")
+
+    [[ -z "$selection" ]] && return 0
+    # Aktion mit $selection
+}
+```
+
+**Regeln:**
+
+- `local query="${1:-}"` für optionalen Suchparameter
+- `[[ -z "$selection" ]] && return 0` für Abbruch-Handling
+- `$FZF_HELPER_DIR` statt hartcodierter Pfade (definiert in `terminal/.config/fzf/init.zsh`)
+- Previews: `$FZF_HELPER_DIR/preview <type> {field}` nutzen
+- Aktionen: `$FZF_HELPER_DIR/action <name> {field}` nutzen
+
+## Schritt 4: header-wrap integrieren
+
+**Kein `--header=`** verwenden — `header-wrap` übernimmt die Header-Generierung mit dynamischem Umbruch.
+
+**Standard-Binding:**
+
+```zsh
+--bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Key: Aktion' 'Key: Aktion'"
+```
+
+**Sonderfälle:**
+
+| Situation | Lösung |
+| --------- | ------ |
+| Anderes `start`-Binding existiert bereits | `start:+transform-header` (additiv) + separates `resize:transform-header` |
+| Pipe-Zeichen im Text | `\|` escapen: `'Enter: Aktion \| Tab: Mehrfach'` |
+
+**Beispiel für additives Binding** (wenn `start` bereits belegt ist wie bei `rg-live`):
+
+```zsh
+--bind "start:+transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Datei öffnen' 'Ctrl+Y: Pfad kopieren'" \
+--bind "resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Datei öffnen' 'Ctrl+Y: Pfad kopieren'"
+```
+
+## Schritt 5: Keybinding-Sync sicherstellen
+
+Zwei Quellen müssen **exakt** übereinstimmen:
+
+| Quelle | Format | Beispiel |
+| ------ | ------ | -------- |
+| Beschreibungskommentar | `Key=Aktion` | `Ctrl+Y=Pfad kopieren` |
+| header-wrap Argumente | `'Key: Aktion'` | `'Ctrl+Y: Pfad kopieren'` |
+
+Der Aktions-Text (nach `=` bzw. `:`) muss **identisch** sein. Nur der Separator (`=` vs `:`) unterscheidet sich.
+
+## Schritt 6: Cross-Platform Abstraktionen
+
+**Immer** diese Wrapper statt nativer Befehle verwenden:
+
+| Statt | Verwende | Definiert in |
+| ----- | -------- | ------------ |
+| `pbcopy` | `clip` | `platform.zsh` |
+| `pbpaste` | `clippaste` | `platform.zsh` |
+| `open` | `xopen` | `platform.zsh` |
+| `sed -i` | `sedi` | `platform.zsh` |
+
+## Schritt 7: Header-Feld `# Aliase :` aktualisieren
+
+In der `.alias`-Datei den Header-Kommentar aktualisieren — die neue Funktion zum `# Aliase :` Feld hinzufügen.
+
+## Schritt 8: Validieren
+
+```zsh
+# Keybinding-Sync prüfen (muss grün sein)
+./.github/scripts/check-header-sync.sh
+
+# Doku generieren (tldr-Patches werden aktualisiert)
+./.github/scripts/generate-docs.sh --generate
+
+# Pre-Commit Checks
+./.github/hooks/pre-commit
+```
+
+## Referenz: Vollständiges Beispiel
+
+```zsh
+# zoxide Browser(suche?) – Enter=Wechseln, Ctrl+D=Eintrag löschen, Ctrl+Y=Pfad kopieren
+zj() {
+    local query="${1:-}"
+    local selection dir
+
+    selection=$(zoxide query -l -s | \
+        fzf -n2.. --query="$query" \
+            --preview "$FZF_HELPER_DIR/preview dir {2..} 2" \
+            --bind "ctrl-d:execute-silent($FZF_HELPER_DIR/action zoxide-remove {2..})+reload(zoxide query -l -s)" \
+            --bind "ctrl-y:execute-silent($FZF_HELPER_DIR/action copy {2..})" \
+            --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Wechseln' 'Ctrl+D: Eintrag löschen' 'Ctrl+Y: Pfad kopieren'")
+
+    [[ -n "$selection" ]] && dir=$(echo "$selection" | awk '{$1=""; print substr($0,2)}') && cd "$dir"
+}
+```
+
+## Checkliste
+
+- [ ] Zuordnung: Funktion ist in der richtigen `.alias`-Datei
+- [ ] Beschreibungskommentar mit `Key=Aktion` Format
+- [ ] `name() {` Syntax (nicht `function name`)
+- [ ] `local query="${1:-}"` für optionalen Suchparameter
+- [ ] `$FZF_HELPER_DIR` statt hartcodierter Pfade
+- [ ] `header-wrap` statt `--header=`
+- [ ] Keybinding-Text exakt synchron (Kommentar ↔ header-wrap)
+- [ ] Cross-Platform: `clip`/`xopen`/`sedi` statt nativer Befehle
+- [ ] `# Aliase :` Header-Feld aktualisiert
+- [ ] `check-header-sync.sh` bestanden
+- [ ] `generate-docs.sh --generate` ausgeführt

--- a/.github/skills/add-fzf-function/SKILL.md
+++ b/.github/skills/add-fzf-function/SKILL.md
@@ -120,9 +120,9 @@ Der Aktions-Text (nach `=` bzw. `:`) muss **identisch** sein. Nur der Separator 
 | `open` | `xopen` | `platform.zsh` |
 | `sed -i` | `sedi` | `platform.zsh` |
 
-## Schritt 7: Header-Feld `# Aliase :` aktualisieren
+## Schritt 7: Header-Feld `# Aliase      :` aktualisieren
 
-In der `.alias`-Datei den Header-Kommentar aktualisieren — die neue Funktion zum `# Aliase :` Feld hinzufügen.
+In der `.alias`-Datei den Header-Kommentar aktualisieren — die neue Funktion zum `# Aliase      :` Feld hinzufügen.
 
 ## Schritt 8: Validieren
 
@@ -166,6 +166,6 @@ zj() {
 - [ ] `header-wrap` statt `--header=`
 - [ ] Keybinding-Text exakt synchron (Kommentar ↔ header-wrap)
 - [ ] Cross-Platform: `clip`/`xopen`/`sedi` statt nativer Befehle
-- [ ] `# Aliase :` Header-Feld aktualisiert
+- [ ] `# Aliase      :` Header-Feld aktualisiert
 - [ ] `check-header-sync.sh` bestanden
 - [ ] `generate-docs.sh --generate` ausgeführt

--- a/.github/skills/add-fzf-function/SKILL.md
+++ b/.github/skills/add-fzf-function/SKILL.md
@@ -18,7 +18,7 @@ Die Funktion gehört in die `.alias`-Datei des Tools, das sie **primär** reprä
 | `bat-theme()` | `bat.alias` | bat-spezifisch |
 | `procs()` | `fzf.alias` | generische Funktion ohne Tool-Bindung |
 
-**Faustregel:** Frage „Ohne welches Tool wäre diese Funktion sinnlos?" → Dort gehört sie hin.
+**Faustregel:** Frage „Ohne welches Tool wäre diese Funktion sinnlos?“ → Dort gehört sie hin.
 
 ## Schritt 2: Beschreibungskommentar schreiben
 

--- a/.github/skills/add-tool/SKILL.md
+++ b/.github/skills/add-tool/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: add-tool
+description: 'Schritt-für-Schritt Workflow um ein neues CLI-Tool zum dotfiles-Repository hinzuzufügen: Brewfile, Linux-Mapping, Alias-Datei, Shell-Init und Doku-Generierung.'
+argument-hint: '<toolname>'
+---
+
+# Neues Tool hinzufügen
+
+Folge diesen Schritten **in Reihenfolge** um ein neues Tool korrekt ins Repository zu integrieren.
+
+## Schritt 1: Brewfile erweitern
+
+Füge das Tool in `setup/Brewfile` ein — in der passenden Sektion (Formulae, Casks, MAS):
+
+```ruby
+brew "toolname"   # Beschreibung | https://docs-url
+```
+
+**Format:** Kommentar mit `# Beschreibung | URL` (wird vom Generator gelesen).
+
+## Schritt 2: Linux-Mapping (BREW_TO_ALT)
+
+Erweitere das `BREW_TO_ALT`-Array in `setup/modules/apt-packages.sh` mit dem Linux-Paketnamen:
+
+```zsh
+[toolname]="toolname"  # oder abweichender Paketname
+```
+
+## Schritt 3: Alias-Datei erstellen
+
+Erstelle `terminal/.config/alias/<tool>.alias` nach diesem Template:
+
+```zsh
+# ============================================================
+# tool.alias - Kurzbeschreibung (max. 50 Zeichen)
+# ============================================================
+# Zweck       : Ausführliche Beschreibung
+# Pfad        : ~/.config/alias/tool.alias
+# Docs        : https://...
+# Config      : ~/.config/tool/config (wenn lokale Config existiert)
+# Nutzt       : - (oder: fzf, bat, etc.)
+# Ersetzt     : - (oder: original-cmd)
+# Aliase      : cmd1, cmd2
+# ============================================================
+
+# Guard   : Nur wenn tool installiert ist
+if ! command -v tool >/dev/null 2>&1; then
+    return 0
+fi
+
+# ------------------------------------------------------------
+# Beschreibung der Sektion
+# ------------------------------------------------------------
+# Beschreibung für cmds/tldr
+alias cmd='tool --flag'
+```
+
+**Regeln:**
+
+- Header-Felder auf 12 Zeichen padden
+- Guard immer als erstes nach dem Header
+- Funktionen als `name() {` — **nicht** `function name`
+- Jeder Alias/Funktion braucht einen Beschreibungskommentar
+
+## Schritt 4: Shell-Init prüfen
+
+Braucht das Tool Shell-Integration (Completions, Prompts, etc.)? Falls ja, füge es in `terminal/.zshrc` ein:
+
+```zsh
+if command -v newtool >/dev/null 2>&1; then
+    eval "$(newtool init zsh)"
+fi
+```
+
+| Tool-Typ | Beispiele | .zshrc nötig? |
+| -------- | --------- | ------------- |
+| Shell-Integration | zoxide, starship, fzf | Ja |
+| Completions | gh, docker | Ja |
+| Nur Aliase | bat, eza, fd | Nein |
+
+**Reihenfolge:** In `.zshrc` werden Tools nach den Alias-Dateien initialisiert.
+
+## Schritt 5: Theming prüfen
+
+Falls das Tool eine Config mit Farben hat:
+
+1. Prüfe ob ein Catppuccin-Theme existiert auf [github.com/catppuccin](https://github.com/catppuccin)
+2. Nutze semantische Farben aus `terminal/.config/theme-style`
+3. Aktualisiere die Theme-Quellen-Tabelle in `theme-style`
+
+## Schritt 6: Doku generieren
+
+```zsh
+./.github/scripts/generate-docs.sh --generate
+```
+
+Dies generiert automatisch tldr-Patches und aktualisiert README + docs.
+
+## Schritt 7: Validieren
+
+```zsh
+# Pre-Commit Checks lokal ausführen
+./.github/hooks/pre-commit
+
+# Health-Check
+./.github/scripts/health-check.sh
+```
+
+## Checkliste
+
+- [ ] Brewfile-Eintrag mit Beschreibung + URL
+- [ ] BREW_TO_ALT Mapping für Linux
+- [ ] `.alias`-Datei mit korrektem Header-Format
+- [ ] Guard-Check am Anfang der `.alias`-Datei
+- [ ] Shell-Init in `.zshrc` (falls nötig)
+- [ ] Catppuccin-Theme geprüft/installiert
+- [ ] `generate-docs.sh --generate` ausgeführt
+- [ ] Pre-Commit Hooks bestanden

--- a/.github/skills/add-tool/SKILL.md
+++ b/.github/skills/add-tool/SKILL.md
@@ -20,10 +20,13 @@ brew "toolname"   # Beschreibung | https://docs-url
 
 ## Schritt 2: Linux-Mapping (BREW_TO_ALT)
 
-Erweitere das `BREW_TO_ALT`-Array in `setup/modules/apt-packages.sh` mit dem Linux-Paketnamen:
+Erweitere das `BREW_TO_ALT`-Array in `setup/modules/apt-packages.sh` mit einer Installationsmethode:
 
 ```zsh
-[toolname]="toolname"  # oder abweichender Paketname
+[toolname]="apt:toolname"        # Standard: Debian/Ubuntu-Paket
+[othertool]="cargo:othertool"    # Falls Installation via cargo erfolgt
+[nodetool]="npm:nodetool"        # Falls Installation via npm erfolgt
+[macos-only-tool]="skip"         # Wenn es unter Linux bewusst übersprungen wird
 ```
 
 ## Schritt 3: Alias-Datei erstellen

--- a/.github/skills/add-tool/SKILL.md
+++ b/.github/skills/add-tool/SKILL.md
@@ -84,9 +84,40 @@ fi
 
 Falls das Tool eine Config mit Farben hat:
 
-1. Prüfe ob ein Catppuccin-Theme existiert auf [github.com/catppuccin](https://github.com/catppuccin)
-2. Nutze semantische Farben aus `terminal/.config/theme-style`
-3. Aktualisiere die Theme-Quellen-Tabelle in `theme-style`
+### 5a: Upstream-Theme suchen
+
+Prüfe ob ein offizielles Theme existiert auf `github.com/catppuccin/<toolname>`. Falls ja:
+
+1. Theme-Datei herunterladen und unter `terminal/.config/<tool>/` ablegen
+2. Header-Block hinzufügen (Zweck, Pfad, Quelle)
+3. Prüfe ob `bg:#1E1E2E` entfernt werden sollte (für transparenten Terminal-Hintergrund)
+4. Akzentfarbe auf **Mauve** (`#CBA6F7`) setzen falls konfigurierbar
+
+### 5b: Semantische Farben anwenden
+
+Falls Anpassungen nötig sind, nutze die Zuweisungen aus `terminal/.config/theme-style`:
+
+| Verwendung | Farbe | Hex |
+| ---------- | ----- | --- |
+| Selection | Surface1 | `#45475A` |
+| Accent | Mauve | `#CBA6F7` |
+| Marker | Lavender | `#B4BEFE` |
+| Success | Green | `#A6E3A1` |
+| Error | Red | `#F38BA8` |
+
+### 5c: Theme-Quellen-Tabelle aktualisieren
+
+In `terminal/.config/theme-style` die Tabelle um einen Eintrag erweitern:
+
+```text
+#   toolname     | ~/.config/tool/theme-file          | github.com/catppuccin/toolname                | upstream+anpassung
+```
+
+Status-Suffixe: `upstream` (unverändert), `+X` (Anpassung), `-X` (Entfernung), `manual` (kein Upstream).
+
+### 5d: Post-Install prüfen
+
+Manche Tools brauchen Cache-Rebuilds nach Theme-Änderungen (z.B. `bat cache --build`). Falls nötig, gehört das in ein Setup-Modul unter `setup/modules/`.
 
 ## Schritt 6: Doku generieren
 

--- a/.github/skills/add-tool/SKILL.md
+++ b/.github/skills/add-tool/SKILL.md
@@ -100,7 +100,7 @@ Prüfe ob ein offizielles Theme existiert auf `github.com/catppuccin/<toolname>`
 
 ### 5b: Semantische Farben anwenden
 
-Falls Anpassungen nötig sind, nutze die Zuweisungen aus `terminal/.config/theme-style`:
+Falls Anpassungen nötig sind, nutze die semantischen Farben aus `terminal/.config/theme-style` (Abschnitt „Semantische Farbzuweisungen"). Die häufigsten:
 
 | Verwendung | Farbe | Hex |
 | ---------- | ----- | --- |
@@ -109,6 +109,11 @@ Falls Anpassungen nötig sind, nutze die Zuweisungen aus `terminal/.config/theme
 | Marker | Lavender | `#B4BEFE` |
 | Success | Green | `#A6E3A1` |
 | Error | Red | `#F38BA8` |
+| Warning | Yellow | `#F9E2AF` |
+| Info/Link | Blue | `#89B4FA` |
+| Directory | Mauve | `#CBA6F7` |
+
+Vollständige Referenz: `theming.instructions.md` → Semantische Farben
 
 ### 5c: Theme-Quellen-Tabelle aktualisieren
 
@@ -122,7 +127,7 @@ Status-Werte: `upstream` (unverändert), `upstream+X` (Anpassung), `upstream-X` 
 
 ### 5d: Post-Install prüfen
 
-Manche Tools brauchen Cache-Rebuilds nach Theme-Änderungen (z.B. `bat cache --build`). Falls nötig, gehört das in ein Setup-Modul unter `setup/modules/`.
+Manche Tools brauchen Cache-Rebuilds nach Theme-Änderungen (z.B. `bat cache --build`). Falls nötig, gehört das in ein Setup-Modul unter `setup/modules/` — und muss im `MODULES`-Array in `setup/bootstrap.sh` registriert werden (Position beachten: Abhängigkeiten vorher).
 
 ## Schritt 6: Doku generieren
 

--- a/.github/skills/add-tool/SKILL.md
+++ b/.github/skills/add-tool/SKILL.md
@@ -100,7 +100,7 @@ Prüfe ob ein offizielles Theme existiert auf `github.com/catppuccin/<toolname>`
 
 ### 5b: Semantische Farben anwenden
 
-Falls Anpassungen nötig sind, nutze die semantischen Farben aus `terminal/.config/theme-style` (Abschnitt „Semantische Farbzuweisungen"). Die häufigsten:
+Falls Anpassungen nötig sind, nutze die semantischen Farben aus `terminal/.config/theme-style` (Abschnitt „Semantische Farbzuweisungen“). Die häufigsten:
 
 | Verwendung | Farbe | Hex |
 | ---------- | ----- | --- |

--- a/.github/skills/add-tool/SKILL.md
+++ b/.github/skills/add-tool/SKILL.md
@@ -20,7 +20,9 @@ brew "toolname"   # Beschreibung | https://docs-url
 
 ## Schritt 2: Linux-Mapping (BREW_TO_ALT)
 
-Erweitere das `BREW_TO_ALT`-Array in `setup/modules/apt-packages.sh` mit einer Installationsmethode:
+Auf **Arch, Fedora und Debian x86_64** reicht das Brewfile — Homebrew/Linuxbrew übernimmt die Installation direkt.
+
+Das `BREW_TO_ALT`-Mapping in `setup/modules/apt-packages.sh` ist ein **Fallback für Debian ARM** (armv6/armv7), wo Homebrew nicht verfügbar ist. Erweitere es trotzdem bei jeder neuen Formula:
 
 ```zsh
 [toolname]="apt:toolname"        # Standard: Debian/Ubuntu-Paket
@@ -143,7 +145,7 @@ Dies generiert automatisch tldr-Patches und aktualisiert README + docs.
 ## Checkliste
 
 - [ ] Brewfile-Eintrag mit Beschreibung + URL
-- [ ] BREW_TO_ALT Mapping für Linux
+- [ ] BREW_TO_ALT Mapping für Debian ARM (apt-packages.sh)
 - [ ] `.alias`-Datei mit korrektem Header-Format
 - [ ] Guard-Check am Anfang der `.alias`-Datei
 - [ ] Shell-Init in `.zshrc` (falls nötig)

--- a/.github/skills/add-tool/SKILL.md
+++ b/.github/skills/add-tool/SKILL.md
@@ -118,7 +118,7 @@ In `terminal/.config/theme-style` die Tabelle um einen Eintrag erweitern:
 #   toolname     | ~/.config/tool/theme-file          | github.com/catppuccin/toolname                | upstream+anpassung
 ```
 
-Status-Suffixe: `upstream` (unverändert), `+X` (Anpassung), `-X` (Entfernung), `manual` (kein Upstream).
+Status-Werte: `upstream` (unverändert), `upstream+X` (Anpassung), `upstream-X` (Entfernung), `builtin` (in Tool eingebaut), `manual` (kein Upstream), `semantics` (nur semantische Farbzuordnung).
 
 ### 5d: Post-Install prüfen
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -497,7 +497,7 @@ Die `.alias`-Datei ist der zentrale Dokumentations-Hub für jedes Tool.
 
 ```text
 Hat das Tool eine .alias-Datei?
-├─ JA → Config-Pfad gehört dort: `# Config : ~/.config/tool/config`
+├─ JA → Config-Pfad gehört dort: `# Config      : ~/.config/tool/config`
 │       (Single Source of Truth für Tool-Dokumentation)
 │
 └─ NEIN → Config-Datei in ~/.config/<tool>/ suchen
@@ -530,9 +530,9 @@ tldr-Generator Quellen:
 
 | Feld | Pflicht | Beispiel |
 | ---- | ------- | -------- |
-| `# Zweck` | ✅ | `# Zweck : GPU-Terminal mit Image-Support` |
-| `# Pfad` | ✅ | `# Pfad : ~/.config/kitty/kitty.conf` |
-| `# Docs` | ✅ | `# Docs : https://sw.kovidgoyal.net/kitty/` |
+| `# Zweck` | ✅ | `# Zweck       : GPU-Terminal mit Image-Support` |
+| `# Pfad` | ✅ | `# Pfad        : ~/.config/kitty/kitty.conf` |
+| `# Docs` | ✅ | `# Docs        : https://sw.kovidgoyal.net/kitty/` |
 | `# Reload` | ⚪ | `# Reload : Ctrl+Shift+F5` |
 | `# Theme` | ⚪ | `# Theme : current-theme.conf (via Stow)` |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -796,7 +796,7 @@ Bestimmte Sektionen in `.alias`-Dateien werden automatisch in `tldr dotfiles` do
 > Neue Sektionen erscheinen ohne Code-Änderung in `dothelp`. Sektionen ohne öffentliche
 > Aliase/Funktionen (z.B. nur `_`-Prefix) werden automatisch übersprungen.
 >
-> `dotfiles.alias` bleibt hardcodiert, da die Sektion „tldr-abhängige Aliase" (`dothelp`/`dh`)
+> `dotfiles.alias` bleibt hardcodiert, da die Sektion „tldr-abhängige Aliase“ (`dothelp`/`dh`)
 > bereits im Header-Block der Page steht und eine dynamische Extraktion zu Duplikaten führen würde.
 
 ### Funktions-Syntax

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -501,13 +501,13 @@ Hat das Tool eine .alias-Datei?
 │       (Single Source of Truth für Tool-Dokumentation)
 │
 └─ NEIN → Config-Datei in ~/.config/<tool>/ suchen
-          ├─ Datei mit `# Pfad :` Header?
+          ├─ Datei mit `# Pfad        :` Header?
           │  └─ JA → Config-Pfad gefunden + tldr-Patch generierbar ✓
           └─ NEIN → Kein Config-Pfad, keine tldr-Dokumentation
 ```
 
-**Regel:** `# Config :` in Alias-Datei ist Pflicht, wenn das Tool eine lokale Config hat.
-Der Fallback (`# Pfad :` in Config-Dateien) ist für Tools ohne `.alias`-Datei.
+**Regel:** `# Config      :` in Alias-Datei ist Pflicht, wenn das Tool eine lokale Config hat.
+Der Fallback (`# Pfad        :` in Config-Dateien) ist für Tools ohne `.alias`-Datei.
 
 ### tldr-Dokumentation für Tools ohne Aliase
 


### PR DESCRIPTION
## Beschreibung

Die monolithische `copilot-instructions.md` (~227 Zeilen) wurde in kontextspezifische `.instructions.md`-Dateien aufgeteilt. VS Code lädt diese automatisch basierend auf `applyTo`-Patterns — nur relevanter Kontext fließt in den Chat, statt immer alles.

Zusätzlich wurden zwei Agent Skills erstellt, die die komplexesten Workflows im Repo Schritt für Schritt abbilden.

### Was ändert sich?

**`copilot-instructions.md`** von ~227 auf ~86 Zeilen verschlankt — enthält nur noch:
- DOs/DON'Ts (repo-weit)
- Architektur-Überblick
- PR-Regeln (KRITISCH)
- Verweise-Tabelle (jetzt mit Links zu `.instructions.md`)

**6 neue `.instructions.md`-Dateien** in `.github/instructions/`:

| Datei | `applyTo` | Inhalt |
| ----- | --------- | ------ |
| `alias-conventions` | `terminal/.config/alias/*.alias` | Header-Format, mehrzeiliger Guard mit `# Guard   :` (korrekt gepadded), Funktions-Syntax, fzf-Keybinding-Sync |
| `shell-zsh` | `{**/*.sh,**/*.zsh,**/.zshrc,**/.zshenv,**/.zprofile,**/.zlogin}` | ZSH-Fallen, Variablen-Quoting, Logging-Systeme |
| `theming` | `**/theme-style` | Catppuccin Mocha Palette, semantische Farben (konsistent mit theme-style SSOT), vollständige Status-Dokumentation (6 Werte), Abschnittsreferenzen |
| `setup-modules` | `setup/modules/*.sh` | Plattform-Prefixes (inkl. `arch:`), Standalone+Guard-Pattern, STEP-Metadaten, MODULES-Registrierung, BREW_TO_ALT mit Method-Prefixen und Debian-ARM-Kontext |
| `github-workflow` | `.github/**` | Merge-Workflow, Review-Threads (inkl. GraphQL-Mutation), Templates, Labels |
| `generators` | `.github/scripts/generators/**` | SSOT, Generator-Pipeline, tldr-Format |

**2 Agent Skills** in `.github/skills/`:

| Skill | Beschreibung |
| ----- | ------------ |
| `add-tool` | 7-Schritte-Workflow: Brewfile → Debian-ARM-Fallback (BREW_TO_ALT mit `apt:`/`cargo:`/`npm:`/`skip` Prefixen, auf Arch/Fedora/Debian x86_64 reicht Homebrew) → .alias → .zshrc → Theming (mit Entscheidungsbaum Upstream vs. Manual, vollständige semantische Farbtabelle, Theme-Quellen-Tabelle) → Doku → Validierung |
| `add-fzf-function` | 8-Schritte-Workflow: Zuordnungsregel → Beschreibungskommentar (SSOT) → Funktions-Template → header-wrap (kein `--header=`) → Keybinding-Sync → Cross-Platform → Header-Feld → Validierung |

### Warum?

- **Token-Effizienz:** Nur relevanter Kontext lädt (statt immer ~227 Zeilen)
- **Bessere Genauigkeit:** Spezifischere Instruktionen → präzisere Ergebnisse
- **Wartbarkeit:** Konventionen leben dort, wo sie hingehören
- **Skalierbarkeit:** Neue Bereiche ergänzen ohne die Monolith-Datei aufzublähen

### Nachträgliche Ergänzungen (Commit `bb45207`)

- `setup-modules.instructions.md`: Standalone+Guard-Reihenfolge, Header-Felder, MODULES-Registrierung, setup-Funktion mit CURRENT_STEP
- `add-tool/SKILL.md` Step 5: Entscheidungsbaum Upstream vs. Manual, semantische Farbtabelle, Theme-Quellen-Tabelle mit Status-Suffixen, Post-Install Hinweis

### Review-Fixes (Commit `8fd3560`)

Alle 10 Copilot-Review-Findings adressiert:
- Guard-Pattern von Einzeiler auf mehrzeiligen Block (konsistent mit bat/eza/fd/rg.alias)
- `arch:` Plattform-Prefix ergänzt (verifiziert in bootstrap.sh:155)
- BREW_TO_ALT-Beispiele mit korrekten Method-Prefixen (`apt:`, `cargo:`, `npm:`, `skip`)
- `applyTo` in shell-zsh erweitert (matcht jetzt auch `.zshrc`, `.zshenv`, `.zprofile`, `.zlogin`)
- Hartcodierte Zeilennummern durch Abschnittsreferenzen ersetzt
- Relativen Link in copilot-instructions.md korrigiert
- Typografisches Anführungszeichen korrigiert (U+0022 → U+201C)

### GraphQL + Kommentar-Regel (Commit `9b05639`)

- `github-workflow.instructions.md`: `gh api graphql` Mutation für Thread-Resolving zurückgeholt (war auf main, fehlte nach Refactoring)
- `copilot-instructions.md`: DON'T ergänzt — keine Offensichtlichkeits-Kommentare (Header-Block und Beschreibungskommentare bleiben Pflicht als Generator-Input)

### Arch-Kontext für BREW_TO_ALT (Commit `342c05e`)

`BREW_TO_ALT` in `apt-packages.sh` ist ein **Debian ARM Fallback** (armv6/armv7). Auf Arch, Fedora und Debian x86_64 installiert Homebrew/Linuxbrew direkt — kein zusätzliches Mapping nötig. Betrifft:
- `add-tool/SKILL.md` Step 2: Plattform-Einschränkung dokumentiert
- `add-tool/SKILL.md` Checkliste: „für Linux" → „für Debian ARM"
- `setup-modules.instructions.md` Linux-Mapping: Homebrew-Klarstellung

### Zweite Review-Runde (Commit `1323615`)

4 Findings, davon 3 valid + 1 False Positive:
- `alias-conventions`: Guard/Config Padding in Regeln korrigiert (`# Guard   :`, `# Config      :`)
- `theming`: `builtin` und `semantics` in Status-Dokumentation ergänzt (6 Werte, konsistent mit theme-style)
- `add-tool/SKILL.md`: Status-Werte als vollständige Tokens dokumentiert statt isolierter Suffixe
- `setup-modules` arch-Finding: False Positive — bereits in `8fd3560` korrigiert

### Dritte Review-Runde (Commit `afbb076`)

1 Finding, valid:
- `copilot-instructions.md`: Schließendes ASCII-Anführungszeichen `"` (U+0022) durch typografisches `"` (U+201C) ersetzt — konsistentes „…"-Paar

### Vierte Review-Runde (Commit `72df34b`)

3 Findings, alle valid:
- `github-workflow.instructions.md`: API-Endpunkt `/pulls//reviews` → `/pulls//comments` (liefert Inline-Kommentare statt Review-Objekte)
- `add-tool/SKILL.md` Step 5b: Farbtabelle um Warning (Yellow), Info/Link (Blue), Directory (Mauve) erweitert + als Subset markiert mit Verweis auf `theming.instructions.md`
- `add-tool/SKILL.md` Step 5d: MODULES-Registrierung in `bootstrap.sh` ergänzt (Position beachten: Abhängigkeiten vorher)

### Fünfte Review-Runde (Commit `494a0f2`)

2 Findings, beide valid:
- `add-tool/SKILL.md`: Schließendes ASCII `"` (U+0022) → typografisches `"` (U+201C) in Abschnitt-Referenz „Semantische Farbzuweisungen"
- `theming.instructions.md`: `Symlink/Info` → `Info/Link` (konsistent mit SSOT in `theme-style:138`)

### Repo-weiter Quote-Scan (Commit `f3282a5`)

Nach wiederholtem Auftreten des Anführungszeichen-Bugs: vollständiger Scan aller Dateien im Repo. 3 weitere defekte „…"-Paare gefunden und gefixt:
- `CONTRIBUTING.md:799`: ASCII `"` → `"` (U+201C)
- `.github/reviews/2025-07-14-review.md:125,175`: Lokal gefixt (untracked Datei)

### Sechste Review-Runde (Commit `0725976`)

2 Findings, beide valid + Phase-3-Scope-Erweiterung:
- `add-fzf-function/SKILL.md`: `# Aliase :` → `# Aliase      :` (3 Stellen: Zeilen 123, 125, 169)
- `CONTRIBUTING.md`: `# Pfad :` → `# Pfad        :` + `# Config :` → `# Config      :` (Backtick-Referenzen)
- 3 Guard-Referenzen (`# Guard   :`) als False Positive verifiziert — Guard ist kein 12-Zeichen-Header-Feld

### Siebte Review-Runde (Commit `d93b823`)

1 Finding, valid + Phase-3-Scope-Erweiterung:
- `CONTRIBUTING.md:500`: `# Config :` → `# Config      :` im Entscheidungsbaum-Beispiel
- Scope-Erweiterung: 3 weitere ungepaddete Beispiele in Config-Patch-Tabelle (Zeilen 533–535: `# Zweck :`, `# Pfad :`, `# Docs :`) — verifiziert gegen `kitty.conf` und `starship.toml` SSOT

## Art der Änderung

- [x] ✨ Neues Feature
- [x] 🔧 Konfiguration

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Pre-Commit Hooks: alle 15 Checks bestanden

## Zusammenhängende Issues

Closes #417