### PR TITLE
feat(brewfile): Obsidian Cask hinzufügen

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -219,6 +219,7 @@ ff                                  # System-Info anzeigen
 | [`copilot-cli`](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli) | Agentic Coding |
 | [`github`](https://desktop.github.com/) | GitHub Desktop GUI |
 | [`kitty`](https://sw.kovidgoyal.net/kitty/) | GPU-Terminal mit Image-Support |
+| [`obsidian`](https://obsidian.md/) | Markdown-Wissensdatenbank |
 | [`visual-studio-code`](https://code.visualstudio.com/) | Editor |
 | [`font-jetbrains-mono-nerd-font`](https://github.com/ryanoasis/nerd-fonts) | Nerd Font |
 | [`font-meslo-lg-nerd-font`](https://github.com/ryanoasis/nerd-fonts) | Nerd Font |

--- a/setup/Brewfile
+++ b/setup/Brewfile
@@ -48,6 +48,7 @@ brew "mas"                                  # Mac App Store CLI | https://github
 cask "copilot-cli"                          # Agentic Coding | https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli
 cask "github"                               # GitHub Desktop GUI | https://desktop.github.com/
 cask "kitty"                                # GPU-Terminal mit Image-Support | https://sw.kovidgoyal.net/kitty/
+cask "obsidian"                             # Markdown-Wissensdatenbank | https://obsidian.md/
 cask "visual-studio-code"                   # Editor | https://code.visualstudio.com/
 cask "font-jetbrains-mono-nerd-font"        # Nerd Font | https://github.com/ryanoasis/nerd-fonts
 cask "font-meslo-lg-nerd-font"              # Nerd Font | https://github.com/ryanoasis/nerd-fonts


### PR DESCRIPTION
## Beschreibung

Fügt [Obsidian](https://obsidian.md/) als Markdown-Wissensdatenbank zum Brewfile hinzu.

Da Obsidian eine GUI-App ohne CLI ist, ist keine `.alias`-Datei und kein `BREW_TO_ALT`-Eintrag nötig (analog zu `kitty`, `github`, `visual-studio-code`).

## Art der Änderung

- [x] 🔧 Konfiguration

## Checkliste

- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] Pre-Commit Hooks bestanden
- [x] `docs/setup.md` regeneriert

## Hinweis zur AI-Integration

Recherchiert: Es gibt keine offizielle Obsidian CLI. Für AI-Anbindung etabliert sich der MCP-Standard (Local REST API Plugin + MCP-Server wie [MarkusPfundstein/mcp-obsidian](https://github.com/MarkusPfundstein/mcp-obsidian)). MCP-Server gehören aber nicht ins Brewfile, sondern in die jeweilige AI-Client-Config (Claude Desktop, Copilot etc.) — daher hier bewusst weggelassen.