### PR TITLE
refactor(stow): Package-Erkennung in geteilte Quelle zentralisieren

### DIFF
--- a/setup/lib/prompts.zsh
+++ b/setup/lib/prompts.zsh
@@ -8,9 +8,10 @@
 # Nutzt       : theme-style Farben (mit Fallback)
 # ============================================================
 
-# Mehrfaches Laden verhindern
+# Mehrfaches Laden verhindern (typeset -gr: bleibt auch beim Sourcen
+# aus Funktions-Scope global – nacktes readonly wäre dort lokal)
 [[ -n "${_SETUP_PROMPTS_LOADED:-}" ]] && return 0
-readonly _SETUP_PROMPTS_LOADED=1
+typeset -gr _SETUP_PROMPTS_LOADED=1
 
 # Farb-Fallbacks: prompts.zsh läuft evtl. unter `set -u` (restore.sh) ohne
 # geladenes theme-style – ohne Fallback bräche ein unbound $C_MAUVE das Skript ab.

--- a/setup/lib/stow-packages.zsh
+++ b/setup/lib/stow-packages.zsh
@@ -1,0 +1,51 @@
+#!/usr/bin/env zsh
+# ============================================================
+# stow-packages.zsh - Stow-Package-Erkennung (geteilte Quelle)
+# ============================================================
+# Zweck       : Erkennt Stow-Packages dynamisch aus der Repo-Struktur
+# Pfad        : setup/lib/stow-packages.zsh
+# Geladen     : setup/modules/backup.sh (Bootstrap),
+#               dotstow() in terminal/.config/alias/dotfiles.alias (Laufzeit)
+# Nutzt       : - (bewusst ohne _core.sh: dotstow lädt kein Bootstrap-Core)
+# ============================================================
+
+# Mehrfaches Laden verhindern
+[[ -n "${_STOW_PACKAGES_LOADED:-}" ]] && return 0
+readonly _STOW_PACKAGES_LOADED=1
+
+# Ermittelt Stow-Packages dynamisch aus der Verzeichnisstruktur.
+# Ein Package ist ein Verzeichnis mit mindestens einer Dotfile
+# oder einem .config-Unterverzeichnis.
+# Aufruf: _get_stow_packages [basis-verzeichnis]
+# Ohne Argument wird $DOTFILES_DIR verwendet (Bootstrap-Kontext).
+_get_stow_packages() {
+    # Lokal normalisierte Optionen: User-Shells (dotstow) können
+    # glob_dots/nomatch abweichend gesetzt haben
+    emulate -L zsh
+
+    local base="${1:-${DOTFILES_DIR:-}}"
+    if [[ -z "$base" || ! -d "$base" ]]; then
+        echo "FEHLER: _get_stow_packages: Basis-Verzeichnis fehlt oder existiert nicht: '$base'" >&2
+        return 1
+    fi
+
+    local dir name
+    for dir in "$base"/*/(N); do
+        name="${dir%/}"
+        name="${name##*/}"
+
+        # Bekannte Nicht-Packages überspringen
+        # (Dot-Verzeichnisse zusätzlich als Schutz bei aktivem glob_dots)
+        [[ "$name" == "setup" ]] && continue
+        [[ "$name" == "docs" ]] && continue
+        [[ "$name" == ".git" ]] && continue
+        [[ "$name" == ".backup" ]] && continue
+        [[ "$name" == ".github" ]] && continue
+
+        # Package-Heuristik: Dotfiles oder .config-Unterverzeichnis
+        if [[ -n "$(find "$dir" -maxdepth 1 -name '.*' -not -name '.DS_Store' -type f 2>/dev/null | head -1)" ]] ||
+           [[ -d "${dir}.config" ]]; then
+            echo "$name"
+        fi
+    done
+}

--- a/setup/lib/stow-packages.zsh
+++ b/setup/lib/stow-packages.zsh
@@ -9,9 +9,10 @@
 # Nutzt       : - (bewusst ohne _core.sh: dotstow lädt kein Bootstrap-Core)
 # ============================================================
 
-# Mehrfaches Laden verhindern
+# Mehrfaches Laden verhindern (typeset -gr: bleibt auch beim Sourcen
+# aus Funktions-Scope global – nacktes readonly wäre dort lokal)
 [[ -n "${_STOW_PACKAGES_LOADED:-}" ]] && return 0
-readonly _STOW_PACKAGES_LOADED=1
+typeset -gr _STOW_PACKAGES_LOADED=1
 
 # Ermittelt Stow-Packages dynamisch aus der Verzeichnisstruktur.
 # Ein Package ist ein Verzeichnis mit mindestens einer Dotfile

--- a/setup/modules/backup.sh
+++ b/setup/modules/backup.sh
@@ -43,29 +43,10 @@ _backup_log() {
 # Hilfsfunktionen
 # ------------------------------------------------------------
 
-# Ermittelt Stow-Packages dynamisch aus Verzeichnisstruktur
-# Ein Package ist ein Verzeichnis mit mindestens einer Datei die mit . beginnt
-# oder ein .config Unterverzeichnis hat
-_get_stow_packages() {
-    local dir
-    for dir in "${DOTFILES_DIR}"/*/; do
-        [[ -d "$dir" ]] || continue
-        local name="${dir%/}"
-        name="${name##*/}"
-
-        # Überspringe bekannte Nicht-Packages
-        [[ "$name" == "setup" ]] && continue
-        [[ "$name" == "docs" ]] && continue
-        [[ "$name" == ".git" ]] && continue
-        [[ "$name" == ".backup" ]] && continue
-        [[ "$name" == ".github" ]] && continue
-
-        # Prüfe ob es Dotfiles oder .config enthält
-        if [[ -n "$(find "$dir" -maxdepth 1 -name '.*' -not -name '.DS_Store' -type f 2>/dev/null | head -1)" ]] ||
-           [[ -d "${dir}.config" ]]; then
-            echo "$name"
-        fi
-    done
+# Stow-Package-Erkennung (_get_stow_packages) – geteilt mit dotstow()
+source "${0:A:h:h}/lib/stow-packages.zsh" || {
+    echo "FEHLER: stow-packages.zsh nicht gefunden" >&2
+    return 1
 }
 
 # Ermittelt alle Zieldateien die von Stow verlinkt würden

--- a/setup/modules/stow.sh
+++ b/setup/modules/stow.sh
@@ -8,6 +8,7 @@
 #
 # STEP        : Stow Symlinks | Verlinkt Dotfile-Packages dynamisch | ⚠️ Kritisch
 # Packages    : Automatisch erkannt via _get_stow_packages()
+#               (setup/lib/stow-packages.zsh, geladen durch backup.sh)
 # ============================================================
 
 # Guard: Core muss geladen sein
@@ -19,8 +20,9 @@
 # ------------------------------------------------------------
 # Konfiguration
 # ------------------------------------------------------------
-# Packages werden dynamisch via _get_stow_packages() aus backup.sh ermittelt
-# Keine hardcoded Liste mehr nötig
+# Packages werden dynamisch via _get_stow_packages() ermittelt
+# (setup/lib/stow-packages.zsh, von backup.sh geladen) – keine
+# hardcoded Liste nötig
 
 # ------------------------------------------------------------
 # Prüfen ob Stow installiert ist

--- a/terminal/.config/alias/dotfiles.alias
+++ b/terminal/.config/alias/dotfiles.alias
@@ -57,7 +57,10 @@ dotstow() {
         echo "stow-packages.zsh nicht gefunden (nur im vollständigen Repository verfügbar)" >&2
         return 1
     fi
-    source "$lib"
+    source "$lib" || {
+        echo "stow-packages.zsh konnte nicht geladen werden" >&2
+        return 1
+    }
 
     local -a pkgs=($(_get_stow_packages "$dotdir"))
 

--- a/terminal/.config/alias/dotfiles.alias
+++ b/terminal/.config/alias/dotfiles.alias
@@ -51,23 +51,15 @@ dotstow() {
         return 1
     fi
 
-    # Stow-Packages dynamisch erkennen
-    local -a pkgs=()
-    local dir name
-    for dir in "$dotdir"/*/; do
-        [[ -d "$dir" ]] || continue
-        name="${dir%/}"
-        name="${name##*/}"
+    # Package-Erkennung aus geteilter Quelle (auch von backup.sh genutzt)
+    local lib="$dotdir/setup/lib/stow-packages.zsh"
+    if [[ ! -f "$lib" ]]; then
+        echo "stow-packages.zsh nicht gefunden (nur im vollständigen Repository verfügbar)" >&2
+        return 1
+    fi
+    source "$lib"
 
-        # Bekannte Nicht-Packages überspringen
-        [[ "$name" == "setup" || "$name" == "docs" || "$name" == ".git" || "$name" == ".backup" || "$name" == ".github" ]] && continue
-
-        # Prüfe ob es Dotfiles oder .config enthält
-        if [[ -n "$(find "$dir" -maxdepth 1 -name '.*' -not -name '.DS_Store' -type f 2>/dev/null | head -1)" ]] ||
-           [[ -d "${dir}.config" ]]; then
-            pkgs+=("$name")
-        fi
-    done
+    local -a pkgs=($(_get_stow_packages "$dotdir"))
 
     if [[ ${#pkgs[@]} -eq 0 ]]; then
         echo "Keine Stow-Packages gefunden in: $dotdir" >&2


### PR DESCRIPTION
## Beschreibung

Zentralisiert die duplizierte Stow-Package-Erkennung (#443) als **Option 1** (geteilte Quelle) — die im Issue offene Kontext-Grenze war lösbar: `dotstow()` braucht das Repo ohnehin zwingend (`stow -R` läuft in `$dotdir`), und mit setup/lib/prompts.zsh existiert das Muster für Core-freie lib-Dateien bereits.

**Änderungen:**

- **Neu [setup/lib/stow-packages.zsh](setup/lib/stow-packages.zsh):** `_get_stow_packages()` mit optionalem Pfad-Parameter (Fallback `$DOTFILES_DIR`), Load-Guard, `emulate -L zsh` (schützt gegen abweichende User-Shell-Optionen wie `glob_dots`) und `(N)`-Qualifier statt nomatch-Crash
- **backup.sh:** eigene Definition → lib-Source (`${0:A:h:h}/lib/`, FUNCTION_ARGZERO-Muster wie ssh-keys.sh)
- **stow.sh:** Aufruf unverändert (Modul-Reihenfolge backup→stow via bootstrap.sh `MODULES` gesichert), Kommentare auf lib-Quelle angepasst
- **dotstow():** Inline-Kopie → source mit Existenz-Check + Pfad-Argument

**Vorarbeit für #239:** Der Plattform-Filter muss künftig nur an einer Stelle implementiert werden.

## Art der Änderung

- [ ] 🐛 Bugfix
- [ ] ✨ Neues Feature
- [ ] 📝 Dokumentation
- [x] ♻️ Refactoring
- [ ] 🔧 Konfiguration
- [ ] 🛠️ Maintenance/Chore
- [x] 🏗️ Setup/Bootstrap
- [ ] 🎨 Theming
- [ ] 🧪 Testing
- [ ] 🔒 Security
- [ ] 🚀 Performance

## Checkliste

- [x] Ich habe die [Contributing Guidelines](CONTRIBUTING.md) gelesen
- [x] `./.github/scripts/generate-docs.sh --check` ist erfolgreich
- [x] `./.github/scripts/health-check.sh` zeigt keine Fehler
- [x] Neue Aliase/Funktionen haben Beschreibungskommentare (falls zutreffend)
- [x] Bei neuen Tools: Guard-Check vorhanden (falls zutreffend)
- [x] Screenshots in `docs/assets/` noch aktuell (falls zutreffend)

### Bei Theme-/Config-Änderungen in `.config/*` (falls zutreffend)

- [x] Theme-Quellen-Tabelle in `theme-style` geprüft (Zeile 13-42) — nicht betroffen
- [x] Status aktualisiert falls Upstream-Abweichung (`upstream+X`) — nicht betroffen
- [x] Semantische Farben eingehalten (siehe CONTRIBUTING.md → Theming)

## Zusammenhängende Issues

Closes #443
Bezieht sich auf #239 (Vorarbeit: Plattform-Filter künftig nur einmal nötig)

## Screenshots / Terminal-Ausgabe

```text
=== Äquivalenzbeweis (Referenz vor Umbau gesichert) ===
Bootstrap-Kette (_core → backup):  editor, terminal  → diff zur Referenz: identisch ✓
Laufzeit-Kette (ohne _core):       editor, terminal  → diff zur Referenz: identisch ✓

=== End-to-End ===
dotstow in echter interaktiver Shell (idempotentes Restow): OK
Health-Check danach: ✔ Alle Komponenten korrekt installiert

=== Edge-Cases ===
fehlendes Verzeichnis → Exit 1 + Fehlermeldung ✓
glob_dots aktiv → emulate -L schützt ✓
Doppel-Source → Load-Guard, Exit 0 ✓
set -u → OK ✓

Pre-Commit: ✔ Alle Checks bestanden
```
