### PR TITLE
docs(bat): Warum-Kommentare für Syntax-Mappings präzisieren

### DIFF
--- a/terminal/.config/bat/config
+++ b/terminal/.config/bat/config
@@ -37,13 +37,16 @@
 # ------------------------------------------------------------
 # Syntax-Mappings (Dateiendung → Sprache)
 # ------------------------------------------------------------
-# Alias-Dateien als Shell/Bash behandeln
+# ZSH-Dateien → Bash-Highlighting (bat hat keine native ZSH-Syntax,
+# Bash deckt ~95 % der ZSH-Syntax ab)
 --map-syntax "*.alias:Bash"
 
-# Zsh-Konfigurationsdateien
+# Nötig für bat < 0.26.0 (Linux/apt): builtin-Erkennung der
+# zsh-Dotfiles kam erst mit v0.26.0 (sharkdp/bat PR #3262)
 --map-syntax ".zshrc:Bash"
 --map-syntax ".zshenv:Bash"
 --map-syntax ".zprofile:Bash"
+--map-syntax ".zlogin:Bash"
 
 # Brewfile als Ruby
 --map-syntax "Brewfile:Ruby"

--- a/terminal/.config/bat/config
+++ b/terminal/.config/bat/config
@@ -37,8 +37,8 @@
 # ------------------------------------------------------------
 # Syntax-Mappings (Dateiendung → Sprache)
 # ------------------------------------------------------------
-# ZSH-Dateien → Bash-Highlighting (bat hat keine native ZSH-Syntax,
-# Bash deckt ~95 % der ZSH-Syntax ab)
+# .alias-Dateien (ZSH-Syntax) → Bash-Highlighting: bat hat keine
+# eigenständige ZSH-Sprache, Bash deckt den Großteil der Syntax ab
 --map-syntax "*.alias:Bash"
 
 # Nötig für bat < 0.26.0 (Linux/apt): builtin-Erkennung der


### PR DESCRIPTION
## Beschreibung

Ersetzt den Papageien-Kommentar über den bat-Syntax-Mappings durch Warum-Erklärungen (#427) — mit zwei Bonus-Funden aus der Validierung:

1. **`.alias:Bash`:** Kommentar erklärt jetzt das Warum (bat hat keine eigenständige ZSH-Syntax). Empirisch belegt: ohne Mapping keine Erkennung, mit `--language=Bash` identisches Rendering (Escape-Sequenz-Diff). Präzisierung zum Issue-Text: `bat --list-languages | grep -i zsh` liefert einen Treffer — `zsh` ist Dateiendung der eingebauten Bash-Syntax, nur eine *eigene* ZSH-Sprache fehlt.
2. **Bonus-Fund 1 — zsh-Dotfile-Mappings sind Altversions-Absicherung, keine Redundanz:** Auf bat 0.26.1 builtin erkannt, aber die builtin-Erkennung kam erst mit **v0.26.0** (sharkdp/bat PR #3262, CHANGELOG verifiziert). Linux/apt (Debian, Raspberry Pi OS) liefert älter → Mappings bleiben, Kommentar dokumentiert das jetzt. Ein vorschnelles „redundant, weg damit" hätte einen Linux-Regression verursacht.
3. **Bonus-Fund 2 — `.zlogin` fehlte:** Das Repo stowt terminal/.zlogin, es war aber das einzige zsh-Dotfile ohne Mapping. Ergänzt.

## Art der Änderung

- [ ] 🐛 Bugfix
- [ ] ✨ Neues Feature
- [x] 📝 Dokumentation
- [ ] ♻️ Refactoring
- [x] 🔧 Konfiguration
- [ ] 🛠️ Maintenance/Chore
- [ ] 🏗️ Setup/Bootstrap
- [ ] 🎨 Theming
- [ ] 🧪 Testing
- [ ] 🔒 Security
- [ ] 🚀 Performance

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare (falls zutreffend)
- [x] Bei neuen Tools: Guard-Check vorhanden (falls zutreffend)
- [x] Screenshots in `docs/assets/` noch aktuell (falls zutreffend)

### Bei Theme-/Config-Änderungen in `.config/*` (falls zutreffend)

- [x] Theme-Quellen-Tabelle in `theme-style` geprüft (Zeile 13-42) — nicht betroffen
- [x] Status aktualisiert falls Upstream-Abweichung (`upstream+X`) — nicht betroffen
- [x] Semantische Farben eingehalten (siehe CONTRIBUTING.md → Theming)

## Zusammenhängende Issues

Closes #427

## Screenshots / Terminal-Ausgabe

```text
=== Mapping-Notwendigkeit (.alias) ===
ohne Mapping: keine Bash-Erkennung | mit --language=Bash: identisches Rendering ✓

=== Altversions-Beweis ===
bat CHANGELOG v0.26.0: "Add missing mappings for various bash/zsh files, see PR #3262"

=== Live-Test ===
bat --config-file → gestowte Config, Rendering OK
Pre-Commit: ✔ Alle Checks bestanden
```
