### PR TITLE
chore: Konsistenz-Findings aus Repo-Review beheben (CI-Pin, mas, LS_COLORS-Guard, platform.zsh)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -157,5 +157,6 @@ jobs:
           echo "Prüfe Markdown-Dateien..."
           # Config aus terminal/.config/ (wird lokal via Stow verlinkt)
           # markdownlint-cli2 via npx – Node.js auf ubuntu-latest vorinstalliert
-          npx --yes markdownlint-cli2@0.22.0 --config terminal/.config/markdownlint-cli2/.markdownlint-cli2.jsonc '**/*.md' '#node_modules'
+          # Pin folgt der lokalen brew-Version – beim brew-Bump nachziehen (markdownlint-cli2 --help)
+          npx --yes markdownlint-cli2@0.23.2 --config terminal/.config/markdownlint-cli2/.markdownlint-cli2.jsonc '**/*.md' '#node_modules'
           echo "✔ Markdown OK"

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -198,6 +198,7 @@ ff                                  # System-Info anzeigen
 | [`jq`](https://jqlang.org/) | JSON-Prozessor |
 | [`lazygit`](https://github.com/jesseduffield/lazygit) | Git-TUI |
 | [`markdownlint-cli2`](https://github.com/DavidAnson/markdownlint-cli2) | Markdown-Linter |
+| [`mas`](https://github.com/mas-cli/mas) | Mac App Store CLI |
 | [`ocrmypdf`](https://ocrmypdf.readthedocs.io/en/latest/) | OCR-Textlayer für PDFs |
 | [`pdftk-java`](https://gitlab.com/pdftk-java/pdftk) | PDF-Formular-Toolkit |
 | [`poppler`](https://poppler.freedesktop.org/) | PDF-Rendering |
@@ -214,7 +215,6 @@ ff                                  # System-Info anzeigen
 | [`zoxide`](https://github.com/ajeetdsouza/zoxide) | Smartes cd mit Frecency |
 | [`zsh-autosuggestions`](https://github.com/zsh-users/zsh-autosuggestions) | History-Vorschläge |
 | [`zsh-syntax-highlighting`](https://github.com/zsh-users/zsh-syntax-highlighting) | Syntax-Highlighting |
-| [`mas`](https://github.com/mas-cli/mas) | Mac App Store CLI |
 
 ### Homebrew Casks
 

--- a/setup/Brewfile
+++ b/setup/Brewfile
@@ -28,6 +28,7 @@ brew "imagemagick"                          # Bild-Manipulation | https://imagem
 brew "jq"                                   # JSON-Prozessor | https://jqlang.org/
 brew "lazygit"                              # Git-TUI | https://github.com/jesseduffield/lazygit
 brew "markdownlint-cli2"                    # Markdown-Linter | https://github.com/DavidAnson/markdownlint-cli2
+brew "mas"                                  # Mac App Store CLI | https://github.com/mas-cli/mas
 brew "ocrmypdf"                             # OCR-Textlayer für PDFs | https://ocrmypdf.readthedocs.io/en/latest/
 brew "pdftk-java"                           # PDF-Formular-Toolkit | https://gitlab.com/pdftk-java/pdftk
 brew "poppler"                              # PDF-Rendering | https://poppler.freedesktop.org/
@@ -44,7 +45,6 @@ brew "yazi"                                 # File Manager | https://yazi-rs.git
 brew "zoxide"                               # Smartes cd mit Frecency | https://github.com/ajeetdsouza/zoxide
 brew "zsh-autosuggestions"                  # History-Vorschläge | https://github.com/zsh-users/zsh-autosuggestions
 brew "zsh-syntax-highlighting"              # Syntax-Highlighting | https://github.com/zsh-users/zsh-syntax-highlighting
-brew "mas"                                  # Mac App Store CLI | https://github.com/mas-cli/mas
 
 # ------------------------------------------------------------
 # Homebrew Casks

--- a/terminal/.config/platform.zsh
+++ b/terminal/.config/platform.zsh
@@ -3,6 +3,7 @@
 # ============================================================
 # Zweck       : Einheitliche Funktionen für macOS und Linux
 # Pfad        : ~/.config/platform.zsh (nach stow)
+# Docs        : CONTRIBUTING.md (Cross-Platform Abstraktionen)
 # Geladen     : Früh in .zshrc (vor Aliase)
 # ============================================================
 # Funktionen:

--- a/terminal/.zshrc
+++ b/terminal/.zshrc
@@ -101,8 +101,9 @@ typeset -gx \
 #   bd=Mauve/Sky  cd=Mauve/Yellow  su=Crust/Red
 #   sg=Crust/Sky  tw=Crust/Green  ow=Crust/Yellow
 #
-# Guard: Nur setzen wenn RGB-Variablen aus theme-style vorhanden sind
-if [[ -n ${RGB_MAUVE-} && -n ${RGB_BLUE-} && -n ${RGB_GREEN-} && -n ${RGB_YELLOW-} ]]; then
+# Guard: Nur setzen wenn alle 8 verwendeten RGB-Variablen aus theme-style vorhanden sind
+if [[ -n ${RGB_MAUVE-} && -n ${RGB_BLUE-} && -n ${RGB_GREEN-} && -n ${RGB_YELLOW-} &&
+      -n ${RGB_SKY-} && -n ${RGB_CRUST-} && -n ${RGB_RED-} && -n ${RGB_SURFACE1-} ]]; then
     export LS_COLORS="di=38;2;${RGB_MAUVE}:ln=38;2;${RGB_BLUE}:so=38;2;${RGB_GREEN}:pi=38;2;${RGB_YELLOW}:ex=38;2;${RGB_GREEN}:bd=38;2;${RGB_MAUVE};48;2;${RGB_SKY}:cd=38;2;${RGB_MAUVE};48;2;${RGB_YELLOW}:su=38;2;${RGB_CRUST};48;2;${RGB_RED}:sg=38;2;${RGB_CRUST};48;2;${RGB_SKY}:tw=38;2;${RGB_CRUST};48;2;${RGB_GREEN}:ow=38;2;${RGB_CRUST};48;2;${RGB_YELLOW}"
 
     # Completion-Farben: LS_COLORS für Dateitypen + Catppuccin Highlight für Auswahl


### PR DESCRIPTION
## Beschreibung

Behebt alle vier Konsistenz-Findings aus dem Repo-Review vom 2026-06-11 (#444). Jedes Finding wurde vor der Umsetzung am aktuellen Code re-verifiziert und mit echten Tests belegt:

1. **CI-Pin markdownlint-cli2 0.22.0 → 0.23.2:** Die Drift war seit dem Review gewachsen (lokal brew 0.23.2, Minor-Sprung statt Patch-Differenz). Statt nur Kommentar deshalb Pin-Bump plus Update-Hinweis. Vorab bewiesen: `npx markdownlint-cli2@0.23.2` läuft grün über alle 19 Markdown-Dateien (0 Findings).
2. **Brewfile: mas alphabetisch einsortiert.** Git-Historie (`0bc1be5`) zeigt: mas wurde ans Ende der damals unsortieren 6-Tool-Liste angehängt, keine bewusste „Meta-Tool"-Entscheidung. `BREW_TO_ALT[mas]=skip` existiert, `brew bundle check` grün, `docs/setup.md` per Generator nachgezogen.
3. **LS_COLORS-Guard prüft alle 8 verwendeten RGB-Variablen statt 4.** Negativ-Test belegt die Lücke: Bei fehlender `RGB_SURFACE1` exportierte der alte Guard eine abgeschnittene Escape-Sequenz (`ma=1;38;2;203;166;247;48;2;`). Positiv-/Negativ-Test plus Live-Test in interaktiver zsh grün.
4. **platform.zsh: Docs-Header-Feld ergänzt.** Nachweislich die einzige Shell-Datei ohne das Pflichtfeld. Muster von `check-header-sync.sh` übernommen: `CONTRIBUTING.md (Cross-Platform Abstraktionen)` — der Anker existiert.

## Art der Änderung

- [ ] 🐛 Bugfix
- [ ] ✨ Neues Feature
- [ ] 📝 Dokumentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Konfiguration
- [x] 🛠️ Maintenance/Chore
- [ ] 🏗️ Setup/Bootstrap
- [ ] 🎨 Theming
- [ ] 🧪 Testing
- [ ] 🔒 Security
- [ ] 🚀 Performance

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare (falls zutreffend)
- [x] Bei neuen Tools: Guard-Check vorhanden (falls zutreffend)
- [x] Screenshots in `docs/assets/` noch aktuell (falls zutreffend)

### Bei Theme-/Config-Änderungen in `.config/*` (falls zutreffend)

- [x] Theme-Quellen-Tabelle in `theme-style` geprüft (Zeile 13-42)
- [x] Status aktualisiert falls Upstream-Abweichung (`upstream+X`) — keine Upstream-Abweichung, nur Guard/Header
- [x] Semantische Farben eingehalten (siehe CONTRIBUTING.md → Theming)

## Zusammenhängende Issues

Closes #444

Zeilen-Drift durch diesen PR in #432 und #442 vermerkt (Issue-Bodies aktualisiert).

## Screenshots / Terminal-Ausgabe

```text
=== Guard-Negativ-Test (RGB_SURFACE1 fehlt) ===
ALT: Guard passt trotz fehlender RGB_SURFACE1 → zstyle ma=1;38;2;203;166;247;48;2; (kaputt)
NEU: Guard blockt korrekt → kein kaputter Export

=== markdownlint-cli2@0.23.2 (exakter CI-Befehl) ===
Linting: 19 files — Summary: 0 issues in 0 files

=== Pre-Commit (Commit d566c6d) ===
✔ Alle Checks bestanden
```
