### PR TITLE
fix(alias): Guard-Abdeckung härten und EXTENDED_GLOB lokal sichern

### DIFF
--- a/.github/scripts/check-alias-format.sh
+++ b/.github/scripts/check-alias-format.sh
@@ -25,7 +25,9 @@ source "${0:A:h}/lib/log.sh"
 # ------------------------------------------------------------
 # Prüft 6 Konventionen aus CONTRIBUTING.md:
 #   1. Header-Block (^# ====) in den ersten 3 Zeilen
-#   2. Guard-Check (command -v) vorhanden
+#   2. Guard-Abdeckung: Öffentliche Top-Level-Definitionen stehen
+#      nach einem Datei-Guard (if ! command -v … return 0) oder in
+#      einem Top-Level 'if command -v'-Block (Ausnahme: dotfiles.alias, #232)
 #   3. Pflichtfelder (Zweck, Pfad, Docs, Nutzt, Ersetzt) im Header
 #   4. Mindestens eine Sektion mit Trennern (^# ----)
 #   5. Beschreibungskommentar über jeder alias/function-Definition
@@ -40,7 +42,8 @@ check_alias_format() {
     local errors=0
     local name line prevline field i
     local -a lines header_lines
-    local total has_header header_end eq_count has_guard found
+    local total has_header header_end eq_count found
+    local file_guarded in_file_guard in_cmd_block
     local sep_count defline funcline
     local -A fo_lines
     local fo_fld fo_prev fo_prev_ln
@@ -77,14 +80,54 @@ check_alias_format() {
         done
         header_lines=("${(@)lines[1,$header_end]}")
 
-        # 2. Guard-Check vorhanden?
-        has_guard=0
-        for (( i = 1; i <= total; i++ )); do
-            [[ "${lines[$i]}" == *"command -v"*">/dev/null"* ]] && { has_guard=1; break; }
-        done
-        if (( ! has_guard )); then
-            err "$name: Kein Guard-Check"
-            (( errors++ )) || true
+        # 2. Guard-Abdeckung prüfen
+        #    Öffentliche Top-Level-Definitionen sind nur erlaubt nach einem
+        #    Datei-Guard (if ! command -v … return 0 … fi) oder innerhalb
+        #    eines Top-Level 'if command -v'-Blocks. Eingehakte Definitionen
+        #    (in sonstigen Blöcken) sind eingerückt und hier nicht erfasst.
+        #    Ausnahme: dotfiles.alias nutzt Laufzeit-Checks im Funktionskörper
+        #    statt Tool-Guards – bewusste Entscheidung aus #232.
+        if [[ "$name" != "dotfiles.alias" ]]; then
+            file_guarded=0
+            in_file_guard=0
+            in_cmd_block=0
+            for (( i = 1; i <= total; i++ )); do
+                line="${lines[$i]}"
+                # Datei-Guard beginnt: if ! command -v … (Top-Level)
+                if [[ "$line" == 'if ! command -v '* ]]; then
+                    in_file_guard=1
+                    continue
+                fi
+                # Datei-Guard bestätigt: return 0 innerhalb des Blocks
+                if (( in_file_guard )) && [[ "$line" == *'return 0'* ]]; then
+                    file_guarded=1
+                    continue
+                fi
+                # Guard-Block beginnt: if command -v … (Top-Level, positiv)
+                if [[ "$line" == 'if command -v '* ]]; then
+                    in_cmd_block=1
+                    continue
+                fi
+                # Top-Level fi schließt Datei-Guard-if und Guard-Block
+                if [[ "$line" == 'fi' || "$line" == 'fi '* ]]; then
+                    in_file_guard=0
+                    in_cmd_block=0
+                    continue
+                fi
+                # Nach bestätigtem Datei-Guard ist der Rest der Datei gedeckt
+                (( file_guarded )) && continue
+                # Innerhalb eines 'if command -v'-Blocks ebenfalls gedeckt
+                (( in_cmd_block )) && continue
+                # Ungeschützte öffentliche Top-Level-Definition?
+                if [[ "$line" =~ '^alias [a-zA-Z]' ]]; then
+                    defline="${line#alias }"
+                    err "$name:$i: 'alias ${defline%%=*}' ohne Guard-Abdeckung (Datei-Guard oder 'if command -v'-Block, siehe #438)"
+                    (( errors++ )) || true
+                elif [[ "$line" =~ '^[a-zA-Z][a-zA-Z0-9_-]*\(\)[[:space:]]*\{' ]]; then
+                    err "$name:$i: '${line%%\(*}()' ohne Guard-Abdeckung (Datei-Guard oder 'if command -v'-Block, siehe #438)"
+                    (( errors++ )) || true
+                fi
+            done
         fi
 
         # 3. Pflichtfelder im Header (CONTRIBUTING.md: Zweck, Pfad, Docs, Nutzt, Ersetzt)

--- a/terminal/.config/alias/7z.alias
+++ b/terminal/.config/alias/7z.alias
@@ -37,8 +37,8 @@ alias unrar='7zz x'
 # ------------------------------------------------------------
 # Archiv Browser(pfad=.) – Enter=Entpacken, Ctrl+Y=Pfad kopieren
 7zf() {
-    if ! command -v fzf >/dev/null 2>&1; then
-        echo "fzf benötigt für 7zf" >&2
+    if ! command -v fzf >/dev/null 2>&1 || ! command -v fd >/dev/null 2>&1; then
+        echo "7zf benötigt fzf und fd (brew install fzf fd)" >&2
         return 1
     fi
 

--- a/terminal/.config/alias/brew.alias
+++ b/terminal/.config/alias/brew.alias
@@ -76,7 +76,8 @@ unset _brew_conf
 typeset -g _BREW_CHECK_INTERVAL="${_BREW_CHECK_INTERVAL:-43200}"
 typeset -g _BREW_CHECK_NOTIFY="${_BREW_CHECK_NOTIFY:-auto}"
 typeset -g _BREW_CHECK_TITLE="${_BREW_CHECK_TITLE:-🍺 Homebrew}"
-typeset -g _BREW_CHECK_MESSAGE=${_BREW_CHECK_MESSAGE:-'{count} Updates verfügbar – Zeit für brew-up'}
+# \} im Default nötig: ungeschütztes } würde die ${...}-Expansion vorzeitig beenden
+typeset -g _BREW_CHECK_MESSAGE="${_BREW_CHECK_MESSAGE:-{count\} Updates verfügbar – Zeit für brew-up}"
 typeset -g _BREW_CHECK_STATE="${XDG_STATE_HOME:-$HOME/.local/state}/homebrew"
 typeset -gi _BREW_NOTIFIED=0
 

--- a/terminal/.config/alias/brew.alias
+++ b/terminal/.config/alias/brew.alias
@@ -16,23 +16,6 @@
 # ============================================================
 
 # ------------------------------------------------------------
-# Update & Wartung
-# ------------------------------------------------------------
-# Homebrew Komplett-Update – update, upgrade, autoremove, cleanup, mas (setzt Auto-Check-Timer zurück)
-brew-up() {
-    brew update && brew upgrade
-    command -v mas >/dev/null 2>&1 && mas upgrade
-    brew autoremove && brew cleanup
-    # Timer zurücksetzen – nächster Check erst wieder nach _BREW_CHECK_INTERVAL
-    [[ -d "${_BREW_CHECK_STATE:-}" ]] && {
-        touch "$_BREW_CHECK_STATE/last-check"
-        rm -f "$_BREW_CHECK_STATE/last-check.result"
-    }
-    # Session-Flag zurücksetzen (Meldung erlauben falls erneut veraltet)
-    _BREW_NOTIFIED=0
-}
-
-# ------------------------------------------------------------
 # Mac App Store (mas)
 # ------------------------------------------------------------
 # Voraussetzung: Anmeldung im App Store über App Store.app
@@ -56,103 +39,127 @@ if command -v mas >/dev/null 2>&1; then
     alias masl='mas list'
 fi
 
+# Guard   : Ab hier nur wenn brew installiert ist
+# (mas-Aliase oben bleiben bewusst unabhängig – siehe #232)
+if ! command -v brew >/dev/null 2>&1; then
+    return 0
+fi
+
+# ------------------------------------------------------------
+# Update & Wartung
+# ------------------------------------------------------------
+# Homebrew Komplett-Update – update, upgrade, autoremove, cleanup, mas (setzt Auto-Check-Timer zurück)
+brew-up() {
+    brew update && brew upgrade
+    command -v mas >/dev/null 2>&1 && mas upgrade
+    brew autoremove && brew cleanup
+    # Timer zurücksetzen – nächster Check erst wieder nach _BREW_CHECK_INTERVAL
+    [[ -d "${_BREW_CHECK_STATE:-}" ]] && {
+        touch "$_BREW_CHECK_STATE/last-check"
+        rm -f "$_BREW_CHECK_STATE/last-check.result"
+    }
+    # Session-Flag zurücksetzen (Meldung erlauben falls erneut veraltet)
+    _BREW_NOTIFIED=0
+}
+
 # ------------------------------------------------------------
 # Automatische Outdated-Prüfung (Background, read-only)
 # ------------------------------------------------------------
 # Prüft im Hintergrund ob Homebrew-Pakete veraltet sind.
 # Zeigt einmalig eine Benachrichtigung – kein Auto-Upgrade.
 # State: ${XDG_STATE_HOME:-~/.local/state}/homebrew (maschinenlokal, nicht in Git)
-# Guard: precmd-Hooks nur registrieren wenn brew installiert ist
-if command -v brew >/dev/null 2>&1; then
-    # Konfiguration laden
-    _brew_conf="${XDG_CONFIG_HOME:-$HOME/.config}/homebrew/check.conf"
-    [[ -f "$_brew_conf" ]] && source "$_brew_conf"
-    unset _brew_conf
-    typeset -g _BREW_CHECK_INTERVAL="${_BREW_CHECK_INTERVAL:-43200}"
-    typeset -g _BREW_CHECK_NOTIFY="${_BREW_CHECK_NOTIFY:-auto}"
-    typeset -g _BREW_CHECK_TITLE="${_BREW_CHECK_TITLE:-🍺 Homebrew}"
-    typeset -g _BREW_CHECK_MESSAGE=${_BREW_CHECK_MESSAGE:-'{count} Updates verfügbar – Zeit für brew-up'}
-    typeset -g _BREW_CHECK_STATE="${XDG_STATE_HOME:-$HOME/.local/state}/homebrew"
-    typeset -gi _BREW_NOTIFIED=0
 
-    _brew_outdated_check() {
-        local stamp="$_BREW_CHECK_STATE/last-check"
+# Konfiguration laden
+_brew_conf="${XDG_CONFIG_HOME:-$HOME/.config}/homebrew/check.conf"
+[[ -f "$_brew_conf" ]] && source "$_brew_conf"
+unset _brew_conf
+typeset -g _BREW_CHECK_INTERVAL="${_BREW_CHECK_INTERVAL:-43200}"
+typeset -g _BREW_CHECK_NOTIFY="${_BREW_CHECK_NOTIFY:-auto}"
+typeset -g _BREW_CHECK_TITLE="${_BREW_CHECK_TITLE:-🍺 Homebrew}"
+typeset -g _BREW_CHECK_MESSAGE=${_BREW_CHECK_MESSAGE:-'{count} Updates verfügbar – Zeit für brew-up'}
+typeset -g _BREW_CHECK_STATE="${XDG_STATE_HOME:-$HOME/.local/state}/homebrew"
+typeset -gi _BREW_NOTIFIED=0
 
-        # Verzeichnis sicherstellen (einmalig)
-        [[ -d "$_BREW_CHECK_STATE" ]] || mkdir -p "$_BREW_CHECK_STATE" || return
+_brew_outdated_check() {
+    # (#q...)-Glob-Qualifier braucht EXTENDED_GLOB – lokal setzen statt
+    # von der .zshrc-Ladekette abzuhängen (isoliertes Sourcen, Tests)
+    setopt LOCAL_OPTIONS extended_glob
+    local stamp="$_BREW_CHECK_STATE/last-check"
 
-        # Timestamp frisch genug? → ZSH Glob Qualifier: ms+N = älter als N Sekunden
-        if [[ -f "$stamp" ]] && [[ -z "$stamp"(#qN.ms+${_BREW_CHECK_INTERVAL}) ]]; then
-            return
+    # Verzeichnis sicherstellen (einmalig)
+    [[ -d "$_BREW_CHECK_STATE" ]] || mkdir -p "$_BREW_CHECK_STATE" || return
+
+    # Timestamp frisch genug? → ZSH Glob Qualifier: ms+N = älter als N Sekunden
+    if [[ -f "$stamp" ]] && [[ -z "$stamp"(#qN.ms+${_BREW_CHECK_INTERVAL}) ]]; then
+        return
+    fi
+
+    # Sofort aktualisieren (Race-Condition-Schutz bei mehreren Shells)
+    touch "$stamp"
+
+    # Background: Index aktualisieren (Netzwerk, blockiert nicht)
+    {
+        export HOMEBREW_LOCK_CONTEXT="brew-outdated-check (background)"
+        brew update-if-needed 2>/dev/null
+    } &!
+
+    # Synchron: Lokalen Index lesen (~1s, kein Netzwerk)
+    local brew_count=0 mas_count=0
+    local brew_out
+    brew_out=$(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --quiet 2>/dev/null)
+    if [[ -n "$brew_out" ]]; then
+        local -a _brew_lines=("${(f)brew_out}")
+        brew_count=${#_brew_lines}
+    fi
+
+    if command -v mas >/dev/null 2>&1; then
+        local mas_out
+        mas_out=$(mas outdated 2>/dev/null)
+        if [[ -n "$mas_out" ]]; then
+            local -a _mas_lines=("${(f)mas_out}")
+            mas_count=${#_mas_lines}
         fi
+    fi
 
-        # Sofort aktualisieren (Race-Condition-Schutz bei mehreren Shells)
-        touch "$stamp"
+    local total=$((brew_count + mas_count))
+    if (( total > 0 )); then
+        echo "$total" > "$stamp.result.tmp" \
+            && mv "$stamp.result.tmp" "$stamp.result" \
+            || rm -f "$stamp.result.tmp"
+    else
+        rm -f "$stamp.result" "$stamp.result.tmp"
+    fi
+}
 
-        # Background: Index aktualisieren (Netzwerk, blockiert nicht)
-        {
-            export HOMEBREW_LOCK_CONTEXT="brew-outdated-check (background)"
-            brew update-if-needed 2>/dev/null
-        } &!
+_brew_outdated_notify() {
+    # Deaktiviert per Config
+    [[ "$_BREW_CHECK_NOTIFY" == off ]] && return
+    # Einmal pro Session anzeigen (Datei bleibt für neue Sessions)
+    (( _BREW_NOTIFIED )) && return
+    local result="$_BREW_CHECK_STATE/last-check.result"
+    [[ -f "$result" ]] || return
+    local count
+    count=$(<"$result")
+    if (( count > 0 )); then
+        local msg="${_BREW_CHECK_MESSAGE//\{count\}/$count}"
+        case "$_BREW_CHECK_NOTIFY" in
+            desktop)
+                notify "$_BREW_CHECK_TITLE" "$msg" 2>/dev/null ;;
+            terminal)
+                echo "${C_YELLOW}${_BREW_CHECK_TITLE}: ${msg}${C_RESET}" ;;
+            *)  # auto: Desktop mit Terminal-Fallback
+                (( _PLATFORM_HAS_DISPLAY )) && notify "$_BREW_CHECK_TITLE" "$msg" 2>/dev/null \
+                    || echo "${C_YELLOW}${_BREW_CHECK_TITLE}: ${msg}${C_RESET}" ;;
+        esac
+        typeset -g _BREW_NOTIFIED=1
+    fi
+}
 
-        # Synchron: Lokalen Index lesen (~1s, kein Netzwerk)
-        local brew_count=0 mas_count=0
-        local brew_out
-        brew_out=$(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --quiet 2>/dev/null)
-        if [[ -n "$brew_out" ]]; then
-            local -a _brew_lines=("${(f)brew_out}")
-            brew_count=${#_brew_lines}
-        fi
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _brew_outdated_notify
 
-        if command -v mas >/dev/null 2>&1; then
-            local mas_out
-            mas_out=$(mas outdated 2>/dev/null)
-            if [[ -n "$mas_out" ]]; then
-                local -a _mas_lines=("${(f)mas_out}")
-                mas_count=${#_mas_lines}
-            fi
-        fi
-
-        local total=$((brew_count + mas_count))
-        if (( total > 0 )); then
-            echo "$total" > "$stamp.result.tmp" \
-                && mv "$stamp.result.tmp" "$stamp.result" \
-                || rm -f "$stamp.result.tmp"
-        else
-            rm -f "$stamp.result" "$stamp.result.tmp"
-        fi
-    }
-
-    _brew_outdated_notify() {
-        # Deaktiviert per Config
-        [[ "$_BREW_CHECK_NOTIFY" == off ]] && return
-        # Einmal pro Session anzeigen (Datei bleibt für neue Sessions)
-        (( _BREW_NOTIFIED )) && return
-        local result="$_BREW_CHECK_STATE/last-check.result"
-        [[ -f "$result" ]] || return
-        local count
-        count=$(<"$result")
-        if (( count > 0 )); then
-            local msg="${_BREW_CHECK_MESSAGE//\{count\}/$count}"
-            case "$_BREW_CHECK_NOTIFY" in
-                desktop)
-                    notify "$_BREW_CHECK_TITLE" "$msg" 2>/dev/null ;;
-                terminal)
-                    echo "${C_YELLOW}${_BREW_CHECK_TITLE}: ${msg}${C_RESET}" ;;
-                *)  # auto: Desktop mit Terminal-Fallback
-                    (( _PLATFORM_HAS_DISPLAY )) && notify "$_BREW_CHECK_TITLE" "$msg" 2>/dev/null \
-                        || echo "${C_YELLOW}${_BREW_CHECK_TITLE}: ${msg}${C_RESET}" ;;
-            esac
-            typeset -g _BREW_NOTIFIED=1
-        fi
-    }
-
-    autoload -Uz add-zsh-hook
-    add-zsh-hook precmd _brew_outdated_notify
-
-    # Check sofort starten (Zählung synchron ~1s, Index-Update im Background)
-    [[ "$_BREW_CHECK_NOTIFY" != off ]] && _brew_outdated_check
-fi
+# Check sofort starten (Zählung synchron ~1s, Index-Update im Background)
+[[ "$_BREW_CHECK_NOTIFY" != off ]] && _brew_outdated_check
 
 # ------------------------------------------------------------
 # Versionsübersicht

--- a/terminal/.config/tealdeer/pages/brew.patch.md
+++ b/terminal/.config/tealdeer/pages/brew.patch.md
@@ -4,10 +4,6 @@
 
 - dotfiles: Automatischer Outdated-Check (Standard: 12h) – zeigt einmalig pro Session eine Benachrichtigung, wenn Updates verfügbar sind. Konfigurierbar via check.conf (Intervall, Kanal, Meldung).
 
-- dotfiles: Homebrew Komplett-Update (update, upgrade, autoremove, cleanup, mas (setzt Auto-Check-Timer zurück)):
-
-`brew-up`
-
 - dotfiles: Zeige veraltete Mac App Store Apps:
 
 `maso`
@@ -27,6 +23,10 @@
 - dotfiles: Alle installierten Mac App Store Apps auflisten:
 
 `masl`
+
+- dotfiles: Homebrew Komplett-Update (update, upgrade, autoremove, cleanup, mas (setzt Auto-Check-Timer zurück)):
+
+`brew-up`
 
 - dotfiles: Brewfile Wartungs-Dashboard (Versionen, Updates, Drift):
 

--- a/terminal/.config/tealdeer/pages/dotfiles.page.md
+++ b/terminal/.config/tealdeer/pages/dotfiles.page.md
@@ -71,10 +71,6 @@
 
 # Homebrew (inkl. Mac App Store)
 
-- Homebrew Komplett-Update (update, upgrade, autoremove, cleanup, mas (setzt Auto-Check-Timer zurück)):
-
-`brew-up`
-
 - Zeige veraltete Mac App Store Apps:
 
 `maso`
@@ -94,6 +90,10 @@
 - Alle installierten Mac App Store Apps auflisten:
 
 `masl`
+
+- Homebrew Komplett-Update (update, upgrade, autoremove, cleanup, mas (setzt Auto-Check-Timer zurück)):
+
+`brew-up`
 
 - Brewfile Wartungs-Dashboard (Versionen, Updates, Drift):
 


### PR DESCRIPTION
## Zusammenfassung

Härtet die Guard-Abdeckung in Alias-Dateien und sichert den Timer-Glob des Outdated-Checks lokal ab. Verschärft zusätzlich den Format-Check, damit ungeschützte Definitionen künftig automatisch erkannt werden.

Closes #438

## Änderungen

| Datei | Änderung |
| --- | --- |
| `terminal/.config/alias/brew.alias` | mas-Block nach oben (bleibt brew-unabhängig, #232-Garantie), danach Datei-Guard `if ! command -v brew … return 0`; Outdated-Check-Block entschachtelt (eine Einrückungsebene weniger); `_brew_outdated_check()` mit `setopt LOCAL_OPTIONS extended_glob` |
| `terminal/.config/alias/7z.alias` | `7zf()` prüft fzf **und** fd (konsistent mit `dotedit()`) |
| `.github/scripts/check-alias-format.sh` | Prüfung 2 verschärft: statt „irgendwo `command -v`" jetzt Guard-*Abdeckungs*-Analyse — öffentliche Top-Level-Definitionen müssen nach einem Datei-Guard oder in einem `if command -v`-Block stehen (Ausnahme: dotfiles.alias, #232) |
| `terminal/.config/tealdeer/pages/{brew.patch.md,dotfiles.page.md}` | Regeneriert — reine Sektions-Umsortierung (mas vor brew-up) |

## Test-Nachweise (alle praktisch reproduziert)

| Szenario | Ergebnis |
| --- | --- |
| Ohne brew im PATH | `brew-up`/`brew-list`/`brew-add` **undefiniert** ✓ |
| Nur mas im PATH (ohne brew) | `maso` definiert, `brew-up` undefiniert — #232-Garantie ✓ |
| Volle Ladekette (`zsh -i`) | Alle 7 Befehle definiert ✓ |
| Timer-Glob ohne globale EXTENDED_GLOB (mtime-Beweis) | Frischer Stamp → früher Return; 13h-alter Stamp → Check läuft ✓ |
| `7zf` ohne fd | Exit 1 mit Meldung ✓ |
| Verschärfter Check gegen ungefixtes brew.alias | Meldete exakt `brew-up`/`brew-list` (Negativ-Test) ✓ |
| Pre-Commit-Hook | Alle 14 Checks grün (inkl. 272 Generator-Tests, Health-Check) ✓ |

## Review-Follow-up (Commit 6ae2ee8)

Copilot-Finding (brew.alias Z. 79, `_BREW_CHECK_MESSAGE` unquoted): Expansions-Gefahr in zsh **widerlegt** (kein `SH_WORD_SPLIT`/`GLOB_SUBST` bei Zuweisungen — praktisch getestet), Konsistenz-Argument **valide**. Naives Quoten hätte den Default gebrochen (inneres `'…'` literal, `}` beendet Expansion); Lösung: escaped `{count\}` im gequoteten Default + Warum-Kommentar. Beide Pfade bis zur Notification verifiziert.

## Checkliste

- [x] `./.github/scripts/generate-docs.sh --check` ausgeführt
- [x] `./.github/scripts/health-check.sh` ausgeführt
- [x] Bei Alias-Änderungen: Doku neu generiert (falls zutreffend)
- [x] Neue Shell-Session getestet (falls zutreffend)

