### PR TITLE
fix(git): Branch-Bereinigung verankern und zentralisieren

### DIFF
--- a/terminal/.config/alias/git.alias
+++ b/terminal/.config/alias/git.alias
@@ -83,8 +83,8 @@ if command -v fzf >/dev/null 2>&1; then
                 --preview 'git log --oneline --color=always {1} | head -20' \
                 --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Checkout' 'Ctrl+D: Löschen' 'Ctrl+Y: Branch kopieren'" \
                 --bind 'ctrl-d:execute(read -q "REPLY?Branch {1} löschen? [y/N] " && git branch -d {1}; echo)+reload(git branch --all --color=always | grep -v HEAD)' \
-                --bind "ctrl-y:execute-silent($FZF_HELPER_DIR/action copy-branch {})" | \
-            sed 's/^[* ]*//' | sed 's|remotes/[^/]*/||')
+                --bind "ctrl-y:execute-silent($FZF_HELPER_DIR/action copy-branch {})")
+        branch=$("$FZF_HELPER_DIR/action" strip-branch "$branch")
 
         [[ -n "$branch" ]] && git checkout "$branch"
     }

--- a/terminal/.config/alias/git.alias
+++ b/terminal/.config/alias/git.alias
@@ -80,9 +80,9 @@ if command -v fzf >/dev/null 2>&1; then
         branch=$(git branch --all --color=always | \
             grep -v HEAD | \
             fzf --ansi --query="$query" \
-                --preview 'git log --oneline --color=always {1} | head -20' \
+                --preview "$FZF_HELPER_DIR/action branch-log {}" \
                 --bind "start,resize:transform-header:$FZF_HELPER_DIR/header-wrap 'Enter: Checkout' 'Ctrl+D: Löschen' 'Ctrl+Y: Branch kopieren'" \
-                --bind 'ctrl-d:execute(read -q "REPLY?Branch {1} löschen? [y/N] " && git branch -d {1}; echo)+reload(git branch --all --color=always | grep -v HEAD)' \
+                --bind "ctrl-d:execute($FZF_HELPER_DIR/action branch-delete {})+reload(git branch --all --color=always | grep -v HEAD)" \
                 --bind "ctrl-y:execute-silent($FZF_HELPER_DIR/action copy-branch {})")
         branch=$("$FZF_HELPER_DIR/action" strip-branch "$branch")
 

--- a/terminal/.config/fzf/action
+++ b/terminal/.config/fzf/action
@@ -7,8 +7,8 @@
 # Aufruf      : ~/.config/fzf/action <command> "argument" [...]
 # Nutzt       : platform.zsh (clip)
 # ============================================================
-# Commands: copy, copy-branch, strip-branch, copy-env, edit, git-diff,
-#           git-restore, git-add, zoxide-remove
+# Commands: copy, copy-branch, strip-branch, branch-log, branch-delete, copy-env,
+#           edit, git-diff, git-restore, git-add, zoxide-remove
 # ============================================================
 
 # Plattform-Abstraktionen laden (clip)
@@ -22,13 +22,16 @@ source "${XDG_CONFIG_HOME:-$HOME/.config}/platform.zsh" 2>/dev/null || {
 source "${XDG_CONFIG_HOME:-$HOME/.config}/theme-style" 2>/dev/null
 : "${C_RED:=}" "${C_RESET:=}"
 
-# Branch-Namen aus fzf-Zeile bereinigen – gemeinsame Quelle für copy-branch und
-# strip-branch: ANSI-Codes weg, führende Marker (*/Leerzeichen) und ein
-# vorangestelltes remotes/<remote>/ (verankert, nur am Zeilenanfang entfernt).
+# fzf-Branch-Zeile bereinigen – zwei Stufen für unterschiedliche Ziele:
+#   _strip_marker : ANSI-Codes weg + führende Marker (*/Leerzeichen). Behält
+#     remotes/<remote>/ – git log / git branch -d brauchen den vollen Ref.
+#   _strip_branch : zusätzlich vorangestelltes remotes/<remote>/ (verankert) –
+#     für Checkout/Kopieren, wo der kurze Branch-Name gewünscht ist.
+_strip_marker() {
+    printf '%s' "$*" | sed 's/\x1b\[[0-9;]*m//g; s/^[* ]*//'
+}
 _strip_branch() {
-    printf '%s' "$*" \
-        | sed 's/\x1b\[[0-9;]*m//g; s/^[* ]*//' \
-        | sed 's|^remotes/[^/]*/||'
+    _strip_marker "$*" | sed 's|^remotes/[^/]*/||'
 }
 
 case "${1:-}" in
@@ -47,6 +50,25 @@ case "${1:-}" in
         # Branch-Name aus fzf-Zeile bereinigen (Ausgabe für git-branch Checkout)
         shift
         _strip_branch "$@"
+        ;;
+    branch-log)
+        # Log-Vorschau für git-branch (Input per {}): Marker weg, remotes/ behalten
+        # (git log braucht den vollen Ref – auch für Remote-Branches)
+        shift
+        ref=$(_strip_marker "$*")
+        [[ -z "$ref" ]] && exit 0
+        git log --oneline --color=always "$ref" | head -20
+        ;;
+    branch-delete)
+        # Branch aus fzf-Zeile löschen (Input per {}) – Bestätigung weil destruktiv
+        # "$ref" gequotet → kein Glob-Risiko (der Marker * expandierte sonst zu Dateien)
+        shift
+        ref=$(_strip_marker "$*")
+        [[ -z "$ref" ]] && exit 0
+        printf 'Branch %s löschen? [y/N] ' "$ref"
+        read -q || { echo; exit 0; }
+        echo
+        git branch -d "$ref"
         ;;
     copy-env)
         # Umgebungsvariable aus farbkodierter fzf-Zeile ins Clipboard kopieren
@@ -105,6 +127,8 @@ Commands:
   copy <path>            Pfad ins Clipboard kopieren
   copy-branch <line>     Branch aus git-branch-Zeile bereinigen + kopieren
   strip-branch <line>    Branch aus git-branch-Zeile bereinigen (nur Ausgabe)
+  branch-log <line>      Log-Vorschau für git-branch-Zeile (Marker weg)
+  branch-delete <line>   Branch aus git-branch-Zeile löschen (mit Bestätigung)
   copy-env <fzf-line>    Umgebungsvariable aus vars()-Zeile kopieren
   edit <file> [line]     Datei im Editor öffnen
   git-diff <file>        Git diff für Datei anzeigen

--- a/terminal/.config/fzf/action
+++ b/terminal/.config/fzf/action
@@ -53,22 +53,23 @@ case "${1:-}" in
         ;;
     branch-log)
         # Log-Vorschau für git-branch (Input per {}): Marker weg, remotes/ behalten
-        # (git log braucht den vollen Ref – auch für Remote-Branches)
+        # (git log braucht den vollen Ref – auch für Remote-Branches). -20 statt
+        # | head; abschließendes -- trennt Rev von Pfad (Branch kann wie Datei heißen).
         shift
         ref=$(_strip_marker "$*")
         [[ -z "$ref" ]] && exit 0
-        git log --oneline --color=always "$ref" | head -20
+        git log --oneline --color=always -20 "$ref" --
         ;;
     branch-delete)
         # Branch aus fzf-Zeile löschen (Input per {}) – Bestätigung weil destruktiv
-        # "$ref" gequotet → kein Glob-Risiko (der Marker * expandierte sonst zu Dateien)
+        # "$ref" gequotet + -- → kein Glob, keine Options-Deutung bei führendem -
         shift
         ref=$(_strip_marker "$*")
         [[ -z "$ref" ]] && exit 0
         printf 'Branch %s löschen? [y/N] ' "$ref"
         read -q || { echo; exit 0; }
         echo
-        git branch -d "$ref"
+        git branch -d -- "$ref"
         ;;
     copy-env)
         # Umgebungsvariable aus farbkodierter fzf-Zeile ins Clipboard kopieren

--- a/terminal/.config/fzf/action
+++ b/terminal/.config/fzf/action
@@ -7,8 +7,8 @@
 # Aufruf      : ~/.config/fzf/action <command> "argument" [...]
 # Nutzt       : platform.zsh (clip)
 # ============================================================
-# Commands: copy, copy-branch, copy-env, edit, git-diff, git-restore,
-#           git-add, zoxide-remove
+# Commands: copy, copy-branch, strip-branch, copy-env, edit, git-diff,
+#           git-restore, git-add, zoxide-remove
 # ============================================================
 
 # Plattform-Abstraktionen laden (clip)
@@ -22,6 +22,15 @@ source "${XDG_CONFIG_HOME:-$HOME/.config}/platform.zsh" 2>/dev/null || {
 source "${XDG_CONFIG_HOME:-$HOME/.config}/theme-style" 2>/dev/null
 : "${C_RED:=}" "${C_RESET:=}"
 
+# Branch-Namen aus fzf-Zeile bereinigen – gemeinsame Quelle für copy-branch und
+# strip-branch: ANSI-Codes weg, führende Marker (*/Leerzeichen), remotes/<remote>/-
+# Präfix (verankert, damit remotes/ nur am Zeilenanfang entfernt wird).
+_strip_branch() {
+    printf '%s' "$*" \
+        | sed 's/\x1b\[[0-9;]*m//g; s/^[* ]*//' \
+        | sed 's|^remotes/[^/]*/||'
+}
+
 case "${1:-}" in
     copy)
         # Pfad ins Clipboard kopieren
@@ -31,12 +40,13 @@ case "${1:-}" in
     copy-branch)
         # Branch-Name aus fzf-Zeile bereinigen und kopieren
         # Input per {}: "* main", "  feature-branch", "  remotes/origin/feat/x"
-        # fzf --ansi strippt ANSI-Codes; sed entfernt ANSI als Defense-in-Depth
         shift
-        printf '%s' "$*" \
-            | sed 's/\x1b\[[0-9;]*m//g; s/^[* ]*//' \
-            | sed 's|^remotes/[^/]*/||' \
-            | clip
+        _strip_branch "$@" | clip
+        ;;
+    strip-branch)
+        # Branch-Name aus fzf-Zeile bereinigen (Ausgabe für git-branch Checkout)
+        shift
+        _strip_branch "$@"
         ;;
     copy-env)
         # Umgebungsvariable aus farbkodierter fzf-Zeile ins Clipboard kopieren
@@ -94,6 +104,7 @@ Usage: ~/.config/fzf/action <command> [args...]
 Commands:
   copy <path>            Pfad ins Clipboard kopieren
   copy-branch <line>     Branch aus git-branch-Zeile bereinigen + kopieren
+  strip-branch <line>    Branch aus git-branch-Zeile bereinigen (nur Ausgabe)
   copy-env <fzf-line>    Umgebungsvariable aus vars()-Zeile kopieren
   edit <file> [line]     Datei im Editor öffnen
   git-diff <file>        Git diff für Datei anzeigen

--- a/terminal/.config/fzf/action
+++ b/terminal/.config/fzf/action
@@ -23,8 +23,8 @@ source "${XDG_CONFIG_HOME:-$HOME/.config}/theme-style" 2>/dev/null
 : "${C_RED:=}" "${C_RESET:=}"
 
 # Branch-Namen aus fzf-Zeile bereinigen – gemeinsame Quelle für copy-branch und
-# strip-branch: ANSI-Codes weg, führende Marker (*/Leerzeichen), remotes/<remote>/-
-# Präfix (verankert, damit remotes/ nur am Zeilenanfang entfernt wird).
+# strip-branch: ANSI-Codes weg, führende Marker (*/Leerzeichen) und ein
+# vorangestelltes remotes/<remote>/ (verankert, nur am Zeilenanfang entfernt).
 _strip_branch() {
     printf '%s' "$*" \
         | sed 's/\x1b\[[0-9;]*m//g; s/^[* ]*//' \

--- a/terminal/.config/fzf/action
+++ b/terminal/.config/fzf/action
@@ -53,12 +53,13 @@ case "${1:-}" in
         ;;
     branch-log)
         # Log-Vorschau für git-branch (Input per {}): Marker weg, remotes/ behalten
-        # (git log braucht den vollen Ref – auch für Remote-Branches). -20 statt
-        # | head; abschließendes -- trennt Rev von Pfad (Branch kann wie Datei heißen).
+        # (git log braucht den vollen Ref – auch für Remote-Branches). -20 limitiert;
+        # --end-of-options neutralisiert ein evtl. führendes - im Ref (Pendant zum --
+        # bei branch-delete); abschließendes -- trennt Rev von Pfad (Branch wie Datei).
         shift
         ref=$(_strip_marker "$*")
         [[ -z "$ref" ]] && exit 0
-        git log --oneline --color=always -20 "$ref" --
+        git log --oneline --color=always -20 --end-of-options "$ref" --
         ;;
     branch-delete)
         # Branch aus fzf-Zeile löschen (Input per {}) – Bestätigung weil destruktiv

--- a/terminal/.config/fzf/action
+++ b/terminal/.config/fzf/action
@@ -23,12 +23,14 @@ source "${XDG_CONFIG_HOME:-$HOME/.config}/theme-style" 2>/dev/null
 : "${C_RED:=}" "${C_RESET:=}"
 
 # fzf-Branch-Zeile bereinigen – zwei Stufen für unterschiedliche Ziele:
-#   _strip_marker : ANSI-Codes weg + führende Marker (*/Leerzeichen). Behält
+#   _strip_marker : ANSI-Codes weg + der feste 2-Zeichen-Prefix von `git branch`
+#     (`* ` aktuell, `+ ` Worktree, `  ` sonst) – genau ein Marker + Space, nicht
+#     gierig; erfasst so auch `+ ` und lässt den Namen selbst unangetastet. Behält
 #     remotes/<remote>/ – git log / git branch -d brauchen den vollen Ref.
 #   _strip_branch : zusätzlich vorangestelltes remotes/<remote>/ (verankert) –
 #     für Checkout/Kopieren, wo der kurze Branch-Name gewünscht ist.
 _strip_marker() {
-    printf '%s' "$*" | sed 's/\x1b\[[0-9;]*m//g; s/^[* ]*//'
+    printf '%s' "$*" | sed 's/\x1b\[[0-9;]*m//g; s/^[*+ ] //'
 }
 _strip_branch() {
     _strip_marker "$*" | sed 's|^remotes/[^/]*/||'


### PR DESCRIPTION
## Beschreibung

Behebt einen Bug in `git-branch()`: Die Branch-Namen-Bereinigung nutzte ein **ungeankertes** sed-Pattern (`s|remotes/[^/]*/||`), das `remotes/<remote>/` an **beliebiger** Position im Namen entfernte. Ein lokaler Branch wie `fix/remotes/origin/bug` wurde zu `fix/bug` verstümmelt → `git checkout` landete auf einem falschen/nicht existenten Branch.

Zusätzlich existierte die Bereinigung **doppelt** mit divergenten Patterns. **Lösung:** Bereinigungslogik in `action` als gemeinsame Funktionen (`_strip_marker` + `_strip_branch`) zentralisiert, genutzt von `copy-branch`, `strip-branch`, `branch-log`, `branch-delete`. Eine Quelle, ein verankertes Pattern, kein Drift.

## Review-Findings

1. **Kommentar-Klarheit** (`05c8797`): Zeilenumbruch bei `remotes/<remote>/`-Präfix umformuliert.

2. **`{1}`-Bug in `git-branch()`** (`78230c7`): Preview/Ctrl+D nutzten `{1}`. Bei `* main` ist `{1}` der Marker `*` → `git log`/`git branch -d` liefen auf `*` (Preview/Löschen der aktuellen Branch defekt, Glob-Risiko). Fix: ganze Zeile `{}` + neue Subcommands `branch-log`/`branch-delete` mit `_strip_marker` (ANSI + Marker weg, `remotes/` **behalten**).

3. **`branch-log` Effizienz** (`19eb534`): `| head -20` → `git log -20` (kein SIGPIPE-Abbruch).

4. **`branch-delete` Robustheit** (`19eb534`): `git branch -d -- "$ref"` (führendes `-` nicht als Option).

5. **`branch-log` gegen führendes `-`** (`f1e41ca`): `git log … --end-of-options "$ref" --` (git-log-Pendant zum `--` bei `branch-delete`, da `--` bei git log Pfade einleitet). `--end-of-options -p --` → „bad revision '-p'".

6. **`{}`-Quoting — geprüft sicher, kein Fix** (`git.alias:86`): Review vermutete unquoted-Interpolation. fzf quotet `{}` automatisch (POSIX). Injection-Test: Zeile `x'; touch /tmp/PWN; echo $(whoami)` erreicht `action` als **ein** wörtliches Argument, nichts wird ausgeführt. False Positive.

7. **`_strip_marker` Worktree-Prefix `+ ` + präziser Strip** (`ae8c180`): `s/^[* ]*//` (gierig) ließ den Worktree-Marker `+ ` (bei `git branch --all` mit verlinkten Worktrees) **ungestrippt** → `branch-log`/`branch-delete`/checkout liefen auf `+ <name>` und brachen. Jetzt `s/^[*+ ] //` (genau ein Marker + Space, deckt `* `/`+ `/`  ` ab). Die vom Review genannte Über-Strippung von `*` aus Refnames ist praktisch **unerreichbar** (`git branch '*foo'` → „is not a valid branch name"), der Fix behebt aber den **realen** Worktree-Fall.

**Scope-Prüfung aller `{1}`/`{}`-Nutzungen** (keine weiteren Bugs):

| Funktion | Platzhalter | Status |
| --- | --- | --- |
| `git-log()` | `{1}` = Commit-Hash | ✅ korrekt (Hash hex, fzf-gequotet) |
| `git-branch()` | `{}` = ganze Zeile | 🐛 **behoben** (2–5, 7), `{}` fzf-gequotet (6) |
| `git-stash()` | `{1}` = `stash@{N}` (`--delimiter ':'`) | ✅ korrekt |
| `brew-add`/`rg-live`/`gh-*` | Typ-Marker / Datei / Nummer (Delimiter) | ✅ korrekt |

`git checkout "$branch"` bleibt bewusst **ohne** `--` (sonst Pfad-Checkout statt Branch-Wechsel).

## Art der Änderung

- [x] 🐛 Bugfix
- [x] ♻️ Refactoring

## Checkliste

- [x] Ich habe die Contributing Guidelines gelesen
- [x] `generate-docs.sh --check` ist erfolgreich
- [x] `health-check.sh` zeigt keine Fehler
- [x] Neue Funktionen/Subcommands haben Beschreibungskommentare

## Zusammenhängende Issues

Closes #440

## Terminal-Ausgabe

**#440 + `{1}`-Fix (real getestet):**
- `fix/remotes/origin/bug` unverändert (vorher `fix/bug`); `remotes/origin/feature-x` → `feature-x`
- `branch-log` **live in fzf**: korrektes `git log` statt `ambiguous argument '*'`; `branch-delete` interaktiv → „Deleted branch"; Glob-Sicherheit `* main` → `main`; Live-Checkout → „Switched to branch"

**Findings 3–7 (real getestet):**
- `git log -20` == `| head -20` (20 Zeilen); `--end-of-options -p --` → „bad revision '-p'"
- `git branch -d -- -foo` → als Name behandelt; `git branch -- -foo` → „is not a valid branch name"
- **fzf `{}`-Injection-Test**: `$()`/`;`/Backtick/Single-Quote → 1 wörtliches Argument, keine Ausführung
- **Worktree** (`git worktree add`): `git branch --all` → `+ wt-branch`; `strip-branch` ALT → `+ wt-branch` (Bug), NEU → `wt-branch`; `branch-log` NEU → 3 Zeilen exit 0
- `strip-branch` real über echte `git branch --color=always`-Zeilen: `  feature-x`→`feature-x`, `* main`→`main`, `+ wt-branch`→`wt-branch`
- `generate-docs.sh --check`, `check-header-sync` (23 Funktionen / 3 fzf-Keybindings), `check-executable-permissions`, `zsh -n` — alle grün
