### PR TITLE
refactor(magick): Bild-Konvertierung auf img*-Präfix vereinheitlichen

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Alle Workflows nutzen [fzf](https://github.com/junegunn/fzf) mit bat-Preview, Ke
 | ---- | ---------- |
 | exiftool | `exifshow`, `exifgps`, `exifstrip`, `exifrename` |
 | ffmpeg | `v2mp3`, `vthumb`, `vcut`, `vcompress`, `v2gif`, `v2mp4`, `vinfo` |
-| magick | `imgresize`, `towebp`, `topng`, `tojpg`, `imgmeta`, `imgsize`, `imgcrop`, `imgstrip` |
+| magick | `imgresize`, `imgwebp`, `imgpng`, `imgjpg`, `imgmeta`, `imgsize`, `imgcrop`, `imgstrip` |
 | poppler | `pdf2txt`, `pdf2img`, `pdfmeta`, `pdfpages`, `pdfsplit`, `pdfmerge` |
 | resvg | `svg2png`, `svgscale` |
 

--- a/terminal/.config/alias/magick.alias
+++ b/terminal/.config/alias/magick.alias
@@ -7,7 +7,7 @@
 # Config      : ~/.config/ImageMagick/policy.xml (Sicherheit)
 # Nutzt       : -
 # Ersetzt     : -
-# Aliase      : imgresize, towebp, topng, tojpg, imgmeta, imgsize, imgcrop, imgstrip
+# Aliase      : imgresize, imgwebp, imgpng, imgjpg, imgmeta, imgsize, imgcrop, imgstrip
 # ============================================================
 
 # Guard   : Nur wenn ImageMagick installiert ist
@@ -34,9 +34,9 @@ imgresize() {
 # Format-Konvertierung
 # ------------------------------------------------------------
 # Bild zu WebP konvertieren(bild, qualität=80, output)
-towebp() {
+imgwebp() {
     if [[ $# -lt 1 ]]; then
-        echo "Verwendung: towebp <bild> [qualität=80] [output.webp]" >&2
+        echo "Verwendung: imgwebp <bild> [qualität=80] [output.webp]" >&2
         return 1
     fi
     local input="$1"
@@ -46,9 +46,9 @@ towebp() {
 }
 
 # Bild zu PNG konvertieren(bild, output)
-topng() {
+imgpng() {
     if [[ $# -lt 1 ]]; then
-        echo "Verwendung: topng <bild> [output.png]" >&2
+        echo "Verwendung: imgpng <bild> [output.png]" >&2
         return 1
     fi
     local input="$1"
@@ -57,9 +57,9 @@ topng() {
 }
 
 # Bild zu JPEG konvertieren(bild, qualität=85, output) – Transparenz wird weiß
-tojpg() {
+imgjpg() {
     if [[ $# -lt 1 ]]; then
-        echo "Verwendung: tojpg <bild> [qualität=85] [output.jpg]" >&2
+        echo "Verwendung: imgjpg <bild> [qualität=85] [output.jpg]" >&2
         return 1
     fi
     local input="$1"

--- a/terminal/.config/tealdeer/pages/magick.patch.md
+++ b/terminal/.config/tealdeer/pages/magick.patch.md
@@ -6,15 +6,15 @@
 
 - dotfiles: Bild zu WebP konvertieren:
 
-`towebp {{bild, qualität, output}}`
+`imgwebp {{bild, qualität, output}}`
 
 - dotfiles: Bild zu PNG konvertieren:
 
-`topng {{bild, output}}`
+`imgpng {{bild, output}}`
 
 - dotfiles: Bild zu JPEG konvertieren (Transparenz wird weiß):
 
-`tojpg {{bild, qualität, output}}`
+`imgjpg {{bild, qualität, output}}`
 
 - dotfiles: Bildinfo anzeigen (Format, Größe, Farbtiefe):
 


### PR DESCRIPTION
## Beschreibung

Vereinheitlicht die Bild-Konvertierungsfunktionen von `magick` auf das `img*`-Domänen-Präfix (konsistent mit `imgresize`, `imgmeta`, `imgsize`, `imgcrop`, `imgstrip`):

- `towebp` → `imgwebp`
- `topng` → `imgpng`
- `tojpg` → `imgjpg`

Damit folgen **alle acht** magick-Funktionen einheitlich dem `img*`-Schema. Das `img2*`-Schema (analog `pdf2txt`/`svg2png`) wurde bewusst verworfen, da `img2webp` (libwebp) und `img2pdf` **echte installierte System-Tools** sind – eine Kollision hätte gegen die Alias-Konventionen verstoßen.

## Art der Änderung

- [x] ♻️ Refactoring

## Checkliste

- [x] Ich habe die Contributing Guidelines gelesen
- [x] `generate-docs.sh --check` ist erfolgreich (README + magick.patch.md regeneriert)
- [x] `health-check.sh` zeigt keine Fehler
- [ ] Screenshots in `docs/assets/` noch aktuell – hero.png (cmds) könnte durch die Namensänderung leicht veralten (non-blocking)

## Zusammenhängende Issues

<!-- Kein Issue – aufgekommen bei der PDF-Tool-Integration (#435/#436) als Konsistenz-Verbesserung -->
