### PR TITLE
feat(brew): pdftk-java + qpdf für PDF-Formulare integrieren

### DIFF
--- a/.github/scripts/health-check.sh
+++ b/.github/scripts/health-check.sh
@@ -145,6 +145,7 @@ get_tools_from_brewfile() {
     [sevenzip]=7zz
     [poppler]=pdftotext
     [imagemagick]=magick
+    [pdftk-java]=pdftk
   )
 
   # Formulae die kein eigenständiges Binary haben (werden separat geprüft)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -198,7 +198,9 @@ ff                                  # System-Info anzeigen
 | [`jq`](https://jqlang.org/) | JSON-Prozessor |
 | [`lazygit`](https://github.com/jesseduffield/lazygit) | Git-TUI |
 | [`markdownlint-cli2`](https://github.com/DavidAnson/markdownlint-cli2) | Markdown-Linter |
+| [`pdftk-java`](https://gitlab.com/pdftk-java/pdftk) | PDF-Formular-Toolkit |
 | [`poppler`](https://poppler.freedesktop.org/) | PDF-Rendering |
+| [`qpdf`](https://qpdf.sourceforge.io/) | PDF-Struktur & Transformation |
 | [`resvg`](https://github.com/RazrFalcon/resvg) | SVG-Rendering |
 | [`ripgrep`](https://github.com/BurntSushi/ripgrep) | grep-Ersatz, schnellste Textsuche |
 | [`sevenzip`](https://7-zip.org/) | Archiv-Extraktion |

--- a/setup/Brewfile
+++ b/setup/Brewfile
@@ -28,7 +28,9 @@ brew "imagemagick"                          # Bild-Manipulation | https://imagem
 brew "jq"                                   # JSON-Prozessor | https://jqlang.org/
 brew "lazygit"                              # Git-TUI | https://github.com/jesseduffield/lazygit
 brew "markdownlint-cli2"                    # Markdown-Linter | https://github.com/DavidAnson/markdownlint-cli2
+brew "pdftk-java"                           # PDF-Formular-Toolkit | https://gitlab.com/pdftk-java/pdftk
 brew "poppler"                              # PDF-Rendering | https://poppler.freedesktop.org/
+brew "qpdf"                                 # PDF-Struktur & Transformation | https://qpdf.sourceforge.io/
 brew "resvg"                                # SVG-Rendering | https://github.com/RazrFalcon/resvg
 brew "ripgrep"                              # grep-Ersatz, schnellste Textsuche | https://github.com/BurntSushi/ripgrep
 brew "sevenzip"                             # Archiv-Extraktion | https://7-zip.org/

--- a/setup/modules/apt-packages.sh
+++ b/setup/modules/apt-packages.sh
@@ -64,7 +64,9 @@ typeset -A BREW_TO_ALT=(
     [imagemagick]=apt:imagemagick
     [jq]=apt:jq
     [lazygit]=apt:lazygit
+    [pdftk-java]=apt:pdftk-java
     [poppler]=apt:poppler-utils
+    [qpdf]=apt:qpdf
     [ripgrep]=apt:ripgrep
     [sevenzip]=apt:7zip
     [shellcheck]=apt:shellcheck
@@ -111,6 +113,7 @@ typeset -A BREW_TO_BINARY=(
     [sevenzip]=7zz
     [poppler]=pdftotext
     [imagemagick]=magick
+    [pdftk-java]=pdftk
 )
 
 # ------------------------------------------------------------

--- a/terminal/.config/alias/pdftk.alias
+++ b/terminal/.config/alias/pdftk.alias
@@ -1,0 +1,111 @@
+# ============================================================
+# pdftk.alias - Aliase für pdftk-java (PDF-Formulare & Struktur)
+# ============================================================
+# Zweck       : PDF-Formulare befüllen, einfrieren, rotieren und stempeln
+# Pfad        : ~/.config/alias/pdftk.alias
+# Docs        : https://gitlab.com/pdftk-java/pdftk
+# Nutzt       : qpdf (für pdfflatten)
+# Ersetzt     : -
+# Aliase      : pdffields, pdffill, pdfflatten, pdfrotate, pdfstamp
+# ============================================================
+
+# Guard   : Nur wenn pdftk installiert ist
+if ! command -v pdftk >/dev/null 2>&1; then
+    return 0
+fi
+
+# ------------------------------------------------------------
+# Formulare
+# ------------------------------------------------------------
+# Formularfelder auflisten(pdf) – Feldnamen, Typen und Optionen
+pdffields() {
+    if [[ $# -lt 1 ]]; then
+        echo "Verwendung: pdffields <pdf>" >&2
+        return 1
+    fi
+    pdftk "$1" dump_data_fields_utf8
+}
+
+# PDF-Formular befüllen(pdf, fdf, output?) – need_appearances für Umlaute
+pdffill() {
+    if [[ $# -lt 2 ]]; then
+        echo "Verwendung: pdffill <pdf> <fdf-daten> [output]" >&2
+        return 1
+    fi
+    local input="$1"
+    local data="$2"
+    local output="${3:-${input%.*}-filled.pdf}"
+
+    if [[ -e "$output" ]]; then
+        echo "Fehler: $output existiert bereits" >&2
+        return 1
+    fi
+    pdftk "$input" fill_form "$data" output "$output" need_appearances
+}
+
+# Formular einfrieren(pdf, output?) – via qpdf, Feldwerte bleiben durchsuchbar
+pdfflatten() {
+    if [[ $# -lt 1 ]]; then
+        echo "Verwendung: pdfflatten <pdf> [output]" >&2
+        return 1
+    fi
+    if ! command -v qpdf >/dev/null 2>&1; then
+        echo "Fehler: pdfflatten benötigt qpdf" >&2
+        return 1
+    fi
+    local input="$1"
+    local output="${2:-${input%.*}-flat.pdf}"
+
+    if [[ -e "$output" ]]; then
+        echo "Fehler: $output existiert bereits" >&2
+        return 1
+    fi
+    qpdf --generate-appearances --flatten-annotations=all "$input" "$output"
+}
+
+# ------------------------------------------------------------
+# Seiten-Operationen
+# ------------------------------------------------------------
+# Seiten rotieren(pdf, richtung, output?) – north/east/south/west/left/right/down
+pdfrotate() {
+    if [[ $# -lt 2 ]]; then
+        echo "Verwendung: pdfrotate <pdf> <north|east|south|west|left|right|down> [output]" >&2
+        return 1
+    fi
+    local input="$1"
+    local dir="${(L)2}"
+    local output="${3:-${input%.*}-rotated.pdf}"
+
+    case "$dir" in
+        north|east|south|west|left|right|down) ;;
+        *)
+            echo "Fehler: Ungültige Richtung '$2' (north/east/south/west/left/right/down)" >&2
+            return 1
+            ;;
+    esac
+    if [[ -e "$output" ]]; then
+        echo "Fehler: $output existiert bereits" >&2
+        return 1
+    fi
+    pdftk "$input" cat "1-end${dir}" output "$output"
+}
+
+# ------------------------------------------------------------
+# Stempel / Wasserzeichen
+# ------------------------------------------------------------
+# Stempel auflegen(pdf, stempel-pdf, output?) – erste Stempelseite auf alle Seiten
+pdfstamp() {
+    if [[ $# -lt 2 ]]; then
+        echo "Verwendung: pdfstamp <pdf> <stempel-pdf> [output]" >&2
+        return 1
+    fi
+    local input="$1"
+    local stamp="$2"
+    local output="${3:-${input%.*}-stamped.pdf}"
+
+    if [[ -e "$output" ]]; then
+        echo "Fehler: $output existiert bereits" >&2
+        return 1
+    fi
+    pdftk "$input" stamp "$stamp" output "$output"
+}

--- a/terminal/.config/tealdeer/pages/dotfiles.page.md
+++ b/terminal/.config/tealdeer/pages/dotfiles.page.md
@@ -129,7 +129,7 @@
 
 - Jedes Tool hat ALLE Aliase+Funktionen dokumentiert:
 
-`tldr {{7z|bat|brew|btop|exiftool|eza|fastfetch|fd|ffmpeg|fzf|gh|git|kitty|lazygit|magick|rg|starship|yazi|zoxide|zsh}}`
+`tldr {{7z|bat|brew|btop|exiftool|eza|fastfetch|fd|ffmpeg|fzf|gh|git|kitty|lazygit|magick|pdftk|rg|starship|yazi|zoxide|zsh}}`
 
 - Eigene Seiten (ohne offizielle tldr-Basis):
 

--- a/terminal/.config/tealdeer/pages/pdftk.patch.md
+++ b/terminal/.config/tealdeer/pages/pdftk.patch.md
@@ -1,0 +1,21 @@
+- dotfiles: Nutzt `qpdf (für pdfflatten)`
+
+- dotfiles: Formularfelder auflisten (Feldnamen, Typen und Optionen):
+
+`pdffields {{pdf}}`
+
+- dotfiles: PDF-Formular befüllen (need_appearances für Umlaute):
+
+`pdffill {{pdf, fdf, output}}`
+
+- dotfiles: Formular einfrieren (via qpdf, Feldwerte bleiben durchsuchbar):
+
+`pdfflatten {{pdf, output}}`
+
+- dotfiles: Seiten rotieren (north/east/south/west/left/right/down):
+
+`pdfrotate {{pdf, richtung, output}}`
+
+- dotfiles: Stempel auflegen (erste Stempelseite auf alle Seiten):
+
+`pdfstamp {{pdf, stempel-pdf, output}}`


### PR DESCRIPTION
## Beschreibung

Integriert `pdftk-java` (PDF-Formular-Toolkit) und `qpdf` (Struktur/Flatten) für CLI-basierte Formularbearbeitung – bisher im Toolkit nicht abgedeckt (`poppler` rendert/extrahiert nur).

Neue `pdftk.alias` im `pdf*`-Stil (konsistent mit `poppler.alias`):

- `pdffields` – Formularfelder auflisten (`dump_data_fields_utf8`)
- `pdffill` – Formular befüllen (`need_appearances` für korrekte Umlaut-Darstellung)
- `pdfflatten` – Formular einfrieren via `qpdf` (Feldwerte bleiben durchsuchbar)
- `pdfrotate` – Seiten rotieren (north/east/south/west/left/right/down)
- `pdfstamp` – Stempel/Wasserzeichen auflegen

`pdfflatten` nutzt `qpdf --generate-appearances --flatten-annotations`, da pdftk-java Feld-Appearances beim Flatten **nicht** in den Seiteninhalt überträgt (real an mehreren Test-PDFs verifiziert – Text ginge sonst verloren). Split/Merge sind bewusst nicht enthalten, da `poppler` (`pdfsplit`/`pdfmerge`) das bereits abdeckt.

## Art der Änderung

- [x] ✨ Neues Feature
- [x] 🏗️ Setup/Bootstrap

## Checkliste

- [x] Ich habe die Contributing Guidelines gelesen
- [x] `generate-docs.sh --check` ist erfolgreich
- [x] `health-check.sh` zeigt keine Fehler (`pdftk`, `qpdf` erkannt)
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Bei neuen Tools: Guard-Check vorhanden

## Zusammenhängende Issues

Closes #436

## Terminal-Ausgabe

Alle 5 Funktionen + Edge-Cases (Usage, Überschreibschutz, ungültige Richtung) real getestet. Befüllen und Flatten mit Umlaut `Jürgen Müller` verifiziert (Text bleibt, Felder=0).
