### PR TITLE
fix(setup): EOF-sichere Bestätigungsprompts in restore.sh + geteilte Ask-Helper

### DIFF
--- a/setup/lib/prompts.zsh
+++ b/setup/lib/prompts.zsh
@@ -16,6 +16,11 @@ readonly _SETUP_PROMPTS_LOADED=1
 # geladenes theme-style – ohne Fallback bräche ein unbound $C_MAUVE das Skript ab.
 : "${C_MAUVE:=}" "${C_RESET:=}" "${C_DIM:=}"
 
+# Prompt-Ausgabe auf das controlling tty (sichtbar auch bei umgeleitetem stdout;
+# bei _ask_input würde $() sonst den Prompt einfangen). Die Subshell verwirft den
+# Redirection-Fehler, falls kein tty existiert (non-interaktiv) – ohne Fehler-Spam.
+_tty_print() { ( print "$@" >/dev/tty ) 2>/dev/null; }
+
 # ------------------------------------------------------------
 # Ja/Nein-Abfrage (set -e sicher)
 # ------------------------------------------------------------
@@ -25,11 +30,10 @@ readonly _SETUP_PROMPTS_LOADED=1
 _ask_yes_no() {
     local prompt="$1"
     local answer
-    # Prompt auf /dev/tty statt stdout – sonst bei Umleitung unsichtbar
-    print -rn -- "${C_MAUVE}?${C_RESET} ${prompt} [j/N] " >/dev/tty
+    _tty_print -rn -- "${C_MAUVE}?${C_RESET} ${prompt} [j/N] "
     if ! read -r answer; then
         # EOF (Ctrl-D) → wie "Nein" behandeln
-        print -r -- "" >/dev/tty
+        _tty_print -r -- ""
         return 1
     fi
     # j (deutsch) und y (englisch) als Ja akzeptieren
@@ -46,13 +50,13 @@ _ask_input() {
     local default="${2:-}"
     local answer
     if [[ -n "$default" ]]; then
-        print -rn -- "${C_MAUVE}?${C_RESET} ${prompt} ${C_DIM}[$default]${C_RESET} " >/dev/tty
+        _tty_print -rn -- "${C_MAUVE}?${C_RESET} ${prompt} ${C_DIM}[$default]${C_RESET} "
     else
-        print -rn -- "${C_MAUVE}?${C_RESET} ${prompt} " >/dev/tty
+        _tty_print -rn -- "${C_MAUVE}?${C_RESET} ${prompt} "
     fi
     if ! read -r answer; then
         # EOF (Ctrl-D) → Default zurückgeben
-        print -r -- "" >/dev/tty
+        _tty_print -r -- ""
         print -r -- "$default"
         return 0
     fi

--- a/setup/lib/prompts.zsh
+++ b/setup/lib/prompts.zsh
@@ -1,0 +1,60 @@
+#!/usr/bin/env zsh
+# ============================================================
+# prompts.zsh - EOF-sichere interaktive Prompts
+# ============================================================
+# Zweck       : EOF-sichere Ja/Nein- und Eingabe-Prompts (Ctrl-D = Nein/Default)
+# Pfad        : setup/lib/prompts.zsh
+# Geladen     : setup/restore.sh, setup/modules/ssh-keys.sh
+# Nutzt       : theme-style Farben (mit Fallback)
+# ============================================================
+
+# Mehrfaches Laden verhindern
+[[ -n "${_SETUP_PROMPTS_LOADED:-}" ]] && return 0
+readonly _SETUP_PROMPTS_LOADED=1
+
+# Farb-Fallbacks: prompts.zsh läuft evtl. unter `set -u` (restore.sh) ohne
+# geladenes theme-style – ohne Fallback bräche ein unbound $C_MAUVE das Skript ab.
+: "${C_MAUVE:=}" "${C_RESET:=}" "${C_DIM:=}"
+
+# ------------------------------------------------------------
+# Ja/Nein-Abfrage (set -e sicher)
+# ------------------------------------------------------------
+# read -r liefert Exit 0 solange stdin offen ist; bei EOF (Ctrl-D) Exit 1 →
+# würde unter `set -e` das Skript abbrechen. Daher EOF explizit abfangen.
+# read -q wäre keine Alternative (Exit 1 bereits bei "Nein" → gleicher Abbruch).
+_ask_yes_no() {
+    local prompt="$1"
+    local answer
+    # Prompt auf /dev/tty statt stdout – sonst bei Umleitung unsichtbar
+    print -rn -- "${C_MAUVE}?${C_RESET} ${prompt} [j/N] " >/dev/tty
+    if ! read -r answer; then
+        # EOF (Ctrl-D) → wie "Nein" behandeln
+        print -r -- "" >/dev/tty
+        return 1
+    fi
+    # j (deutsch) und y (englisch) als Ja akzeptieren
+    [[ "$answer" == [jJyY] ]]
+}
+
+# ------------------------------------------------------------
+# Eingabe mit optionalem Vorschlag (set -e sicher)
+# ------------------------------------------------------------
+# Prompt auf /dev/tty, Ergebnis auf stdout – so fängt $(...) nur die Antwort,
+# nicht den Prompt. Bei EOF wird der Default zurückgegeben (Exit 0).
+_ask_input() {
+    local prompt="$1"
+    local default="${2:-}"
+    local answer
+    if [[ -n "$default" ]]; then
+        print -rn -- "${C_MAUVE}?${C_RESET} ${prompt} ${C_DIM}[$default]${C_RESET} " >/dev/tty
+    else
+        print -rn -- "${C_MAUVE}?${C_RESET} ${prompt} " >/dev/tty
+    fi
+    if ! read -r answer; then
+        # EOF (Ctrl-D) → Default zurückgeben
+        print -r -- "" >/dev/tty
+        print -r -- "$default"
+        return 0
+    fi
+    print -r -- "${answer:-$default}"
+}

--- a/setup/lib/prompts.zsh
+++ b/setup/lib/prompts.zsh
@@ -19,7 +19,9 @@ readonly _SETUP_PROMPTS_LOADED=1
 # Prompt-Ausgabe auf das controlling tty (sichtbar auch bei umgeleitetem stdout;
 # bei _ask_input würde $() sonst den Prompt einfangen). Die Subshell verwirft den
 # Redirection-Fehler, falls kein tty existiert (non-interaktiv) – ohne Fehler-Spam.
-_tty_print() { ( print "$@" >/dev/tty ) 2>/dev/null; }
+# || true: Ausgabe ist best-effort → immer Exit 0, damit ein Aufruf unter `set -e`
+# nie abbricht (sonst würde der EOF/Default-Fallback nicht erreicht).
+_tty_print() { ( print "$@" >/dev/tty ) 2>/dev/null || true; }
 
 # ------------------------------------------------------------
 # Ja/Nein-Abfrage (set -e sicher)

--- a/setup/modules/ssh-keys.sh
+++ b/setup/modules/ssh-keys.sh
@@ -33,44 +33,11 @@ typeset -gr _SSH_CONFIG="$_SSH_DIR/config"
 typeset -gr _ALLOWED_SIGNERS="$_SSH_DIR/allowed_signers"
 
 # ------------------------------------------------------------
-# Helper: Ja/Nein-Abfrage (set -e sicher)
+# Interaktive Prompts (EOF-sicher) – geteilt mit restore.sh
 # ------------------------------------------------------------
-# read -r gibt immer Exit 0 zurück (solange stdin offen).
-# read -q würde Exit 1 bei "Nein" geben → set -e Crash.
-_ask_yes_no() {
-    local prompt="$1"
-    local answer
-    # Prompt auf /dev/tty statt stdout – sonst ist er bei Umleitung unsichtbar
-    print -rn -- "${C_MAUVE}?${C_RESET} ${prompt} [j/N] " >/dev/tty
-    if ! read -r answer; then
-        # EOF (Ctrl-D) → wie "Nein" behandeln
-        print -r -- "" >/dev/tty
-        return 1
-    fi
-    [[ "$answer" == [jJ] ]]
-}
-
-# ------------------------------------------------------------
-# Helper: Eingabe mit optionalem Vorschlag
-# ------------------------------------------------------------
-_ask_input() {
-    local prompt="$1"
-    local default="${2:-}"
-    local answer
-
-    # Prompt auf /dev/tty statt stdout – sonst fängt $() den Prompt ab
-    if [[ -n "$default" ]]; then
-        print -rn -- "${C_MAUVE}?${C_RESET} ${prompt} ${C_DIM}[$default]${C_RESET} " >/dev/tty
-    else
-        print -rn -- "${C_MAUVE}?${C_RESET} ${prompt} " >/dev/tty
-    fi
-    if ! read -r answer; then
-        # EOF (Ctrl-D) → Default zurückgeben
-        print -r -- "" >/dev/tty
-        print -r -- "$default"
-        return 0
-    fi
-    print -r -- "${answer:-$default}"
+source "${0:A:h:h}/lib/prompts.zsh" || {
+    echo "FEHLER: prompts.zsh nicht gefunden" >&2
+    return 1
 }
 
 # ------------------------------------------------------------
@@ -351,8 +318,9 @@ _configure_ssh_hosts() {
             continue
         fi
 
-        # Prüfe ob Host bereits in Config existiert
-        if [[ -f "$_SSH_CONFIG" ]] && grep -qxF "Host $alias_name" "$_SSH_CONFIG" 2>/dev/null; then
+        # Prüfe ob Host bereits in Config existiert (auch eingerückt / Mehrfach-
+        # Alias "Host a b"; Kommentarzeilen via [^#] ausgeschlossen)
+        if [[ -f "$_SSH_CONFIG" ]] && grep -qE "^[[:space:]]*Host[[:space:]]+([^#]*[[:space:]])?${alias_name}([[:space:]]|$)" "$_SSH_CONFIG" 2>/dev/null; then
             warn "Host '$alias_name' bereits in SSH-Config vorhanden – übersprungen"
             continue
         fi

--- a/setup/modules/ssh-keys.sh
+++ b/setup/modules/ssh-keys.sh
@@ -319,8 +319,10 @@ _configure_ssh_hosts() {
         fi
 
         # Prüfe ob Host bereits in Config existiert (auch eingerückt / Mehrfach-
-        # Alias "Host a b"; Kommentarzeilen via [^#] ausgeschlossen)
-        if [[ -f "$_SSH_CONFIG" ]] && grep -qE "^[[:space:]]*Host[[:space:]]+([^#]*[[:space:]])?${alias_name}([[:space:]]|$)" "$_SSH_CONFIG" 2>/dev/null; then
+        # Alias "Host a b"; Kommentarzeilen via [^#] ausgeschlossen). alias_name
+        # ist auf [A-Za-z0-9._-] validiert → nur '.' ist ERE-aktiv, daher escapen.
+        local alias_re="${alias_name//./\\.}"
+        if [[ -f "$_SSH_CONFIG" ]] && grep -qE "^[[:space:]]*Host[[:space:]]+([^#]*[[:space:]])?${alias_re}([[:space:]]|$)" "$_SSH_CONFIG" 2>/dev/null; then
             warn "Host '$alias_name' bereits in SSH-Config vorhanden – übersprungen"
             continue
         fi

--- a/setup/restore.sh
+++ b/setup/restore.sh
@@ -58,6 +58,12 @@ fi
 # Farb-Variablen: Defaults für Fallback-Pfad (theme-style nicht geladen)
 : "${C_YELLOW:=}" "${C_RESET:=}"
 
+# EOF-sichere Prompt-Helper (_ask_yes_no) – geteilt mit ssh-keys.sh
+source "${SCRIPT_DIR}/lib/prompts.zsh" || {
+    err "prompts.zsh nicht gefunden – Abbruch"
+    exit 1
+}
+
 # ------------------------------------------------------------
 # Prüfungen
 # ------------------------------------------------------------
@@ -213,7 +219,6 @@ cleanup_brew_packages() {
     local skip_confirm="$1"
     local dry_run="$2"
     local brewfile="${DOTFILES_DIR}/setup/Brewfile"
-    local response
 
     if ! command -v brew >/dev/null 2>&1; then
         warn "Homebrew nicht gefunden – Paketentfernung übersprungen"
@@ -255,9 +260,7 @@ cleanup_brew_packages() {
             else
                 local do_remove=true
                 if [[ "$skip_confirm" != "true" ]]; then
-                    echo -n "Diese ${#to_remove[@]} Formulae entfernen? [y/N] "
-                    read -r response
-                    [[ ! "$response" =~ ^[Yy]$ ]] && do_remove=false
+                    _ask_yes_no "Diese ${#to_remove[@]} Formulae entfernen?" || do_remove=false
                 fi
                 if [[ "$do_remove" == "true" ]]; then
                     for pkg in "${to_remove[@]}"; do
@@ -304,9 +307,7 @@ cleanup_brew_packages() {
             else
                 local do_remove=true
                 if [[ "$skip_confirm" != "true" ]]; then
-                    echo -n "Diese ${#to_remove_casks[@]} Casks entfernen? [y/N] "
-                    read -r response
-                    [[ ! "$response" =~ ^[Yy]$ ]] && do_remove=false
+                    _ask_yes_no "Diese ${#to_remove_casks[@]} Casks entfernen?" || do_remove=false
                 fi
                 if [[ "$do_remove" == "true" ]]; then
                     for pkg in "${to_remove_casks[@]}"; do
@@ -366,9 +367,7 @@ cleanup_brew_packages() {
                 else
                     local do_remove=true
                     if [[ "$skip_confirm" != "true" ]]; then
-                        echo -n "Diese ${#to_remove_mas[@]} MAS-Apps entfernen? [y/N] "
-                        read -r response
-                        [[ ! "$response" =~ ^[Yy]$ ]] && do_remove=false
+                        _ask_yes_no "Diese ${#to_remove_mas[@]} MAS-Apps entfernen?" || do_remove=false
                     fi
                     if [[ "$do_remove" == "true" ]]; then
                         for app_id in "${to_remove_mas_ids[@]}"; do
@@ -413,9 +412,7 @@ cleanup_brew_packages() {
             else
                 local do_remove=true
                 if [[ "$skip_confirm" != "true" ]]; then
-                    echo -n "Diese ${#to_remove_taps[@]} Taps entfernen? [y/N] "
-                    read -r response
-                    [[ ! "$response" =~ ^[Yy]$ ]] && do_remove=false
+                    _ask_yes_no "Diese ${#to_remove_taps[@]} Taps entfernen?" || do_remove=false
                 fi
                 if [[ "$do_remove" == "true" ]]; then
                     for tap in "${to_remove_taps[@]}"; do
@@ -440,7 +437,6 @@ cleanup_brew_packages() {
 cleanup_repository() {
     local skip_confirm="$1"
     local dry_run="$2"
-    local response
 
     # Sicherheitscheck: DOTFILES_DIR muss gesetzt, unter $HOME und ein Git-Repo sein
     if [[ -z "$DOTFILES_DIR" || "$DOTFILES_DIR" == "/" ]]; then
@@ -468,9 +464,7 @@ cleanup_repository() {
 
     if [[ "$skip_confirm" != "true" ]]; then
         echo "${C_YELLOW}WARNUNG:${C_RESET} Dies löscht das gesamte dotfiles-Repository unwiderruflich!"
-        echo -n "Repository entfernen? [y/N] "
-        read -r response
-        if [[ ! "$response" =~ ^[Yy]$ ]]; then
+        if ! _ask_yes_no "Repository entfernen?"; then
             dim "Repository-Entfernung übersprungen"
             return 0
         fi
@@ -487,7 +481,6 @@ main() {
     local skip_confirm=false
     local do_cleanup=false
     local dry_run=false
-    local response
 
     # Argumente parsen
     while [[ $# -gt 0 ]]; do
@@ -602,9 +595,7 @@ main() {
         echo "  • Stellt gesicherte Originaldateien wieder her"
         echo "  • Setzt Terminal-Profil auf 'Basic' zurück"
         echo ""
-        echo -n "Fortfahren? [y/N] "
-        read -r response
-        if [[ ! "$response" =~ ^[Yy]$ ]]; then
+        if ! _ask_yes_no "Fortfahren?"; then
             echo "Abgebrochen."
             return 0
         fi


### PR DESCRIPTION
## Beschreibung

`setup/restore.sh` brach bei EOF (Ctrl-D) an seinen sechs Bestätigungsprompts unter `set -euo pipefail` **hart ab** — mitten in der Deinstallation (z. B. nach dem Entfernen der Symlinks, vor der Backup-Wiederherstellung → inkonsistenter Zwischenzustand, kein Datenverlust). `ssh-keys.sh` löste dasselbe Problem bereits mit `_ask_yes_no`/`_ask_input`, die EOF explizit als „Nein"/Default behandeln.

**Lösung (DRY):** Die beiden Helper in **`setup/lib/prompts.zsh`** zentralisiert; `restore.sh` und `ssh-keys.sh` teilen sie (netto −41 Zeilen Duplikat).

### Finding 1 — EOF-Abbruch unter `set -e` (🟢)

Die sechs `read -r response`-Prompts (Formulae/Casks/MAS-Apps/Taps/Repo/Fortfahren) nutzen jetzt `_ask_yes_no`. EOF → „Nein" (sicherer Default bei destruktivem Cleanup), kein Skript-Abbruch. Alle Aufrufe stehen in `if`/`||`-Kontext — Pflicht, da `_ask_yes_no` bei „Nein" Exit 1 liefert und ein bloßer Aufruf unter `set -e` sonst crashen würde. `_ask_yes_no` akzeptiert `j` **und** `y` (Prompt `[j/N]`, damit bisherige `y`-Nutzer von restore.sh nicht überrascht werden).

### Finding 2 — SSH-Host-Duplikat-Erkennung (⚪)

`grep -qxF "Host x"` erkannte nur exakte Zeilen → neue Regex erkennt auch eingerückte und Mehrfach-Alias-Zeilen (`Host a b`) und ignoriert Kommentare.

### Zusätzlich — No-TTY-Robustheit

`_tty_print`-Helper (Subshell `( print >/dev/tty ) 2>/dev/null || true`) unterdrückt `device not configured`, falls kein controlling tty vorhanden ist (non-interaktiv). `2>/dev/null` am Kommando allein reicht nicht — zsh meldet den Redirection-Fehler auf Shell-Ebene.

### Review-Findings (Copilot, `f63ac3c`)

1. **`_tty_print` immer Exit 0**: Ohne controlling tty scheiterte die Subshell-Redirection → Exit 1. In einem bloßen Aufruf-Kontext hätte `set -e` das Skript **vor** dem EOF/Default-Fallback abgebrochen. `|| true` entkoppelt die best-effort-Ausgabe vom Aufruf-Kontext (empirisch via `os.setsid()` bestätigt).
2. **`alias_name` in SSH-Regex escapen**: `${alias_name}` war unescaped im ERE; `.` (in `validate_ssh_alias` erlaubt) wirkte als Wildcard → `foo.bar` matchte `fooXbar` (False-Positive, Host fälschlich als „vorhanden" übersprungen). Jetzt `${alias_name//./\.}` — nur `.` ist ERE-aktiv (`-`/`_` literal).

## Art der Änderung

- [x] 🐛 Bugfix
- [x] ♻️ Refactoring
- [x] 🏗️ Setup/Bootstrap

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare (falls zutreffend)

## Zusammenhängende Issues

Closes #439

## Screenshots / Terminal-Ausgabe

**Finding 1 – EOF (real reproduziert + behoben):**
- Repro: `printf '' | zsh -c 'set -euo pipefail; read -r r; echo x'` → exit 1 (Bug bestätigt)
- NEU: `_ask_yes_no` bei EOF → „Nein", Zeile danach erreicht (exit 0, kein Crash)
- Eingaben `j`/`J`/`y`/`Y` → Ja; `n`/`x`/leer → Nein; `_ask_input` EOF/leer → Default
- 3 verwaiste `local response`-Deklarationen entfernt

**Finding 2 + Regex-Escaping (real getestet):**
- `indented` / `multi1` / `multi2` (eingerückt/Mehrfach) → jetzt erkannt (vorher nicht)
- `foo` matcht nicht `foobar`; Kommentarzeilen ignoriert
- Alias `foo.bar` matcht **nicht** mehr `fooXbar` (`.` escaped); echter `Host foo.bar` weiterhin erkannt

**No-TTY (via `os.setsid()`):** kein `device`-Spam, `_tty_print` immer exit 0 (auch bloßer Aufruf unter `set -e`), kein Crash; `_ask_input` in `$()` fängt nur die Antwort (nicht den Prompt).

**Checks:** `zsh -n` (3 Dateien), `generate-docs --check`, `check-header-alignment`, `check-executable-permissions` (prompts.zsh 644), `check-platform-sync`, `check-alias-format`, Generator-Tests, `health-check` — alle grün.
