### PR TITLE
feat(brew): ocrmypdf + tesseract-lang für deutsche OCR integrieren

### DIFF
--- a/.github/scripts/health-check.sh
+++ b/.github/scripts/health-check.sh
@@ -153,6 +153,7 @@ get_tools_from_brewfile() {
     zsh-syntax-highlighting
     zsh-autosuggestions
     mas
+    tesseract-lang
   )
 
   # Extrahiere brew-Formulae (keine casks, keine mas)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -198,6 +198,7 @@ ff                                  # System-Info anzeigen
 | [`jq`](https://jqlang.org/) | JSON-Prozessor |
 | [`lazygit`](https://github.com/jesseduffield/lazygit) | Git-TUI |
 | [`markdownlint-cli2`](https://github.com/DavidAnson/markdownlint-cli2) | Markdown-Linter |
+| [`ocrmypdf`](https://ocrmypdf.readthedocs.io/en/latest/) | OCR-Textlayer für PDFs |
 | [`poppler`](https://poppler.freedesktop.org/) | PDF-Rendering |
 | [`resvg`](https://github.com/RazrFalcon/resvg) | SVG-Rendering |
 | [`ripgrep`](https://github.com/BurntSushi/ripgrep) | grep-Ersatz, schnellste Textsuche |
@@ -206,6 +207,7 @@ ff                                  # System-Info anzeigen
 | [`starship`](https://starship.rs/) | Shell-Prompt |
 | [`stow`](https://www.gnu.org/software/stow/) | Symlink-Manager |
 | [`tealdeer`](https://tealdeer-rs.github.io/tealdeer/) | tldr-Client |
+| [`tesseract-lang`](https://github.com/tesseract-ocr/tessdata_fast) | Tesseract-Sprachpakete (inkl. deu) |
 | [`yazi`](https://yazi-rs.github.io/) | File Manager |
 | [`zoxide`](https://github.com/ajeetdsouza/zoxide) | Smartes cd mit Frecency |
 | [`zsh-autosuggestions`](https://github.com/zsh-users/zsh-autosuggestions) | History-Vorschläge |

--- a/setup/Brewfile
+++ b/setup/Brewfile
@@ -28,6 +28,7 @@ brew "imagemagick"                          # Bild-Manipulation | https://imagem
 brew "jq"                                   # JSON-Prozessor | https://jqlang.org/
 brew "lazygit"                              # Git-TUI | https://github.com/jesseduffield/lazygit
 brew "markdownlint-cli2"                    # Markdown-Linter | https://github.com/DavidAnson/markdownlint-cli2
+brew "ocrmypdf"                             # OCR-Textlayer für PDFs | https://ocrmypdf.readthedocs.io/en/latest/
 brew "poppler"                              # PDF-Rendering | https://poppler.freedesktop.org/
 brew "resvg"                                # SVG-Rendering | https://github.com/RazrFalcon/resvg
 brew "ripgrep"                              # grep-Ersatz, schnellste Textsuche | https://github.com/BurntSushi/ripgrep
@@ -36,6 +37,7 @@ brew "shellcheck"                           # Shell-Script-Linter (für Bash) | 
 brew "starship"                             # Shell-Prompt | https://starship.rs/
 brew "stow"                                 # Symlink-Manager | https://www.gnu.org/software/stow/
 brew "tealdeer"                             # tldr-Client | https://tealdeer-rs.github.io/tealdeer/
+brew "tesseract-lang"                       # Tesseract-Sprachpakete (inkl. deu) | https://github.com/tesseract-ocr/tessdata_fast
 brew "yazi"                                 # File Manager | https://yazi-rs.github.io/
 brew "zoxide"                               # Smartes cd mit Frecency | https://github.com/ajeetdsouza/zoxide
 brew "zsh-autosuggestions"                  # History-Vorschläge | https://github.com/zsh-users/zsh-autosuggestions

--- a/setup/modules/apt-packages.sh
+++ b/setup/modules/apt-packages.sh
@@ -64,6 +64,7 @@ typeset -A BREW_TO_ALT=(
     [imagemagick]=apt:imagemagick
     [jq]=apt:jq
     [lazygit]=apt:lazygit
+    [ocrmypdf]=apt:ocrmypdf
     [poppler]=apt:poppler-utils
     [ripgrep]=apt:ripgrep
     [sevenzip]=apt:7zip
@@ -71,6 +72,7 @@ typeset -A BREW_TO_ALT=(
     [starship]=apt:starship
     [stow]=apt:stow
     [tealdeer]=apt:tealdeer
+    [tesseract-lang]=apt:tesseract-ocr-deu
     [zoxide]=apt:zoxide
 
     # ZSH-Plugins (apt, werden separat vom Plugin-Pfad-Fallback genutzt)

--- a/terminal/.config/alias/ocrmypdf.alias
+++ b/terminal/.config/alias/ocrmypdf.alias
@@ -1,0 +1,51 @@
+# ============================================================
+# ocrmypdf.alias - Aliase für OCRmyPDF (OCR-Textlayer)
+# ============================================================
+# Zweck       : Gescannte PDFs durchsuchbar machen (deutsch by default)
+# Pfad        : ~/.config/alias/ocrmypdf.alias
+# Docs        : https://ocrmypdf.readthedocs.io/
+# Nutzt       : -
+# Ersetzt     : -
+# Aliase      : pdfocr, pdfscan
+# ============================================================
+
+# Guard   : Nur wenn ocrmypdf installiert ist
+if ! command -v ocrmypdf >/dev/null 2>&1; then
+    return 0
+fi
+
+# ------------------------------------------------------------
+# OCR
+# ------------------------------------------------------------
+# OCR-Textlayer hinzufügen(pdf, sprache=deu, output?) – macht Scans durchsuchbar
+pdfocr() {
+    if [[ $# -lt 1 ]]; then
+        echo "Verwendung: pdfocr <pdf> [sprache=deu] [output]" >&2
+        return 1
+    fi
+    local input="$1"
+    local lang="${2:-deu}"
+    local output="${3:-${input%.*}-ocr.pdf}"
+
+    if [[ -e "$output" ]]; then
+        echo "Fehler: $output existiert bereits" >&2
+        return 1
+    fi
+    ocrmypdf -l "$lang" "$input" "$output"
+}
+
+# Scan optimieren und OCR(pdf, output?) – deskew, clean, rotate-pages, deutsch
+pdfscan() {
+    if [[ $# -lt 1 ]]; then
+        echo "Verwendung: pdfscan <pdf> [output]" >&2
+        return 1
+    fi
+    local input="$1"
+    local output="${2:-${input%.*}-scan.pdf}"
+
+    if [[ -e "$output" ]]; then
+        echo "Fehler: $output existiert bereits" >&2
+        return 1
+    fi
+    ocrmypdf --deskew --clean --rotate-pages -l deu "$input" "$output"
+}

--- a/terminal/.config/alias/ocrmypdf.alias
+++ b/terminal/.config/alias/ocrmypdf.alias
@@ -1,7 +1,7 @@
 # ============================================================
 # ocrmypdf.alias - Aliase für OCRmyPDF (OCR-Textlayer)
 # ============================================================
-# Zweck       : Gescannte PDFs durchsuchbar machen (deutsch by default)
+# Zweck       : Gescannte PDFs durchsuchbar machen (standardmäßig Deutsch)
 # Pfad        : ~/.config/alias/ocrmypdf.alias
 # Docs        : https://ocrmypdf.readthedocs.io/
 # Nutzt       : -
@@ -34,7 +34,7 @@ pdfocr() {
     ocrmypdf -l "$lang" "$input" "$output"
 }
 
-# Scan optimieren und OCR(pdf, output?) – deskew, clean, rotate-pages, deutsch
+# Scan optimieren und OCR(pdf, output?) – deskew, clean, rotate-pages, Deutsch
 pdfscan() {
     if [[ $# -lt 1 ]]; then
         echo "Verwendung: pdfscan <pdf> [output]" >&2

--- a/terminal/.config/tealdeer/pages/dotfiles.page.md
+++ b/terminal/.config/tealdeer/pages/dotfiles.page.md
@@ -129,7 +129,7 @@
 
 - Jedes Tool hat ALLE Aliase+Funktionen dokumentiert:
 
-`tldr {{7z|bat|brew|btop|exiftool|eza|fastfetch|fd|ffmpeg|fzf|gh|git|kitty|lazygit|magick|rg|starship|yazi|zoxide|zsh}}`
+`tldr {{7z|bat|brew|btop|exiftool|eza|fastfetch|fd|ffmpeg|fzf|gh|git|kitty|lazygit|magick|ocrmypdf|rg|starship|yazi|zoxide|zsh}}`
 
 - Eigene Seiten (ohne offizielle tldr-Basis):
 

--- a/terminal/.config/tealdeer/pages/ocrmypdf.patch.md
+++ b/terminal/.config/tealdeer/pages/ocrmypdf.patch.md
@@ -2,6 +2,6 @@
 
 `pdfocr {{pdf, sprache, output}}`
 
-- dotfiles: Scan optimieren und OCR (deskew, clean, rotate-pages, deutsch):
+- dotfiles: Scan optimieren und OCR (deskew, clean, rotate-pages, Deutsch):
 
 `pdfscan {{pdf, output}}`

--- a/terminal/.config/tealdeer/pages/ocrmypdf.patch.md
+++ b/terminal/.config/tealdeer/pages/ocrmypdf.patch.md
@@ -1,0 +1,7 @@
+- dotfiles: OCR-Textlayer hinzufügen (macht Scans durchsuchbar):
+
+`pdfocr {{pdf, sprache, output}}`
+
+- dotfiles: Scan optimieren und OCR (deskew, clean, rotate-pages, deutsch):
+
+`pdfscan {{pdf, output}}`


### PR DESCRIPTION
## Beschreibung

Integriert `ocrmypdf` (OCR-Textlayer) und `tesseract-lang` (Sprachpakete inkl. `deu`) – bisher fehlte jegliche OCR-Funktionalität. Macht gescannte PDFs (Belege, Verträge, Behördenpost) durchsuchbar.

Neue `ocrmypdf.alias`:

- `pdfocr` – OCR-Textlayer hinzufügen (standardmäßig Deutsch, Sprache wählbar)
- `pdfscan` – Scan-Optimierung (`--deskew --clean --rotate-pages`) + deutsche OCR

`tesseract-lang` liefert kein eigenes Binary (nur `.traineddata`) und ist daher in `skip_formulae` des Health-Checks aufgenommen. `deu` steckt ausschließlich in `tesseract-lang` (Basis-`tesseract` hat nur `eng`/`osd`).

**Review-Findings:** Copilot-Review-Kommentar zur Sprach-Konsistenz im Header adressiert (`393ac5f`): „deutsch by default“ → „standardmäßig Deutsch“, Sprachbezeichnung durchgängig großgeschrieben.

## Art der Änderung

- [x] ✨ Neues Feature
- [x] 🏗️ Setup/Bootstrap

## Checkliste

- [x] Ich habe die Contributing Guidelines gelesen
- [x] `generate-docs.sh --check` ist erfolgreich
- [x] `health-check.sh` zeigt keine Fehler (`ocrmypdf` erkannt, `tesseract-lang` übersprungen)
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare
- [x] Bei neuen Tools: Guard-Check vorhanden

## Zusammenhängende Issues

Closes #435

## Terminal-Ausgabe

Deutsche OCR real an realistischem A4-Scan getestet: alle Umlaute (ä/ö/ü) korrekt erkannt ("Jürgen Müller", "Königsallee", "Düsseldorf", "März"), PDF/A erzeugt, exit 0.

